### PR TITLE
SAA-475: Remove alternate shading from print views

### DIFF
--- a/frontend/components/multi-select/_multi-select.scss
+++ b/frontend/components/multi-select/_multi-select.scss
@@ -16,7 +16,9 @@
 
   .govuk-table__row {
     &:nth-of-type(even) {
-      background: govuk-colour(light-grey);
+      @media not print {
+        background: govuk-colour(light-grey);
+      }
     }
   }
 

--- a/frontend/utilities/_misc.scss
+++ b/frontend/utilities/_misc.scss
@@ -47,9 +47,8 @@ body {
 
 .alternating-row-shading {
   tr:nth-child(even) {
-    background-color: govuk-tint(govuk-colour("light-grey"), 30);
-    @media print {
-      background: govuk-tint(govuk-colour("light-grey"), 20);
+    @media not print {
+      background-color: govuk-tint(govuk-colour("light-grey"), 30);
     }
   }
 }


### PR DESCRIPTION
Removes alternate shading from print views to save on ink


![Screenshot 2023-03-14 at 17 00 30](https://user-images.githubusercontent.com/30229564/225081382-785e52b5-81f5-4e59-99fa-56c062d6b44f.png)
![Screenshot 2023-03-14 at 16 57 25](https://user-images.githubusercontent.com/30229564/225081368-4cfaf189-0d08-449f-ad20-445b598a4e96.png)
