### PR TITLE
SAA-458: Remove grey summary list heading

### DIFF
--- a/frontend/utilities/_typography.scss
+++ b/frontend/utilities/_typography.scss
@@ -1,7 +1,3 @@
-.summary-list-heading {
-    background: govuk-colour("light-grey");
-}
-
 .secondary-text-colour {
     color: $govuk-secondary-text-colour;
 }

--- a/server/views/pages/allocate-to-activity/check-answers.njk
+++ b/server/views/pages/allocate-to-activity/check-answers.njk
@@ -14,7 +14,7 @@
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
-            <h2 class="summary-list-heading govuk-heading-m">Who you're allocating</h2>
+            <h2 class="govuk-heading-m">Who you're allocating</h2>
             {{ govukSummaryList({
                 rows: [
                     {
@@ -61,7 +61,7 @@
                 ]
             }) }}
 
-            <h2 class="summary-list-heading govuk-heading-m">Activity you're allocating to</h2>
+            <h2 class="govuk-heading-m">Activity you're allocating to</h2>
             {{ govukSummaryList({
                 rows: [
                     {

--- a/server/views/pages/appointments/create-single/check-answers.njk
+++ b/server/views/pages/appointments/create-single/check-answers.njk
@@ -12,7 +12,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Check your appointment details before you accept and save</h1>
-            <h2 class="summary-list-heading govuk-heading-m">Appointment details</h2>
+            <h2 class="govuk-heading-m">Appointment details</h2>
             {{ govukSummaryList({
                 rows: [
                     {

--- a/server/views/pages/create-an-activity/check-answers.njk
+++ b/server/views/pages/create-an-activity/check-answers.njk
@@ -14,7 +14,7 @@
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
-            <h2 class="summary-list-heading govuk-heading-m">Activity details</h2>
+            <h2 class="govuk-heading-m">Activity details</h2>
             {{ govukSummaryList({
                 rows: [
                     {

--- a/server/views/pages/manage-schedules/create-schedule/check-answers.njk
+++ b/server/views/pages/manage-schedules/create-schedule/check-answers.njk
@@ -16,7 +16,7 @@
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
-            <h2 class="summary-list-heading govuk-heading-m">Schedule details</h2>
+            <h2 class="govuk-heading-m">Schedule details</h2>
             {{ govukSummaryList({
                 attributes: { 'id': 'scheduleDetailsList' },
                 rows: [
@@ -59,7 +59,7 @@
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
-            <h2 class="summary-list-heading govuk-heading-m">Dates and schedule</h2>
+            <h2 class="govuk-heading-m">Dates and schedule</h2>
             {{ govukSummaryList({
                 attributes: {
                     'id': 'datesAndScheduleList'
@@ -115,7 +115,7 @@
     </div>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
-            <h2 class="summary-list-heading govuk-heading-m">Activity details</h2>
+            <h2 class="govuk-heading-m">Activity details</h2>
             {{ govukSummaryList({
                 attributes: {
                     'id': 'activityDetailsList'


### PR DESCRIPTION
## Overview

Removed grey summary list heading from check answers pages

### Screenshots

<img width="934" alt="Screenshot at Mar 10 11-02-15" src="https://user-images.githubusercontent.com/125488090/224299714-908bb442-68d3-499a-a67d-04c55180283d.png">
