### PR TITLE
SAA-279 Basic activities dashboard

### DIFF
--- a/server/routes/allocate-to-activity/handlers/activities.test.ts
+++ b/server/routes/allocate-to-activity/handlers/activities.test.ts
@@ -13,7 +13,7 @@ jest.mock('../../../services/capacitiesService')
 const activitiesService = new ActivitiesService(null, null) as jest.Mocked<ActivitiesService>
 const capacitiesService = new CapacitiesService(null) as jest.Mocked<CapacitiesService>
 
-describe('Route Handlers - Activities dashboard', () => {
+describe('Route Handlers - Allocation dashboard', () => {
   const handler = new ActivitiesRoutes(activitiesService, capacitiesService)
   let req: Request
   let res: Response

--- a/server/views/pages/allocate-to-activity/activities-dashboard.njk
+++ b/server/views/pages/allocate-to-activity/activities-dashboard.njk
@@ -9,7 +9,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-xl">Activities dashboard: activities view</h1>
+            <h1 class="govuk-heading-xl">Allocation dashboard: activities view</h1>
         </div>
     </div>
     <div class="govuk-grid-row">

--- a/server/views/pages/allocate-to-activity/categories-dashboard.njk
+++ b/server/views/pages/allocate-to-activity/categories-dashboard.njk
@@ -9,14 +9,14 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-xl">Activities dashboard: categories view</h1>
+            <h1 class="govuk-heading-xl">Allocation dashboard: categories view</h1>
         </div>
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <p class="govuk-body">Use the dashboard to identify activities with vacancies or search for an activity by name.</p>
 
-            <h2 class="govuk-heading-m">Activities dashboard</h2>
+            <h2 class="govuk-heading-m">Allocation dashboard</h2>
 
             {% set rows = [
                 [

--- a/server/views/pages/allocate-to-activity/schedules-dashboard.njk
+++ b/server/views/pages/allocate-to-activity/schedules-dashboard.njk
@@ -9,7 +9,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-xl">Activities dashboard: series view</h1>
+            <h1 class="govuk-heading-xl">Allocation dashboard: series view</h1>
         </div>
     </div>
     <div class="govuk-grid-row">


### PR DESCRIPTION
The allocation dashboard should be called “Allocation dashboard” and not “Activities dashboard”.