### PR TITLE
SAA-742: Small changes to app insights configuration.

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,3 +1,6 @@
+// Require app insights before anything else to allow instrumentation of bunyan and express.
+import 'applicationinsights'
+
 import { app, metricsApp } from './server/index'
 import logger from './logger'
 

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -17,7 +17,7 @@ function version(): string {
 export function initialiseAppInsights(): void {
   // Loads .env file contents into | process.env
   config()
-  if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+  if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     // eslint-disable-next-line no-console
     console.log('Enabling azure application insights')
 
@@ -26,7 +26,7 @@ export function initialiseAppInsights(): void {
 }
 
 export function buildAppInsightsClient(name = defaultName()): TelemetryClient {
-  if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+  if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     defaultClient.context.tags['ai.cloud.role'] = name
     defaultClient.context.tags['ai.application.ver'] = version()
     return defaultClient


### PR DESCRIPTION
Discovered that the UI service has not been logging traces or exceptions to App Insights (for some time..)
This config change should instrument Bunyan to do this.

Test (for last 3 days)

```
traces
| where cloud_Rolename == 'hmpps-activities-management'
```