### PR TITLE
⬆️ SAA-154: Upgrade Circle Orb to v6 and Helm charts to 2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@5.1
+  hmpps: ministryofjustice/hmpps@6
   slack: circleci/slack@4.4.2
 
 parameters:

--- a/helm_deploy/hmpps-activities-management/Chart.yaml
+++ b/helm_deploy/hmpps-activities-management/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-activities-management
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.2.2
+    version: 2.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.4.1
+    version: 1.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
- Hoping upgrading the circle orb will help speed up the multi-architecture builds 