### PR TITLE
SAA-134 updating front end to latest LTS version of Node, v18.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
 
   node-version:
     type: string
-    default: 16.17-browsers
+    default: 18.11-browsers
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:16.17-bullseye-slim as base
+FROM node:18.11-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This service requires the following dependent services:
 
 Ensure you have the appropriate tools locally:
 
-`node - v16.x`
+`node - v18.x`
 
 `npm - v8.x`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "typescript": "^4.8.4"
       },
       "engines": {
-        "node": "^16",
+        "node": "^18",
         "npm": "^8"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "clean": "rm -rf dist build node_modules stylesheets"
   },
   "engines": {
-    "node": "^16",
+    "node": "^18",
     "npm": "^8"
   },
   "jest": {


### PR DESCRIPTION
This brings inline with the latest TypeScript template.