### PR TITLE
SAA-715: Adds "edit allocation" button

### DIFF
--- a/frontend/components/multi-select/multi-select.js
+++ b/frontend/components/multi-select/multi-select.js
@@ -10,6 +10,7 @@ function MultiSelect(container) {
   this.itemsDescriptionSingular = this.stickyBar.getAttribute('data-description-singular')
   this.itemsDescriptionPlural = this.stickyBar.getAttribute('data-description-plural')
   this.clearLink = this.container.querySelector('.multi-select-sticky__clear-link')
+  this.actionButtons = this.container.querySelectorAll('.govuk-button')
 
   this.stickyBar.setAttribute('aria-disabled', 'true')
 
@@ -47,6 +48,8 @@ MultiSelect.prototype.handleCheckboxChanged = function () {
     } else if (count > 1 && this.itemsDescriptionPlural) {
       this.selectedCount.innerText = `${count} ${this.itemsDescriptionPlural} selected`
     }
+
+    this.handleDisabledButtons(count)
   } else {
     this.stickyBar.classList.remove('multi-select-sticky--active')
     this.stickyBar.setAttribute('aria-disabled', 'true')
@@ -60,6 +63,19 @@ MultiSelect.prototype.handleToggleAllButtonChanged = function () {
       var event = document.createEvent('HTMLEvents')
       event.initEvent('change', false, true)
       $el.dispatchEvent(event)
+    }.bind(this)
+  )
+}
+
+MultiSelect.prototype.handleDisabledButtons = function (checkCount) {
+  nodeListForEach(
+    this.actionButtons,
+    function ($el) {
+      if (parseInt($el.dataset.maxItems) < checkCount) {
+        $el.setAttribute('disabled', 'disabled')
+      } else {
+        $el.removeAttribute('disabled')
+      }
     }.bind(this)
   )
 }

--- a/server/views/components/multi-select.njk
+++ b/server/views/components/multi-select.njk
@@ -107,11 +107,13 @@
                 <div class='govuk-button-group'>
                     {% for action in params.actions %}
                         {{ govukButton({
+                            href: action.href if action.href,
                             text: action.text,
                             classes: 'govuk-button--white',
                             preventDoubleClick: true,
                             attributes: {
-                                formaction: action.formAction
+                                formaction: action.formAction,
+                                'data-max-items': action.maxItems if action.maxItems
                             }
                         }) }}
                     {% endfor %}

--- a/server/views/pages/allocation-dashboard/allocation-dashboard.njk
+++ b/server/views/pages/allocation-dashboard/allocation-dashboard.njk
@@ -214,6 +214,11 @@
                 {
                     text: 'Remove from activity',
                     formAction: 'allocation-dashboard/deallocate'
+                },
+                {
+                    text: 'Edit allocation',
+                    href: "#",
+                    maxItems: 1
                 }
             ],
             itemsDescription: {


### PR DESCRIPTION
## Overview

Adds an edit allocation button to the "current allocated" tab of the allocation dashboard.

Note: Edit functionality to come in later ticket

### Screenshots

<img width="1292" alt="Screenshot at May 24 17-12-44" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/87c5546c-fa8a-4250-aa4a-8da1a1f9fd2c">


<img width="1249" alt="Screenshot at May 24 17-13-20" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/698ba233-f8c2-476a-ba30-1b83a9b3fb8b">

