### PR TITLE
SAA-211 adding missing description text and populating the allocation column.

### DIFF
--- a/server/routes/allocate-to-activity/candidates/people-allocated-now/handlers/PeopleAllocatedNowRouteHandler.test.ts
+++ b/server/routes/allocate-to-activity/candidates/people-allocated-now/handlers/PeopleAllocatedNowRouteHandler.test.ts
@@ -126,15 +126,13 @@ describe('Route Handlers - Schedules dashboard', () => {
         ],
         rowData: [
           {
-            alerts: [],
-            incentiveLevel: '',
+            description: 'Wing cleaning 99',
             location: 'Room 1',
             name: 'Bob Flemming',
             prisonNumber: '111111',
           },
           {
-            alerts: [],
-            incentiveLevel: '',
+            description: 'Wing cleaning 99',
             location: 'Room 2',
             name: 'Fred Bloggs',
             prisonNumber: '222222',

--- a/server/routes/allocate-to-activity/candidates/people-allocated-now/handlers/PeopleAllocatedNowRouteHandler.ts
+++ b/server/routes/allocate-to-activity/candidates/people-allocated-now/handlers/PeopleAllocatedNowRouteHandler.ts
@@ -3,7 +3,6 @@ import PrisonService from '../../../../../services/prisonService'
 import ActivityService from '../../../../../services/activitiesService'
 import CapacitiesService from '../../../../../services/capacitiesService'
 import { InmateBasicDetails } from '../../../../../@types/prisonApiImport/types'
-import { CandidateListTableRow } from '../../../../../@types/activities'
 
 export default class PeopleAllocatedNowRouteHandler {
   constructor(
@@ -23,7 +22,7 @@ export default class PeopleAllocatedNowRouteHandler {
       this.capacitiesService.getScheduleAllocationsSummary(+scheduleId, user),
       this.activitiesService.getActivitySchedule(scheduleId as unknown as number, user),
     ])
-    const rowData = inmateDetails.map(this.toRowData)
+    const rowData = inmateDetails.map(inmate => this.toRowData(inmate, schedule.description))
 
     const viewContext = {
       pageHeading: `Identify candidates for ${schedule.description}`,
@@ -57,13 +56,12 @@ export default class PeopleAllocatedNowRouteHandler {
     res.render('pages/allocate-to-activity/candidates/people-allocated-now/index', viewContext)
   }
 
-  private toRowData(prisoner: InmateBasicDetails): CandidateListTableRow {
+  private toRowData(prisoner: InmateBasicDetails, allocation: string) {
     return {
       name: `${prisoner.firstName} ${prisoner.lastName}`,
       prisonNumber: prisoner.offenderNo,
       location: prisoner.assignedLivingUnitDesc,
-      incentiveLevel: '',
-      alerts: [],
+      description: allocation,
     }
   }
 }

--- a/server/views/pages/allocate-to-activity/candidates/people-allocated-now/index.njk
+++ b/server/views/pages/allocate-to-activity/candidates/people-allocated-now/index.njk
@@ -8,6 +8,10 @@
 {% set backLinkHref = "/" %}
 
 {% block tabPanel %}
+    <div>
+        <h2 class="govuk-heading-m">People allocated now</h2>
+        <p>Review the list of people currently allocated to identify any non-associations or other risks. You can also remove someone from the activity by selecting their name.</p>
+    </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% set rows = [] %}
@@ -36,14 +40,12 @@
                         attributes: {
                         id: 'allocation-' + loop.index
                     },
-                        text: 'allocation goes here'
+                        text: allocation.description
                     }
                 ]), rows) %}
             {% endfor %}
 
             {{ govukTable({
-                caption: "People allocated now",
-                captionClasses: "govuk-heading-m",
                 head: [
                     {
                         text: "Name"

--- a/server/views/pages/allocate-to-activity/candidates/people-allocated-now/index.njk
+++ b/server/views/pages/allocate-to-activity/candidates/people-allocated-now/index.njk
@@ -46,6 +46,8 @@
             {% endfor %}
 
             {{ govukTable({
+                caption: "People allocated now",
+                captionClasses: "govuk-visually-hidden",
                 head: [
                     {
                         text: "Name"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/60104344/206695261-ba2ef81d-e4a1-4de2-8175-86f1bb8734ea.png)

This isn't quite as per ticket for the allocation column.  It should show all schedules they are allocated to.  We currently don't have an endpoint to support this.