### PR TITLE
SAA-15: Provide missing env vars for API urls

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,8 @@ generic-service:
     INGRESS_URL: "https://activities-dev.prison.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
+    ACTIVITIES_API_URL: "https://activities-api-dev.prison.service.justice.gov.uk"
+    PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-dev.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
Oops. Added two env vars to the config.ts file but forgot to set these in /helm_deploy/values-dev.yaml. This corrects the omission.