### PR TITLE
Use official redis v6 distribution for local running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ version: '3.1'
 services:
 
   redis:
-    image: 'bitnami/redis:5.0'
+    image: 'redis:6.2'
     networks:
       - hmpps
-    container_name: redis 
+    container_name: redis
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:


### PR DESCRIPTION
The bitnami distribution does not have a docker image compatible with ARM architecture CPUs (Apple M1 chip) and so performs poorly. The official redis distribution does have an ARM image.

<img width="906" alt="Screenshot 2022-10-27 at 12 36 32" src="https://user-images.githubusercontent.com/30229564/198274667-758cc7a1-7762-462a-9cd7-efe60402913f.png">
<img width="904" alt="Screenshot 2022-10-27 at 12 36 54" src="https://user-images.githubusercontent.com/30229564/198274673-9c1645f2-6d5e-4dfa-8504-a62bfe01d44d.png">
