### PR TITLE
SAA-467: Updated check answers page for group appointments

### DIFF
--- a/integration_tests/e2e/appointments/createGroupAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createGroupAppointment.cy.ts
@@ -1,0 +1,122 @@
+import { addDays } from 'date-fns'
+import Page from '../../pages/page'
+import IndexPage from '../../pages'
+import AppointmentsManagementPage from '../../pages/appointments/appointmentsManagementPage'
+import SelectPrisonerPage from '../../pages/appointments/create/selectPrisonerPage'
+import CategoryPage from '../../pages/appointments/create/categoryPage'
+import LocationPage from '../../pages/appointments/create/locationPage'
+import getPrisonPrisonersA1351DZ from '../../fixtures/prisonerSearchApi/getPrisonPrisoners-MDI-A1351DZ.json'
+import getPrisonPrisonersA8644DYA1351DZ from '../../fixtures/prisonerSearchApi/postPrisonerNumbers-A1350DZ-A8644DY.json'
+import getCategories from '../../fixtures/activitiesApi/getAppointmentCategories.json'
+import getAppointmentLocations from '../../fixtures/prisonApi/getMdiAppointmentLocations.json'
+import getAppointment from '../../fixtures/activitiesApi/getAppointment.json'
+import getAppointmentDetails from '../../fixtures/activitiesApi/getAppointmentDetails.json'
+import HowToAddPrisonersPage from '../../pages/appointments/create/howToAddPrisonersPage'
+import ReviewPrisonersPage from '../../pages/appointments/create/reviewPrisonersPage'
+import DateAndTimePage from '../../pages/appointments/create/dateAndTimePage'
+import RepeatPage from '../../pages/appointments/create/repeatPage'
+import CheckAnswersPage from '../../pages/appointments/create/checkAnswersPage'
+import ConfirmationPage from '../../pages/appointments/create/confirmationPage'
+import { formatDate } from '../../../server/utils/utils'
+import UploadPrisonerListPage from '../../pages/appointments/create/uploadPrisonerListPage'
+
+context('Create group appointment', () => {
+  const tomorrow = addDays(new Date(), 1)
+  // To pass validation we must ensure the appointment details start date are set to tomorrow
+  getAppointmentDetails.startDate = formatDate(tomorrow, 'yyyy-MM-dd')
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubPrisonUser')
+    cy.signIn()
+    cy.stubEndpoint('GET', '/prison/MDI/prisoners\\?term=lee', getPrisonPrisonersA1351DZ)
+    cy.stubEndpoint('POST', '/prisoner-search/prisoner-numbers', getPrisonPrisonersA8644DYA1351DZ)
+    cy.stubEndpoint('GET', '/appointment-categories', getCategories)
+    cy.stubEndpoint('GET', '/api/agencies/MDI/locations\\?eventType=APP', getAppointmentLocations)
+    cy.stubEndpoint('POST', '/appointments', getAppointment)
+    cy.stubEndpoint('GET', '/appointment-details/10', getAppointmentDetails)
+  })
+
+  it('Should complete create group appointment journey', () => {
+    const indexPage = Page.verifyOnPage(IndexPage)
+    indexPage.appointmentsManagementCard().should('contain.text', 'Appointments management')
+    indexPage
+      .appointmentsManagementCard()
+      .should('contain.text', 'Create and manage appointments for individuals and groups.')
+    indexPage.appointmentsManagementCard().click()
+
+    const appointmentsManagementPage = Page.verifyOnPage(AppointmentsManagementPage)
+    appointmentsManagementPage.createGroupAppointmentCard().should('contain.text', 'Create a group appointment')
+    appointmentsManagementPage
+      .createGroupAppointmentCard()
+      .should('contain.text', 'Add a one-off or repeat appointment for a group of people.')
+    appointmentsManagementPage.createGroupAppointmentCard().click()
+
+    let howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
+    howToAddPrisonersPage.selectHowToAdd('Upload a CSV file of prison numbers to add to the appointment list')
+    howToAddPrisonersPage.continue()
+
+    const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)
+    uploadPrisonerListPage.attatchFile('upload-prisoner-list.csv')
+    uploadPrisonerListPage.continue()
+
+    let reviewPrisonersPage = Page.verifyOnPage(ReviewPrisonersPage)
+    reviewPrisonersPage.assertPrisonerInList('Gregs, Stephen')
+    reviewPrisonersPage.assertPrisonerInList('Winchurch, David')
+    reviewPrisonersPage.selectAddAnotherPrisoner('Yes')
+    reviewPrisonersPage.continue()
+
+    howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
+    howToAddPrisonersPage.selectHowToAdd('Search for a prison number to add to the appointment list')
+    howToAddPrisonersPage.continue()
+
+    const selectPrisonerPage = Page.verifyOnPage(SelectPrisonerPage)
+    selectPrisonerPage.enterPrisonerNumber('lee')
+    selectPrisonerPage.continue()
+
+    reviewPrisonersPage = Page.verifyOnPage(ReviewPrisonersPage)
+    reviewPrisonersPage.assertPrisonerInList('Jacobson, Lee')
+    reviewPrisonersPage.selectAddAnotherPrisoner('No')
+    reviewPrisonersPage.continue()
+
+    const categoryPage = Page.verifyOnPage(CategoryPage)
+    categoryPage.selectCategory('Chaplaincy')
+    categoryPage.continue()
+
+    const locationPage = Page.verifyOnPage(LocationPage)
+    locationPage.selectLocation('Chapel')
+    locationPage.continue()
+
+    const dateAndTimePage = Page.verifyOnPage(DateAndTimePage)
+    dateAndTimePage.enterStartDate(tomorrow)
+    dateAndTimePage.selectStartTime(14, 0)
+    dateAndTimePage.selectEndTime(15, 30)
+    dateAndTimePage.continue()
+
+    const repeatPage = Page.verifyOnPage(RepeatPage)
+    repeatPage.selectRepeat('No')
+    repeatPage.continue()
+
+    const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage)
+    checkAnswersPage.assertPrisonerInList('Winchurch, David', 'A1350DZ')
+    checkAnswersPage.assertPrisonerInList('Gregs, Stephen', 'A8644DY')
+    checkAnswersPage.assertPrisonerInList('Jacobson, Lee', 'A1351DZ')
+    checkAnswersPage.assertCategory('Chaplaincy')
+    checkAnswersPage.assertLocation('Chapel')
+    checkAnswersPage.assertStartDate(tomorrow)
+    checkAnswersPage.assertStartTime(14, 0)
+    checkAnswersPage.assertEndTime(15, 30)
+    checkAnswersPage.assertRepeat('No')
+    checkAnswersPage.createAppointment()
+
+    const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+    const successMessage = `You have successfully created an appointment for 3 prisoners on ${formatDate(
+      tomorrow,
+      'EEEE d MMMM yyyy',
+    )}.`
+    confirmationPage.assertMessageEquals(successMessage)
+    confirmationPage.assertCreateAnotherLinkExists()
+    confirmationPage.assertViewAppointmentLinkExists()
+  })
+})

--- a/integration_tests/fixtures/prisonerSearchApi/getPrisonPrisoners-MDI-A1351DZ.json
+++ b/integration_tests/fixtures/prisonerSearchApi/getPrisonPrisoners-MDI-A1351DZ.json
@@ -1,0 +1,46 @@
+{
+  "totalElements": 1,
+  "totalPages": 1,
+  "size": 1,
+  "content": [
+    {
+      "prisonerNumber": "A1351DZ",
+      "bookingId": "1205035",
+      "bookNumber": "42038A",
+      "firstName": "LEE",
+      "middleNames": "BOB",
+      "lastName": "JACOBSON",
+      "dateOfBirth": "1990-03-15",
+      "gender": "Male",
+      "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+      "youthOffender": false,
+      "status": "ACTIVE IN",
+      "lastMovementTypeCode": "ADM",
+      "lastMovementReasonCode": "27",
+      "inOutStatus": "IN",
+      "prisonId": "MDI",
+      "prisonName": "Moorland (HMP & YOI)",
+      "cellLocation": "1-3-004",
+      "aliases": [],
+      "alerts": [],
+      "legalStatus": "SENTENCED",
+      "imprisonmentStatus": "RECEP_DET",
+      "imprisonmentStatusDescription": "Determinate sentence (reception)",
+      "recall": false,
+      "indeterminateSentence": false,
+      "receptionDate": "2023-02-16",
+      "locationDescription": "Moorland (HMP & YOI)",
+      "restrictedPatient": false,
+      "currentIncentive": {
+        "level": {
+          "code": "ENH",
+          "description": "Enhanced"
+        },
+        "dateTime": "2023-02-16T19:38:00",
+        "nextReviewDate": "2023-05-16"
+      }
+    }
+  ],
+  "last": true,
+  "empty": false
+}

--- a/integration_tests/pages/appointments/create/checkAnswersPage.ts
+++ b/integration_tests/pages/appointments/create/checkAnswersPage.ts
@@ -15,6 +15,10 @@ export default class CheckAnswersPage extends Page {
     cy.get('[data-qa=prisoner-cell-location]').contains(cellLocation)
   }
 
+  assertPrisonerInList = (name: string, number: string) => {
+    cy.get('[data-qa=prisoner-name]').contains(name).parent().find('[data-qa=prisoner-number]').contains(number)
+  }
+
   assertCategory = (category: string) => this.assertAppointmentDetail('Category', category)
 
   assertLocation = (location: string) => this.assertAppointmentDetail('Location', location)

--- a/integration_tests/pages/appointments/create/reviewPrisonersPage.ts
+++ b/integration_tests/pages/appointments/create/reviewPrisonersPage.ts
@@ -1,0 +1,12 @@
+import Page from '../../page'
+
+export default class ReviewPrisonersPage extends Page {
+  constructor() {
+    super('appointments-create-review-prisoners-page')
+  }
+
+  selectAddAnotherPrisoner = (text: string) => this.getInputByLabel(text).click()
+
+  assertPrisonerInList = (name: string) =>
+    cy.get('[data-qa="prisoners-list-table"]').find('tr td:nth-child(1)').contains(name)
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -63,7 +63,7 @@ export default abstract class Page {
       .get(`[data-qa=${listIdentifier}] > .govuk-summary-list__row > .govuk-summary-list__key`)
       .contains(heading)
       .parent()
-      .get('.govuk-summary-list__value')
+      .find('.govuk-summary-list__value')
       .should('contain.text', expectedValue)
 
   protected getDatePickerById = (id: string) => new DatePicker(id)

--- a/server/middleware/setUpChangeLinks.ts
+++ b/server/middleware/setUpChangeLinks.ts
@@ -4,12 +4,14 @@ export default function setUpChangeLinks(): Router {
   const router = Router({ mergeParams: true })
 
   router.use((req, res, next) => {
-    res.redirectOrReturn = (path: string, returnTo = 'check-answers', flag = 'fromReview'): void => {
-      if (req.query[flag]) {
-        res.redirect(returnTo)
-      } else {
-        res.redirect(path)
-      }
+    if (req.query.fromReview) {
+      req.session.returnTo = 'check-answers'
+    }
+
+    res.redirectOrReturn = (path: string): void => {
+      const { returnTo } = req.session
+      req.session.returnTo = null
+      res.redirect(returnTo || path)
     }
 
     next()

--- a/server/nunjucks/nunjucksSetup.ts
+++ b/server/nunjucks/nunjucksSetup.ts
@@ -91,7 +91,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   // Only register nunjucks helpers/filters here - they should be implemented and unit tested elsewhere
   njkEnv.addFilter('fullName', fullName)
   njkEnv.addFilter('initialiseName', initialiseName)
-  njkEnv.addFilter('prisonerName', str => njkEnv.getFilter('safe')(prisonerName(str)))
+  njkEnv.addFilter('prisonerName', (str, bold) => njkEnv.getFilter('safe')(prisonerName(str, bold)))
   njkEnv.addFilter('setSelected', setSelected)
   njkEnv.addFilter('addDefaultSelectedValue', addDefaultSelectedValue)
   njkEnv.addFilter('toTimeItems', toTimeItems)

--- a/server/routes/appointments/create/handlers/reviewPrisoners.test.ts
+++ b/server/routes/appointments/create/handlers/reviewPrisoners.test.ts
@@ -44,7 +44,7 @@ describe('Route Handlers - Create Appointment - Review Prisoners', () => {
         addAnother: 'NO',
       }
       await handler.POST(req, res)
-      expect(res.redirect).toBeCalledWith('category')
+      expect(res.redirectOrReturn).toBeCalledWith('category')
     })
   })
 })

--- a/server/routes/appointments/create/handlers/reviewPrisoners.ts
+++ b/server/routes/appointments/create/handlers/reviewPrisoners.ts
@@ -20,7 +20,7 @@ export default class ReviewPrisonerRoutes {
     if (YesNo[addAnother] === YesNo.YES) {
       res.redirect('how-to-add-prisoners')
     } else {
-      res.redirect('category')
+      res.redirectOrReturn('category')
     }
   }
 }

--- a/server/routes/create-an-activity/handlers/checkEducationLevels.test.ts
+++ b/server/routes/create-an-activity/handlers/checkEducationLevels.test.ts
@@ -19,6 +19,7 @@ describe('Route Handlers - Create an activity - Check education levels', () => {
       },
       render: jest.fn(),
       redirect: jest.fn(),
+      redirectOrReturn: jest.fn(),
     } as unknown as Response
 
     req = {
@@ -71,7 +72,7 @@ describe('Route Handlers - Create an activity - Check education levels', () => {
   describe('POST', () => {
     it('should add the minimum incentive level to the session and redirect', async () => {
       await handler.POST(req, res)
-      expect(res.redirect).toHaveBeenCalledWith('start-date')
+      expect(res.redirectOrReturn).toHaveBeenCalledWith('start-date')
     })
   })
 })

--- a/server/routes/create-an-activity/handlers/checkEducationLevels.ts
+++ b/server/routes/create-an-activity/handlers/checkEducationLevels.ts
@@ -3,21 +3,11 @@ import { Request, Response } from 'express'
 export default class CheckPayRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
     const { educationLevels } = req.session.createJourney
-    const { fromReview } = req.query
-
-    if (!req.session.createJourney.fromReview) {
-      req.session.createJourney.fromReview = fromReview === 'true'
-    }
 
     res.render(`pages/create-an-activity/check-education-level`, { educationLevels })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
-    if (req.session.createJourney.fromReview) {
-      delete req.session.createJourney.fromReview
-      return res.redirect(`check-answers`)
-    }
-
-    return res.redirect(`start-date`)
+    return res.redirectOrReturn(`start-date`)
   }
 }

--- a/server/routes/create-an-activity/handlers/checkPay.test.ts
+++ b/server/routes/create-an-activity/handlers/checkPay.test.ts
@@ -98,20 +98,5 @@ describe('Route Handlers - Create an activity - Check pay', () => {
       expect(req.session.createJourney.minimumIncentiveLevel).toEqual('Standard')
       expect(res.redirectOrReturn).toHaveBeenCalledWith('qualification')
     })
-
-    it('should redirect to check answers page if fromCreateActivityReview set', async () => {
-      req.session.createJourney.fromReview = true
-
-      when(prisonService.getIncentiveLevels)
-        .calledWith(atLeast('MDI'))
-        .mockResolvedValueOnce([
-          { iepLevel: 'ENH', iepDescription: 'Enhanced', sequence: 3 },
-          { iepLevel: 'BAS', iepDescription: 'Basic', sequence: 1 },
-          { iepLevel: 'STD', iepDescription: 'Standard', sequence: 2 },
-        ] as IepLevel[])
-
-      await handler.POST(req, res)
-      expect(res.redirect).toHaveBeenCalledWith('check-answers')
-    })
   })
 })

--- a/server/routes/create-an-activity/handlers/checkPay.ts
+++ b/server/routes/create-an-activity/handlers/checkPay.ts
@@ -12,13 +12,8 @@ export default class CheckPayRoutes {
 
   GET = async (req: Request, res: Response): Promise<void> => {
     const { user } = res.locals
-    const { fromReview } = req.query
 
     const incentiveLevelPays = await this.helper.getPayGroupedByIncentiveLevel(req, user)
-
-    if (!req.session.createJourney.fromReview) {
-      req.session.createJourney.fromReview = fromReview === 'true'
-    }
 
     res.render(`pages/create-an-activity/check-pay`, { incentiveLevelPays })
   }
@@ -39,10 +34,6 @@ export default class CheckPayRoutes {
     req.session.createJourney.minimumIncentiveNomisCode = minimumIncentiveLevel.iepLevel
     req.session.createJourney.minimumIncentiveLevel = minimumIncentiveLevel.iepDescription
 
-    if (req.session.createJourney.fromReview) {
-      delete req.session.createJourney.fromReview
-      return res.redirect(`check-answers`)
-    }
     return res.redirectOrReturn(`qualification`)
   }
 }

--- a/server/routes/create-an-activity/journey.ts
+++ b/server/routes/create-an-activity/journey.ts
@@ -37,5 +37,4 @@ export type CreateAnActivityJourney = {
   }
   capacity?: number
   runsOnBankHoliday?: boolean
-  fromReview?: boolean
 }

--- a/server/views/pages/appointments/create/check-answers.njk
+++ b/server/views/pages/appointments/create/check-answers.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% from "partials/appointmentPrisonerSummary.njk" import appointmentPrisonerSummary %}
+{% from "partials/showProfileLink.njk" import showProfileLink %}
 
 {% set pageTitle = "Appointments Management - Create Appointment - Check Answers" %}
 {% set pageId = 'appointments-create-check-answers-page' %}
@@ -212,6 +213,8 @@
                 attributes: { 'data-qa': 'appointment-details' }
             }) }}
 
+            {{ prisonersList() if session.createAppointmentJourney.type == 'group' }}
+
             <form method="POST">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
@@ -225,3 +228,42 @@
         </div>
     </div>
 {% endblock %}
+
+{% macro prisonersList() %}
+    {% set prisonerListRows = [{
+        key: {
+            text: "Prisoners"
+        },
+        value: {
+            text: session.createAppointmentJourney.prisoners | length
+        },
+        actions: {
+            items: [
+                {
+                    href: "review-prisoners?fromReview=true",
+                    text: "Change",
+                    visuallyHiddenText: "change prisoners",
+                    classes: "govuk-link--no-visited-state",
+                    attributes: { 'data-qa': 'change-prisoners' }
+                }
+            ]
+        }
+    }] %}
+
+    {% for prisoner in session.createAppointmentJourney.prisoners %}
+        {% set prisonerListRows = (prisonerListRows.push({
+            key: {
+                text: "Prisoner"
+            },
+            value: {
+                text: showProfileLink(prisoner.number, prisoner.name, false)
+            }
+        }), prisonerListRows) %}
+    {% endfor %}
+
+    <h2 class="govuk-heading-m">Prisoner details</h2>
+    {{ govukSummaryList({
+        rows: prisonerListRows,
+        attributes: { 'data-qa': 'prisoner-details' }
+    }) }}
+{% endmacro %}

--- a/server/views/pages/appointments/create/check-answers.njk.test.ts
+++ b/server/views/pages/appointments/create/check-answers.njk.test.ts
@@ -8,26 +8,31 @@ import { AppointmentRepeatPeriod } from '../../../../@types/activitiesAPI/types'
 import { YesNo } from '../../../../@types/activities'
 import { AppointmentType, CreateAppointmentJourney } from '../../../../routes/appointments/create/journey'
 
+let $: CheerioAPI
 const view = fs.readFileSync('server/views/pages/appointments/create/check-answers.njk')
 
-const getAppointmentDetailsValueElement = ($: CheerioAPI, heading: string) =>
+const getAppointmentDetailsValueElement = (heading: string) =>
   $(`[data-qa=appointment-details] > .govuk-summary-list__row > .govuk-summary-list__key:contains("${heading}")`)
     .parent()
     .find('.govuk-summary-list__value')
-const getRepeatPeriodValueElement = ($: CheerioAPI) => getAppointmentDetailsValueElement($, 'Frequency')
-const getRepeatCountValueElement = ($: CheerioAPI) => getAppointmentDetailsValueElement($, 'Occurrences')
 
-describe('Views - Create Individual Appointment - Check Answers', () => {
+const getPrisonerDetailsValueElement = (heading: string) =>
+  $(`[data-qa=prisoner-details] > .govuk-summary-list__row > .govuk-summary-list__key:contains("${heading}")`)
+    .parent()
+    .find('.govuk-summary-list__value')
+
+const getRepeatPeriodValueElement = () => getAppointmentDetailsValueElement('Frequency')
+const getRepeatCountValueElement = () => getAppointmentDetailsValueElement('Occurrences')
+const getIndividualPrisonerValueElement = (qaAttr: string) =>
+  getAppointmentDetailsValueElement('Prisoner').find(`[data-qa="${qaAttr}"]`)
+const getPrisonerListValueElement = (qaAttr: string, index: number) =>
+  $(getPrisonerDetailsValueElement('Prisoner').find(`[data-qa="${qaAttr}"]`).get(index))
+
+describe('Views - Create Appointment - Check Answers', () => {
   let compiledTemplate: Template
   const tomorrow = addDays(new Date(), 1)
-  let viewContext = {
-    session: {
-      createAppointmentJourney: { type: AppointmentType.INDIVIDUAL } as CreateAppointmentJourney,
-    },
-    startDate: tomorrow,
-    startTime: tomorrow.setHours(9, 30),
-    endTime: tomorrow.setHours(10, 0),
-  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let viewContext: any = {}
 
   const njkEnv = registerNunjucks()
 
@@ -35,21 +40,31 @@ describe('Views - Create Individual Appointment - Check Answers', () => {
     compiledTemplate = nunjucks.compile(view.toString(), njkEnv)
     viewContext = {
       session: {
-        createAppointmentJourney: { type: AppointmentType.INDIVIDUAL } as CreateAppointmentJourney,
+        createAppointmentJourney: {
+          type: AppointmentType.INDIVIDUAL,
+          prisoners: [
+            {
+              name: 'Lee Jacobson',
+              number: 'A1351DZ',
+              cellLocation: '1-3-004',
+            },
+          ],
+        } as CreateAppointmentJourney,
       },
       startDate: tomorrow,
       startTime: tomorrow.setHours(9, 30),
       endTime: tomorrow.setHours(10, 0),
     }
+
+    $ = cheerio.load(compiledTemplate.render(viewContext))
   })
 
   it('should not display repeat frequency or occurrences when repeat = NO', () => {
     viewContext.session.createAppointmentJourney.repeat = YesNo.NO
+    $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    const $ = cheerio.load(compiledTemplate.render(viewContext))
-
-    expect(getRepeatPeriodValueElement($).length).toBe(0)
-    expect(getRepeatCountValueElement($).length).toBe(0)
+    expect(getRepeatPeriodValueElement().length).toBe(0)
+    expect(getRepeatCountValueElement().length).toBe(0)
   })
 
   it.each([
@@ -61,18 +76,46 @@ describe('Views - Create Individual Appointment - Check Answers', () => {
   ])('should display frequency $repeatPeriod as $expectedText when repeat = YES', ({ repeatPeriod, expectedText }) => {
     viewContext.session.createAppointmentJourney.repeat = YesNo.YES
     viewContext.session.createAppointmentJourney.repeatPeriod = repeatPeriod
+    $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    const $ = cheerio.load(compiledTemplate.render(viewContext))
-
-    expect(getRepeatPeriodValueElement($).text().trim()).toEqual(expectedText)
+    expect(getRepeatPeriodValueElement().text().trim()).toEqual(expectedText)
   })
 
   it('should display repeat occurrences when repeat = YES', () => {
     viewContext.session.createAppointmentJourney.repeat = YesNo.YES
     viewContext.session.createAppointmentJourney.repeatCount = 6
+    $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect(getRepeatCountValueElement().text().trim()).toEqual('6')
+  })
 
-    expect(getRepeatCountValueElement($).text().trim()).toEqual('6')
+  describe('Individual Appointment', () => {
+    it('should display prisoner details', () => {
+      expect(getIndividualPrisonerValueElement('prisoner-name').text().trim()).toEqual('Lee Jacobson')
+    })
+  })
+
+  describe('Group Appointment', () => {
+    beforeEach(() => {
+      viewContext.session.createAppointmentJourney.type = AppointmentType.GROUP
+      viewContext.session.createAppointmentJourney.prisoners = [
+        {
+          name: 'Lee Jacobson',
+          number: 'A1351DZ',
+          cellLocation: '1-3-004',
+        },
+        {
+          name: 'David Winchurch',
+          number: 'A1350DZ',
+          cellLocation: '2-2-024',
+        },
+      ]
+      $ = cheerio.load(compiledTemplate.render(viewContext))
+    })
+
+    it('should display prisoners details', () => {
+      expect(getPrisonerListValueElement('prisoner-name', 0).text().trim()).toEqual('Jacobson, Lee')
+      expect(getPrisonerListValueElement('prisoner-name', 1).text().trim()).toEqual('Winchurch, David')
+    })
   })
 })

--- a/server/views/pages/appointments/create/confirmation.njk
+++ b/server/views/pages/appointments/create/confirmation.njk
@@ -38,7 +38,7 @@
 
             <h2 class="govuk-heading-m">What you can do next</h2>
             <p class="govuk-body">
-                <a href="{{ "/appointments/create/start-group" if session.createAppointmentJourney.type == "group" else "/appointments/create/start-individual" }}" class="govuk-link govuk-link--no-visited-state" data-qa="create-another-link">Create another appointment</a>
+                <a href="/appointments" class="govuk-link govuk-link--no-visited-state" data-qa="create-another-link">Create another appointment</a>
             </p>
             <p class="govuk-body">
                 <a href="/appointments/{{ id }}" class="govuk-link govuk-link--no-visited-state" data-qa="view-appointment-link">View and edit appointment details</a>

--- a/server/views/pages/appointments/create/confirmation.njk
+++ b/server/views/pages/appointments/create/confirmation.njk
@@ -38,7 +38,7 @@
 
             <h2 class="govuk-heading-m">What you can do next</h2>
             <p class="govuk-body">
-                <a href="/appointments" class="govuk-link govuk-link--no-visited-state" data-qa="create-another-link">Create another appointment</a>
+                <a href="{{ "/appointments/create/start-group" if session.createAppointmentJourney.type == "group" else "/appointments/create/start-individual" }}" class="govuk-link govuk-link--no-visited-state" data-qa="create-another-link">Create another appointment</a>
             </p>
             <p class="govuk-body">
                 <a href="/appointments/{{ id }}" class="govuk-link govuk-link--no-visited-state" data-qa="view-appointment-link">View and edit appointment details</a>

--- a/server/views/pages/appointments/create/confirmation.njk.test.ts
+++ b/server/views/pages/appointments/create/confirmation.njk.test.ts
@@ -9,7 +9,7 @@ import { AppointmentType, CreateAppointmentJourney } from '../../../../routes/ap
 
 const view = fs.readFileSync('server/views/pages/appointments/create/confirmation.njk')
 
-describe('Views - Create Individual Appointment - Check Answers', () => {
+describe('Views - Create Appointment - Check Answers', () => {
   let compiledTemplate: Template
   const tomorrow = addDays(new Date(), 1)
   let viewContext = {
@@ -84,4 +84,36 @@ describe('Views - Create Individual Appointment - Check Answers', () => {
       )
     },
   )
+
+  describe('Group Appointment', () => {
+    it('should display number of prisoners added to appointment', () => {
+      viewContext.session.createAppointmentJourney = {
+        type: AppointmentType.GROUP,
+        prisoners: [
+          {
+            name: 'TEST PRISONER',
+            number: 'A1234BC',
+            cellLocation: '1-2-3',
+          },
+          {
+            name: 'SECOND PRISONER',
+            number: 'A1234BD',
+            cellLocation: '3-2-1',
+          },
+          {
+            name: 'THIRD PRISONER',
+            number: 'A1234BE',
+            cellLocation: '3-3-3',
+          },
+        ],
+        repeat: YesNo.NO,
+      } as CreateAppointmentJourney
+
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('[data-qa=message]').text().trim().replace(/\s+/g, ' ')).toEqual(
+        `You have successfully created an appointment for 3 prisoners on ${format(tomorrow, 'EEEE d MMMM yyyy')}.`,
+      )
+    })
+  })
 })

--- a/server/views/pages/appointments/create/repeat-period-and-count.njk.test.ts
+++ b/server/views/pages/appointments/create/repeat-period-and-count.njk.test.ts
@@ -7,7 +7,7 @@ import { AppointmentType, CreateAppointmentJourney } from '../../../../routes/ap
 
 const view = fs.readFileSync('server/views/pages/appointments/create/repeat-period-and-count.njk')
 
-describe('Views - Create Individual Appointment - Repeat Period and Count', () => {
+describe('Views - Create Appointment - Repeat Period and Count', () => {
   let compiledTemplate: Template
   let viewContext = {
     session: {
@@ -26,12 +26,6 @@ describe('Views - Create Individual Appointment - Repeat Period and Count', () =
       },
       formResponses: {},
     }
-  })
-
-  it('should display journey title', () => {
-    const $ = cheerio.load(compiledTemplate.render(viewContext))
-
-    expect($('[data-qa=caption]').text()).toBe('Individual appointment')
   })
 
   it('should contain enum WEEKDAY, DAILY, WEEKLY, FORTNIGHTLY and MONTHLY inputs', () => {
@@ -99,5 +93,25 @@ describe('Views - Create Individual Appointment - Repeat Period and Count', () =
     const checked = $("[name='repeatPeriod']:checked")
     expect(checked.length).toEqual(1)
     expect(checked.val()).toEqual(AppointmentRepeatPeriod.WEEKLY.toString())
+  })
+
+  describe('Individual Appointment', () => {
+    it('should display journey title', () => {
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('[data-qa=caption]').text()).toBe('Individual appointment')
+    })
+  })
+
+  describe('Group Appointment', () => {
+    beforeEach(() => {
+      viewContext.session.createAppointmentJourney.type = AppointmentType.GROUP
+    })
+
+    it('should display journey title', () => {
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('[data-qa=caption]').text()).toBe('Group appointment')
+    })
   })
 })

--- a/server/views/pages/appointments/create/repeat.njk.test.ts
+++ b/server/views/pages/appointments/create/repeat.njk.test.ts
@@ -7,7 +7,7 @@ import { AppointmentType, CreateAppointmentJourney } from '../../../../routes/ap
 
 const view = fs.readFileSync('server/views/pages/appointments/create/repeat.njk')
 
-describe('Views - Create Individual Appointment - Repeat', () => {
+describe('Views - Create Appointment - Repeat', () => {
   let compiledTemplate: Template
   let viewContext = {
     session: {
@@ -26,12 +26,6 @@ describe('Views - Create Individual Appointment - Repeat', () => {
       },
       formResponses: {},
     }
-  })
-
-  it('should display journey title', () => {
-    const $ = cheerio.load(compiledTemplate.render(viewContext))
-
-    expect($('[data-qa=caption]').text()).toBe('Individual appointment')
   })
 
   it('should contain enum YES and NO inputs', () => {
@@ -77,5 +71,25 @@ describe('Views - Create Individual Appointment - Repeat', () => {
     const checked = $("[name='repeat']:checked")
     expect(checked.length).toEqual(1)
     expect(checked.val()).toEqual(YesNo.NO.toString())
+  })
+
+  describe('Individual Appointment', () => {
+    it('should display journey title', () => {
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('[data-qa=caption]').text()).toBe('Individual appointment')
+    })
+  })
+
+  describe('Group Appointment', () => {
+    beforeEach(() => {
+      viewContext.session.createAppointmentJourney.type = AppointmentType.GROUP
+    })
+
+    it('should display journey title', () => {
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('[data-qa=caption]').text()).toBe('Group appointment')
+    })
   })
 })

--- a/server/views/pages/appointments/create/review-prisoners.njk
+++ b/server/views/pages/appointments/create/review-prisoners.njk
@@ -30,6 +30,9 @@
                 ]), prisonersList) %}
             {% endfor %}
             {{ govukTable({
+                attributes: {
+                    'data-qa': 'prisoners-list-table'
+                },
                 head: [
                     {
                         text: "Name",

--- a/server/views/pages/appointments/create/review-prisoners.njk
+++ b/server/views/pages/appointments/create/review-prisoners.njk
@@ -10,7 +10,7 @@
 
 {% set pageTitle = "Appointments Management - Create Appointment - Review Prisoners" %}
 {% set pageId = 'appointments-create-review-prisoners-page' %}
-{% set backLinkHref = "/select-prisoners" %}
+{% set backLinkHref = "select-prisoner" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/partials/showProfileLink.njk
+++ b/server/views/partials/showProfileLink.njk
@@ -1,11 +1,15 @@
-{% macro showProfileLink(prisonerNumber, displayName) %}
+{% macro showProfileLink(prisonerNumber, displayName, link = true) %}
     <div class="hmpps-inline-block">
       <div>
-        <a href="{{ dpsUrl }}/prisoner/{{ prisonerNumber }}"
-          target="_blank"
-          class="govuk-link govuk-link--no-visited-state">
-          {{ displayName | toTitleCase | prisonerName }}
-        </a>
+        {% if link %}
+          <a href="{{ dpsUrl }}/prisoner/{{ prisonerNumber }}"
+            target="_blank"
+            class="govuk-link govuk-link--no-visited-state">
+            {{ displayName | toTitleCase | prisonerName }}
+          </a>
+        {% else %}
+          {{ displayName | toTitleCase | prisonerName(false) }}
+        {% endif %}
       </div>
       <div class="govuk-!-font-size-14">{{ prisonerNumber }}</div>
     </div>

--- a/server/views/partials/showProfileLink.njk
+++ b/server/views/partials/showProfileLink.njk
@@ -1,6 +1,6 @@
 {% macro showProfileLink(prisonerNumber, displayName, link = true) %}
     <div class="hmpps-inline-block">
-      <div>
+      <div data-qa="prisoner-name">
         {% if link %}
           <a href="{{ dpsUrl }}/prisoner/{{ prisonerNumber }}"
             target="_blank"
@@ -11,6 +11,6 @@
           {{ displayName | toTitleCase | prisonerName(false) }}
         {% endif %}
       </div>
-      <div class="govuk-!-font-size-14">{{ prisonerNumber }}</div>
+      <div class="govuk-!-font-size-14" data-qa="prisoner-number">{{ prisonerNumber }}</div>
     </div>
 {% endmacro %}


### PR DESCRIPTION
## Overview

- Updated check answers page to support editing prisoner list.
- Added tests 

Note: To support the multi-page change prisoners flow, I've changed the way the check answers `from-review` param works. Now this param will set a session which will be used by the `redirectOrReturn` method to return to check answers page.

### Screenshots

<img width="981" alt="Screenshot at Mar 30 12-28-45" src="https://user-images.githubusercontent.com/125488090/228822269-4564fa5c-8378-4714-a4e7-3a06e867a6f9.png">
