### PR TITLE
SAA-14: Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "connect-redis": "^6.1.3",
         "csurf": "^1.11.0",
         "dotenv": "^16.0.2",
+        "eslint-import-resolver-typescript": "^3.5.0",
         "eslint-plugin-no-only-tests": "^3.0.0",
         "express": "^4.18.1",
         "express-prom-bundle": "^6.5.0",
@@ -91,7 +92,7 @@
         "sass": "^1.54.7",
         "supertest": "^6.2.4",
         "ts-jest": "^28.0.8",
-        "typescript": "^4.8.2"
+        "typescript": "^4.8.3"
       },
       "engines": {
         "node": "^16",
@@ -11760,9 +11761,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -20962,9 +20963,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
     },
     "uid-safe": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "connect-redis": "^6.1.3",
     "csurf": "^1.11.0",
     "dotenv": "^16.0.2",
+    "eslint-import-resolver-typescript": "^3.5.0",
     "eslint-plugin-no-only-tests": "^3.0.0",
     "express": "^4.18.1",
     "express-prom-bundle": "^6.5.0",
@@ -169,6 +170,6 @@
     "sass": "^1.54.7",
     "supertest": "^6.2.4",
     "ts-jest": "^28.0.8",
-    "typescript": "^4.8.2"
+    "typescript": "^4.8.3"
   }
 }


### PR DESCRIPTION
Small change to update typescript version 4.8.2 -> 4.8.3 (Fixes overnight security check in circleci too)