### PR TITLE
SAA-33: Correct cert secret name

### DIFF
--- a/helm_deploy/hmpps-activities-management/values.yaml
+++ b/helm_deploy/hmpps-activities-management/values.yaml
@@ -12,7 +12,7 @@ generic-service:
   ingress:
     enabled: true
     host: app-hostname.local    # override per environment
-    tlsSecretName: hmpps-activities-management-cert
+    tlsSecretName: activities-cert
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
Certificate secret name was incorrect from template - did not match the CP name. This corrects it.