### PR TITLE
SAA-374: Fixed grunt watch task

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -84,7 +84,7 @@ module.exports = grunt => {
     },
     watch: {
       scripts: {
-        files: ['**/*.scss', '**/*.js'],
+        files: ['frontend/**/*.js', 'frontend/**/*.scss'],
         tasks: ['default'],
       },
     },
@@ -107,5 +107,4 @@ module.exports = grunt => {
     'uglify',
     'copy',
   ])
-  grunt.registerTask('watch', ['watch'])
 }


### PR DESCRIPTION
## Overview
Fixes grunt watch task and it's associated npm scripts (`watch-assets` & `start:dev`),  enabling automatic rebuilding of frontend assets.
