### PR TITLE
SAA-607: Updated unlock list appointment events

### DIFF
--- a/frontend/components/tags/_tags.scss
+++ b/frontend/components/tags/_tags.scss
@@ -1,3 +1,8 @@
+.govuk-tag--small {
+  font-size: .875rem;
+  line-height: 1;
+}
+
 .govuk-tag--dark-green {
   background: govuk-colour("green");
   color: govuk-colour("white");

--- a/server/@types/activitiesAPI/index.d.ts
+++ b/server/@types/activitiesAPI/index.d.ts
@@ -912,6 +912,11 @@ export interface components {
        */
       appointmentInstanceId?: number
       /**
+       * @description For appointments from SAA the optional appointment description
+       * @example Meeting with the governor
+       */
+      appointmentDescription?: string
+      /**
        * Format: int64
        * @description For adjudication hearings from NOMIS the ID for the OIC hearing, or null for other types
        * @example 9999

--- a/server/services/unlockListService.ts
+++ b/server/services/unlockListService.ts
@@ -91,7 +91,7 @@ export default class UnlockListService {
       return {
         ...prisoner,
         displayName: convertToTitleCase(`${prisoner.lastName}, ${prisoner.firstName}`),
-        events: this.sortByPriority(allEventsForPrisoner),
+        events: this.unlockListSort(allEventsForPrisoner),
       } as UnlockListItem
     })
 
@@ -159,11 +159,11 @@ export default class UnlockListService {
     return ''
   }
 
-  private sortByPriority = (data: ScheduledEvent[]): ScheduledEvent[] => {
+  // Events should be sorted by time, then event name (summary)
+  private unlockListSort = (data: ScheduledEvent[]): ScheduledEvent[] => {
     return data.sort((p1, p2) => {
-      if (p1.priority > p2.priority) return 1
-      if (p1.priority < p2.priority) return -1
       if (p1.startTime < p2.startTime) return -1
+      if (p1.summary.toLowerCase() < p2.summary.toLowerCase()) return -1
       return 0
     })
   }

--- a/server/services/unlockListService.ts
+++ b/server/services/unlockListService.ts
@@ -163,6 +163,7 @@ export default class UnlockListService {
     return data.sort((p1, p2) => {
       if (p1.priority > p2.priority) return 1
       if (p1.priority < p2.priority) return -1
+      if (p1.startTime < p2.startTime) return -1
       return 0
     })
   }

--- a/server/views/pages/record-attendance/attendance-list.njk
+++ b/server/views/pages/record-attendance/attendance-list.njk
@@ -8,6 +8,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "partials/attendance/otherEvent.njk" import otherEvent %}
 
 {% set pageTitle = applicationName + " - Record attendance" %}
 {% set pageId = 'attendance-list-page' %}
@@ -221,22 +223,7 @@
 
 {% macro renderOtherEvents(otherEvents) %}
     {% for event in otherEvents %}
-        <div>
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
-                {% if event.eventType == 'ACTIVITY' and event.eventSource == 'SAA' %}
-                    <a href="/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list" class="govuk-link govuk-link--no-visited-state">{{ event.summary }}</a>
-                {% elseif event.eventType == 'APPOINTMENT' and event.eventSource == 'SAA' %}
-                    <span>{{ event.summary }} {{ event.categoryDescription }}</span>
-                {% else %}
-                    <span>{{ event.summary }}</span>
-                {% endif %}
-            </h2>
-
-            {% if event.eventType != 'EXTERNAL_TRANSFER' and event.eventType != 'COURT_HEARING' %}
-               <div class="govuk-hint govuk-!-font-size-14 govuk-!-margin-0">{{ event.startTime }} - {{ event.endTime }}</div>
-               <div class="govuk-hint govuk-!-font-size-14 govuk-!-margin-0">{{ event.internalLocationDescription }}</div>
-            {% endif %}
-        </div>
+        {{ otherEvent(event) }}
     {% endfor %}
 {% endmacro %}
 

--- a/server/views/pages/record-attendance/not-attended-reason.njk
+++ b/server/views/pages/record-attendance/not-attended-reason.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "partials/attendance/otherEvent.njk" import otherEvent %}
 
 {% set pageTitle = applicationName + " - Record attendance - Not Attended Reason" %}
 {% set pageId = 'not-attended-reason-page' %}
@@ -192,20 +193,6 @@
 
 {% macro renderOtherEvents(otherEvents) %}
     {% for event in otherEvents %}
-        <div>
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
-                {% if event.eventType == 'ACTIVITY' and event.eventSource =='SAA' %}
-                    <a href="/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list" class="govuk-link govuk-link--no-visited-state">{{ event.summary }}</a>
-                {% elseif event.eventType == 'APPOINTMENT' and event.eventSource =='SAA' %}
-                    <span>{{ event.summary }} {{ event.categoryDescription }}</span>
-                {% else %}
-                    <span>{{ event.summary }}</span>
-                {% endif %}
-            </h2>
-            {% if event.eventType != 'EXTERNAL_TRANSFER' and event.eventType != 'COURT_HEARING' %}
-                <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-0">{{ event.startTime }} - {{ event.endTime }}</div>
-                <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-0">{{ event.internalLocationDescription }}</div>
-            {% endif %}
-        </div>
+        {{ otherEvent(event) }}
     {% endfor %}
 {% endmacro %}

--- a/server/views/partials/attendance/otherEvent.njk
+++ b/server/views/partials/attendance/otherEvent.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+{% macro otherEvent(event) %}
+  <div class="govuk-body govuk-!-margin-0">
+      <div class="govuk-!-font-weight-bold">
+        {% if event.eventType == 'ACTIVITY' and event.eventSource =='SAA' %}
+          <a href="/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list" class="govuk-link govuk-link--no-visited-state">{{ event.summary }}</a>
+        {% else %}
+          <span>{{ event.summary }}</span>
+        {% endif %}
+        {% if event.eventType == 'APPOINTMENT' and event.eventSource =='SAA' %}
+          <div>{{ govukTag({ text: 'Appointment', classes: 'govuk-tag--small' }) }}</div>
+        {% endif %}
+      </div>
+      {% if event.eventType != 'EXTERNAL_TRANSFER' and event.eventType != 'COURT_HEARING' %}
+        <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-0">{{ event.startTime }} - {{ event.endTime }}</div>
+        <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-0">{{ event.internalLocationDescription }}</div>
+      {% endif %}
+  </div>
+{% endmacro %}

--- a/server/views/partials/showUnlockEvents.njk
+++ b/server/views/partials/showUnlockEvents.njk
@@ -5,24 +5,22 @@
         {% for e in events %}
             {% if not loop.first %}<hr class="mid-grey-tint-20-hr" />{% endif %}
 
-            {% if e.eventType === 'ACTIVITY' and e.eventSource === 'SAA' %}
-                <div class="govuk-!-font-weight-bold">
+            <div class="govuk-!-font-weight-bold">
+                {% if e.eventType === 'ACTIVITY' and e.eventSource === 'SAA' %}
                     <a href="/attendance/activities/{{ e.scheduledInstanceId }}/attendance-list"
-                       class="govuk-link govuk-link--no-visited-state">
+                    class="govuk-link govuk-link--no-visited-state">
                         {{ e.summary | trim }}
                     </a>
-                </div>
-            {% elseif e.eventType === 'APPOINTMENT' and e.eventSource === 'SAA'%}
-                <div class="govuk-!-font-weight-bold">
+                {% elseif e.eventType === 'APPOINTMENT' and e.eventSource === 'SAA'%}
                     <a href="/appointments/{{ e.appointmentId }}/occurrence/{{ e.appointmentOccurrenceId }}"
-                       class="govuk-link govuk-link--no-visited-state">
-                        {{ (e.appointmentDescription or e.categoryDescription) | trim }}
+                    class="govuk-link govuk-link--no-visited-state">
+                        {{ e.summary | trim }}
                     </a>
                     <div>{{ govukTag({ text: 'Appointment', classes: 'govuk-tag--small' }) }}</div>
-                </div>
-            {% else %}
-                <div class="govuk-!-font-weight-bold">{{ e.summary | trim }}</div>
-            {% endif %}
+                {% else %}
+                    {{ e.summary | trim }}
+                {% endif %}
+            </div>
 
             {% if e.suspended %}
                 <strong class="govuk-tag govuk-tag--red-border govuk-!-font-size-14">Prisoner suspended</strong>

--- a/server/views/partials/showUnlockEvents.njk
+++ b/server/views/partials/showUnlockEvents.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
 {% macro showUnlockEvents(events) %}
     <div class="govuk-body govuk-!-margin-0 govuk-!-font-size-16">
         {% for e in events %}
@@ -14,8 +16,9 @@
                 <div class="govuk-!-font-weight-bold">
                     <a href="/appointments/{{ e.appointmentId }}/occurrence/{{ e.appointmentOccurrenceId }}"
                        class="govuk-link govuk-link--no-visited-state">
-                        {{ e.summary | trim }} {{ e.categoryDescription | trim }}
+                        {{ (e.appointmentDescription or e.categoryDescription) | trim }}
                     </a>
+                    <div>{{ govukTag({ text: 'Appointment', classes: 'govuk-tag--small' }) }}</div>
                 </div>
             {% else %}
                 <div class="govuk-!-font-weight-bold">{{ e.summary | trim }}</div>


### PR DESCRIPTION
## Overview

When set shows the appointment description on the unlock list and orders events by start time, summary.

Note: I've included a content change for events on the "attendance list" and "not attended reason" page. This is to support the change to the appointment summary field (https://github.com/ministryofjustice/hmpps-activities-management-api/pull/350) and brings the design in line with the latest version of the prototype.

### Screenshots

<img width="1242" alt="Screenshot at May 23 18-00-23" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/02ecc218-14ef-4121-8aee-d552a9395aba">

<img width="1240" alt="Screenshot at May 23 18-02-44" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/ac7d359e-d62a-42c7-9964-91468d02aae4">

<img width="1200" alt="Screenshot at May 25 12-58-24" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/b76fe34b-86e7-400b-b843-03e336e5363f">

