### PR TITLE
SAA-256: Use new API endpoints in unlock list and calendar spike

### DIFF
--- a/server/@types/activities.ts
+++ b/server/@types/activities.ts
@@ -1,4 +1,4 @@
-import { Attendance, InternalLocation, ScheduledActivity } from './activitiesAPI/types'
+import { Attendance, InternalLocation, ScheduledEvent } from './activitiesAPI/types'
 import { Alert } from './prisonApiImport/types'
 
 export type PrisonerAlert = {
@@ -76,6 +76,6 @@ export type UnlockListItem = {
   locationPrefix?: string
   cellLocation: string
   alerts?: Alert[]
-  events?: ScheduledActivity[]
+  events?: ScheduledEvent[]
   status: string
 }

--- a/server/@types/activitiesAPI/index.d.ts
+++ b/server/@types/activitiesAPI/index.d.ts
@@ -32,17 +32,27 @@ export interface paths {
      */
     post: operations['allocate']
   }
-  '/prisons/{prisonCode}/scheduled-events': {
+  '/scheduled-events/prison/{prisonCode}': {
     /**
-     * Get a list of scheduled events for a prison, prisoner and date range (max 3 months)
-     * @description Returns zero or more scheduled events for a prison, prisoner and date range (max 3 months).
+     * Get a list of scheduled events for a prison, prisoner, date range (max 3 months) and optional time slot.
+     * @description
+     *       Returns scheduled events for the prison, prisoner, date range (max 3 months) and optional time slot.
+     *       Court hearings, appointments and visits always come from NOMIS (via prison API).
+     *       Activities come from either NOMIS or the new Activities database, depending on whether the prison is
+     *       marked as rolled-out in the activities database.
+     *       (Intended usage: Prisoner calendar)
      */
-    get: operations['getScheduledEventsByDateRange']
+    get: operations['getScheduledEventsByPrisonAndPrisonerAndDateRange']
     /**
-     * Get a list of scheduled events for a prison, offender list
-     * @description Returns zero or more scheduled events for a prison, offender list.
+     * Get a list of scheduled events for a prison and list of prisoner numbers for a date and time slot
+     * @description
+     *       Returns scheduled events for the prison, prisoner numbers, single date and an optional time slot.
+     *       Court hearings, appointments and visits always come from NOMIS (via prison API).
+     *       Activities come from either NOMIS or the new activities database, depending on whether the prison is
+     *       marked as rolled-out in the activities database.
+     *       (Intended usage: Unlock list)
      */
-    post: operations['getScheduledEventsForOffenderList']
+    post: operations['getScheduledEventsByPrisonAndPrisonersAndDateRange']
   }
   '/prisons/{prisonCode}/prisoner-allocations': {
     /**
@@ -109,8 +119,8 @@ export interface paths {
   }
   '/prisons/{prisonCode}/scheduled-instances': {
     /**
-     * Get a list of scheduled instances for a prison, prisoner (optional), date range (max 3 months) and time slot (AM, PM or ED - optional)
-     * @description Returns zero or more scheduled instances for a prison, prisoner (optional) and date range (max 3 months).
+     * Get a list of scheduled instances for a prison, date range (max 3 months) and time slot (AM, PM or ED - optional)
+     * @description Returns zero or more scheduled instances for a prison and date range (max 3 months).
      */
     get: operations['getActivityScheduleInstancesByDateRange']
   }
@@ -1293,12 +1303,12 @@ export interface components {
        * @description The child groups of this group
        * @example [
        *   {
-       *     "name": "Landing A/1",
-       *     "key": "1"
+       *     'name': 'Landing A/1',
+       *     'key': '1'
        *   },
        *   {
-       *     "name": "Landing A/2",
-       *     "key": "2"
+       *     'name': 'Landing A/2',
+       *     'key': '2'
        *   }
        * ]
        */
@@ -1475,20 +1485,28 @@ export interface operations {
       }
     }
   }
-  getScheduledEventsByDateRange: {
+  getScheduledEventsByPrisonAndPrisonerAndDateRange: {
     /**
-     * Get a list of scheduled events for a prison, prisoner and date range (max 3 months)
-     * @description Returns zero or more scheduled events for a prison, prisoner and date range (max 3 months).
+     * Get a list of scheduled events for a prison, prisoner, date range (max 3 months) and optional time slot.
+     * @description
+     *       Returns scheduled events for the prison, prisoner, date range (max 3 months) and optional time slot.
+     *       Court hearings, appointments and visits always come from NOMIS (via prison API).
+     *       Activities come from either NOMIS or the new Activities database, depending on whether the prison is
+     *       marked as rolled-out in the activities database.
+     *       (Intended usage: Prisoner calendar)
      */
     parameters: {
-      /** @description Prisoner number */
-      /** @description Start date of query */
-      /** @description End date of query (max 3 months from start date) */
+      /** @description Prisoner number (required). Format A9999AA. */
+      /** @description Start date of query (required). Format YYYY-MM-DD. */
+      /** @description End date of query (required). Format YYYY-MM-DD. The end date must be withing 3 months of the start date) */
+      /** @description Time slot for the events (optional). If supplied, one of AM, PM or ED. */
       query: {
         prisonerNumber: string
         startDate: string
         endDate: string
+        timeSlot?: string
       }
+      /** @description The 3-digit prison code. */
       path: {
         prisonCode: string
       }
@@ -1526,18 +1544,24 @@ export interface operations {
       }
     }
   }
-  getScheduledEventsForOffenderList: {
+  getScheduledEventsByPrisonAndPrisonersAndDateRange: {
     /**
-     * Get a list of scheduled events for a prison, offender list
-     * @description Returns zero or more scheduled events for a prison, offender list.
+     * Get a list of scheduled events for a prison and list of prisoner numbers for a date and time slot
+     * @description
+     *       Returns scheduled events for the prison, prisoner numbers, single date and an optional time slot.
+     *       Court hearings, appointments and visits always come from NOMIS (via prison API).
+     *       Activities come from either NOMIS or the new activities database, depending on whether the prison is
+     *       marked as rolled-out in the activities database.
+     *       (Intended usage: Unlock list)
      */
     parameters: {
-      /** @description Date of the events */
-      /** @description Time slot of the events */
-      query?: {
-        date?: string
+      /** @description The exact date to return events for (required) in format YYYY-MM-DD */
+      /** @description Time slot of the events (optional). If supplied, one of AM, PM or ED. */
+      query: {
+        date: string
         timeSlot?: string
       }
+      /** @description The 3-character prison code. */
       path: {
         prisonCode: string
       }
@@ -1887,20 +1911,19 @@ export interface operations {
   }
   getActivityScheduleInstancesByDateRange: {
     /**
-     * Get a list of scheduled instances for a prison, prisoner (optional), date range (max 3 months) and time slot (AM, PM or ED - optional)
-     * @description Returns zero or more scheduled instances for a prison, prisoner (optional) and date range (max 3 months).
+     * Get a list of scheduled instances for a prison, date range (max 3 months) and time slot (AM, PM or ED - optional)
+     * @description Returns zero or more scheduled instances for a prison and date range (max 3 months).
      */
     parameters: {
-      /** @description Prisoner number (optional) */
-      /** @description Start date of query */
-      /** @description End date of query (max 3 months from start date) */
-      /** @description The time slot - AM, PM or ED (optional) */
+      /** @description Start date of query (required). Format YYYY-MM-DD. */
+      /** @description End date of query (reuired). The end date must be within 3 months of the start date. */
+      /** @description The time slot (optional). If supplied, one of AM, PM or ED. */
       query: {
-        prisonerNumber?: string
         startDate: string
         endDate: string
         slot?: string
       }
+      /** @description The 3-character prison code. */
       path: {
         prisonCode: string
       }

--- a/server/data/activitiesApiClient.test.ts
+++ b/server/data/activitiesApiClient.test.ts
@@ -11,6 +11,7 @@ import {
   LocationGroup,
   LocationPrefix,
   PrisonerAllocations,
+  PrisonerScheduledEvents,
 } from '../@types/activitiesAPI/types'
 import TimeSlot from '../enum/timeSlot'
 
@@ -328,6 +329,74 @@ describe('activitiesApiClient', () => {
       const output = await activitiesApiClient.getPrisonerAllocations('MDI', ['1234567'], user)
 
       expect(output).toEqual(response)
+      expect(nock.isDone()).toBe(true)
+    })
+  })
+
+  describe('GET getScheduledEvents', () => {
+    const prisonCode = 'MDI'
+    const prisonerNumber = 'A1234AA'
+    const startDate = '2022-10-01'
+    const endDate = '2022-10-02'
+
+    it('should return scheduled events for a single prisoner and a date range', async () => {
+      const response = {
+        prisonCode,
+        prisonerNumbers: [prisonerNumber],
+        startDate,
+        endDate,
+        appointments: [],
+        activities: [],
+        visits: [],
+        courtHearings: [],
+      } as PrisonerScheduledEvents
+
+      fakeActivitiesApi
+        .get(`/scheduled-events/prison/${prisonCode}`)
+        .query({ prisonerNumber, startDate, endDate })
+        .matchHeader('authorization', `Bearer token`)
+        .reply(200, response)
+
+      const result = await activitiesApiClient.getScheduledEvents(prisonCode, prisonerNumber, startDate, endDate, user)
+
+      expect(result).toEqual(response)
+      expect(nock.isDone()).toBe(true)
+    })
+  })
+
+  describe('POST getScheduledEventsByPrisonerNumbers', () => {
+    const prisonCode = 'MDI'
+    const prisonerNumbers = ['A1234AA', 'B1234BB']
+    const date = '2022-10-01'
+    const timeSlot = 'AM'
+
+    it('should return scheduled events for a list of prisoners and single date / time slot', async () => {
+      const response = {
+        prisonCode,
+        prisonerNumbers,
+        startDate: date,
+        endDate: date,
+        appointments: [],
+        activities: [],
+        visits: [],
+        courtHearings: [],
+      } as PrisonerScheduledEvents
+
+      fakeActivitiesApi
+        .post(`/scheduled-events/prison/${prisonCode}`, prisonerNumbers)
+        .query({ date, timeSlot })
+        .matchHeader('authorization', `Bearer token`)
+        .reply(200, response)
+
+      const result = await activitiesApiClient.getScheduledEventsByPrisonerNumbers(
+        prisonCode,
+        date,
+        timeSlot,
+        prisonerNumbers,
+        user,
+      )
+
+      expect(result).toEqual(response)
       expect(nock.isDone()).toBe(true)
     })
   })

--- a/server/data/activitiesApiClient.ts
+++ b/server/data/activitiesApiClient.ts
@@ -121,14 +121,11 @@ export default class ActivitiesApiClient extends AbstractHmppsRestClient {
     endDate: string,
     user: ServiceUser,
   ): Promise<PrisonerScheduledEvents> {
-    const query = prisonerNumber ? { prisonerNumber, startDate, endDate } : { startDate, endDate }
-    return this.get(
-      {
-        path: `/prisons/${prisonCode}/scheduled-events`,
-        query,
-      },
-      user,
-    )
+    return this.get({
+      path: `/scheduled-events/prison/${prisonCode}`,
+      query: { prisonerNumber, startDate, endDate },
+      authToken: user.token,
+    })
   }
 
   getScheduledEventsByPrisonerNumbers(
@@ -138,14 +135,12 @@ export default class ActivitiesApiClient extends AbstractHmppsRestClient {
     prisonerNumbers: string[],
     user: ServiceUser,
   ): Promise<PrisonerScheduledEvents> {
-    return this.post(
-      {
-        path: `/prisons/${prisonCode}/scheduled-events`,
-        query: { date, timeSlot },
-        data: prisonerNumbers,
-      },
-      user,
-    )
+    return this.post({
+      path: `/scheduled-events/prison/${prisonCode}`,
+      query: { date, timeSlot },
+      data: prisonerNumbers,
+      authToken: user.token,
+    })
   }
 
   async getRolloutPrison(prisonCode: string, user: ServiceUser): Promise<RolloutPrison> {

--- a/server/routes/spikes/handlers/calendarSpike.ts
+++ b/server/routes/spikes/handlers/calendarSpike.ts
@@ -1,16 +1,19 @@
 import { Request, Response } from 'express'
-import { addMonths } from 'date-fns'
+import { format, lastDayOfMonth } from 'date-fns'
 import ActivitiesService from '../../../services/activitiesService'
 
 export default class CalendarSpikeRoutes {
   constructor(private readonly activitiesService: ActivitiesService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
+    // Pull back events for the current month - even when today's date is near the end of the month.
     const referenceDate = req.query.referenceDate ? new Date(req.query.referenceDate as string) : new Date()
+    const firstDayInMonth = new Date(format(referenceDate, 'yyyy-MM-01'))
+    const lastDayInMonth = lastDayOfMonth(referenceDate)
     const { user } = res.locals
 
     const activities = await this.activitiesService
-      .getScheduledEvents('A5193DY', referenceDate, addMonths(referenceDate, 1), user)
+      .getScheduledEvents('G4793VF', firstDayInMonth, lastDayInMonth, user)
       .then(events =>
         events.map(e => ({
           start: new Date(`${e.date} ${e.startTime}`),

--- a/server/services/unlockListService.test.ts
+++ b/server/services/unlockListService.test.ts
@@ -63,6 +63,8 @@ describe('Unlock list service', () => {
     content: [],
   } as unknown as PagePrisoner
 
+  // TODO: Add some data here - populate with realistic response values
+
   const scheduledEvents = {
     prisonCode: 'MDI',
     startDate: '',
@@ -78,6 +80,7 @@ describe('Unlock list service', () => {
   describe('getUnlockListForLocationGroups', () => {
     it('should get the unlock list items for one location group', async () => {
       const prisonerNumbers = ['A1234AA']
+
       activitiesApiClient.getPrisonLocationPrefixByGroup.mockResolvedValue({ locationPrefix: 'MDI-1-' })
       prisonerSearchApiClient.searchPrisonersByLocationPrefix.mockResolvedValue(prisoners)
       activitiesApiClient.getScheduledEventsByPrisonerNumbers.mockResolvedValue(scheduledEvents)

--- a/server/services/unlockListService.ts
+++ b/server/services/unlockListService.ts
@@ -73,7 +73,11 @@ export default class UnlockListService {
       user,
     )
 
-    // TODO: Get activities - similar shape within scheduled events - in the API call for scheduled events
+    logger.info(`Total activities: ${scheduledEvents?.activities.length}`)
+    logger.info(`Total visits: ${scheduledEvents?.visits.length}`)
+    logger.info(`Total appointments: ${scheduledEvents?.appointments.length}`)
+    logger.info(`Total court hearings: ${scheduledEvents?.courtHearings.length}`)
+
     // TODO: Get transfers - similar shape as scheduled events
     // TODO: Adjudication hearings (currently in appointments, check with Adjudications team for rolled-out prisons)
     // TODO: Get ROTLs - Prison API: /api/movements/agency/{prisonCode}/temporary-absences - filtered to today?
@@ -81,9 +85,11 @@ export default class UnlockListService {
     // Match the prisoners with their events by prisonerNumber
     const unlockListItems = prisoners.map(prisoner => {
       const appointments = scheduledEvents?.appointments.filter(app => app.prisonerNumber === prisoner.prisonerNumber)
-      const courtHearings = scheduledEvents?.courtHearings.filter(app => app.prisonerNumber === prisoner.prisonerNumber)
-      const visits = scheduledEvents?.visits.filter(app => app.prisonerNumber === prisoner.prisonerNumber)
-      const allEventsForPrisoner = [...appointments, ...courtHearings, ...visits]
+      const courtHearings = scheduledEvents?.courtHearings.filter(crt => crt.prisonerNumber === prisoner.prisonerNumber)
+      const visits = scheduledEvents?.visits.filter(vis => vis.prisonerNumber === prisoner.prisonerNumber)
+      const activities = scheduledEvents?.activities.filter(act => act.prisonerNumber === prisoner.prisonerNumber)
+      const allEventsForPrisoner = [...appointments, ...courtHearings, ...visits, ...activities]
+
       return {
         ...prisoner,
         displayName: convertToTitleCase(`${prisoner.lastName}, ${prisoner.firstName}`),
@@ -96,7 +102,7 @@ export default class UnlockListService {
     return unlockListItems
   }
 
-  private sortByPriority = (data: ScheduledEvent[]) => {
+  private sortByPriority = (data: ScheduledEvent[]): ScheduledEvent[] => {
     return data.sort((p1, p2) => {
       if (p1.priority > p2.priority) return 1
       if (p1.priority < p2.priority) return -1

--- a/server/views/partials/showUnlockEvents.njk
+++ b/server/views/partials/showUnlockEvents.njk
@@ -1,7 +1,7 @@
 {% macro showUnlockEvents(events) %}
     <div class="govuk-body govuk-!-font-size-14">
         {% for e in events %}
-           <span class="govuk-!-display-block">{{ e.eventType | title }} {{ e.location | title }} {{ e.startTime }} - {{ e.endTime }}</span>
+           <span class="govuk-!-display-block">{{ e.eventType | title }} {{ e.location | title }} {{ e.details }} {{ e.startTime }} - {{ e.endTime }}</span>
         {% endfor %}
     </div>
 {% endmacro %}


### PR DESCRIPTION
With the API changes to get scheduled events from a view, these are the minor changes required in the UI to match up.