### PR TITLE
SAA-731: Bulk appointment comments

### DIFF
--- a/frontend/utilities/_misc.scss
+++ b/frontend/utilities/_misc.scss
@@ -99,7 +99,7 @@ body {
   overflow: auto;
 }
 
-.govuk-table__celll--vertical-align-top {
+.govuk-table__cell--vertical-align-top {
   vertical-align: top;
 }
 

--- a/frontend/utilities/_misc.scss
+++ b/frontend/utilities/_misc.scss
@@ -99,6 +99,10 @@ body {
   overflow: auto;
 }
 
+.govuk-table__celll--vertical-align-top {
+  vertical-align: top;
+}
+
 .govuk-summary-list--vertical-align-top {
   dt {
     vertical-align: top;

--- a/integration_tests/e2e/appointments/editAppointments.cy.ts
+++ b/integration_tests/e2e/appointments/editAppointments.cy.ts
@@ -127,19 +127,19 @@ context('Edit appointment', () => {
     context('Comment', () => {
       it('Should update the comment of appointment occurrence', () => {
         let occurrenceDetailsPage = Page.verifyOnPage(OccurrenceDetailsPage)
-        occurrenceDetailsPage.getChangeLink('Heads up').click()
+        occurrenceDetailsPage.getChangeLink('Comment').click()
 
         const commentPage = Page.verifyOnPage(CommentPage)
         commentPage.enterComment('Updated appointment level comment')
         commentPage.getButton('Confirm and save').click()
 
         occurrenceDetailsPage = Page.verifyOnPage(OccurrenceDetailsPage)
-        occurrenceDetailsPage.assertNotificationContents("You've changed the heads up for this appointment")
+        occurrenceDetailsPage.assertNotificationContents("You've changed the comment for this appointment")
       })
 
       it('Returns to occurrence details page if back link clicked', () => {
         const occurrenceDetailsPage = Page.verifyOnPage(OccurrenceDetailsPage)
-        occurrenceDetailsPage.getChangeLink('Heads up').click()
+        occurrenceDetailsPage.getChangeLink('Comment').click()
 
         const commentPage = Page.verifyOnPage(CommentPage)
         commentPage.back()

--- a/integration_tests/e2e/appointments/editAppointments.cy.ts
+++ b/integration_tests/e2e/appointments/editAppointments.cy.ts
@@ -127,19 +127,19 @@ context('Edit appointment', () => {
     context('Comment', () => {
       it('Should update the comment of appointment occurrence', () => {
         let occurrenceDetailsPage = Page.verifyOnPage(OccurrenceDetailsPage)
-        occurrenceDetailsPage.getChangeLink('Comment').click()
+        occurrenceDetailsPage.getChangeLink('Extra information').click()
 
         const commentPage = Page.verifyOnPage(CommentPage)
         commentPage.enterComment('Updated appointment level comment')
         commentPage.getButton('Confirm and save').click()
 
         occurrenceDetailsPage = Page.verifyOnPage(OccurrenceDetailsPage)
-        occurrenceDetailsPage.assertNotificationContents("You've changed the comment for this appointment")
+        occurrenceDetailsPage.assertNotificationContents("You've changed the extra information for this appointment")
       })
 
       it('Returns to occurrence details page if back link clicked', () => {
         const occurrenceDetailsPage = Page.verifyOnPage(OccurrenceDetailsPage)
-        occurrenceDetailsPage.getChangeLink('Comment').click()
+        occurrenceDetailsPage.getChangeLink('Extra information').click()
 
         const commentPage = Page.verifyOnPage(CommentPage)
         commentPage.back()

--- a/integration_tests/pages/appointments/create-and-edit/checkAnswersPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/checkAnswersPage.ts
@@ -38,7 +38,7 @@ export default class CheckAnswersPage extends Page {
 
   assertRepeatCount = (option: string) => this.assertAppointmentDetail('Number of appointments', option)
 
-  assertComment = (comment: string) => this.assertAppointmentDetail('Comment', comment)
+  assertComment = (comment: string) => this.assertAppointmentDetail('Extra information', comment)
 
   changePrisoner = () => cy.get('[data-qa=change-prisoner]').click()
 

--- a/integration_tests/pages/appointments/create-and-edit/checkAnswersPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/checkAnswersPage.ts
@@ -38,7 +38,7 @@ export default class CheckAnswersPage extends Page {
 
   assertRepeatCount = (option: string) => this.assertAppointmentDetail('Number of appointments', option)
 
-  assertComment = (comment: string) => this.assertAppointmentDetail('Heads up', comment)
+  assertComment = (comment: string) => this.assertAppointmentDetail('Comment', comment)
 
   changePrisoner = () => cy.get('[data-qa=change-prisoner]').click()
 

--- a/integration_tests/pages/appointments/movementSlip/occurrenceMovementSlip.ts
+++ b/integration_tests/pages/appointments/movementSlip/occurrenceMovementSlip.ts
@@ -24,5 +24,5 @@ export default class OccurrenceMovementSlip extends Page {
   assertEndTime = (hour: number, minute: number) =>
     cy.get('[data-qa=time]').contains(`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`)
 
-  assertComments = (comments: string) => cy.get('[data-qa=comment]').contains(comments)
+  assertComments = (comments: string) => cy.get('[data-qa=extra-information]').contains(comments)
 }

--- a/integration_tests/pages/appointments/movementSlip/occurrenceMovementSlip.ts
+++ b/integration_tests/pages/appointments/movementSlip/occurrenceMovementSlip.ts
@@ -24,5 +24,5 @@ export default class OccurrenceMovementSlip extends Page {
   assertEndTime = (hour: number, minute: number) =>
     cy.get('[data-qa=time]').contains(`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`)
 
-  assertComments = (comments: string) => cy.get('[data-qa=heads-up]').contains(comments)
+  assertComments = (comments: string) => cy.get('[data-qa=comment]').contains(comments)
 }

--- a/server/routes/appointments/create-and-edit/bulkAppointmentJourney.ts
+++ b/server/routes/appointments/create-and-edit/bulkAppointmentJourney.ts
@@ -13,5 +13,6 @@ export type BulkAppointmentJourney = {
       name: string
       cellLocation: string
     }
+    comment?: string
   }[]
 }

--- a/server/routes/appointments/create-and-edit/createRoutes.ts
+++ b/server/routes/appointments/create-and-edit/createRoutes.ts
@@ -12,6 +12,10 @@ import DateAndTimeRoutes, { DateAndTime } from './handlers/dateAndTime'
 import RepeatRoutes, { Repeat } from './handlers/repeat'
 import RepeatPeriodAndCountRoutes, { RepeatPeriodAndCount } from './handlers/repeatPeriodAndCount'
 import CommentRoutes, { Comment } from './handlers/comment'
+import BulkAppointmentComments from './handlers/bulk-appointments/bulkAppointmentComments'
+import BulkAppointmentAddComment, {
+  BulkAppointmentComment,
+} from './handlers/bulk-appointments/bulkAppointmentAddComment'
 import CheckAnswersRoutes from './handlers/checkAnswers'
 import ConfirmationRoutes from './handlers/confirmation'
 import HowToAddPrisoners, { HowToAddPrisonersForm } from './handlers/howToAddPrisoners'
@@ -57,6 +61,8 @@ export default function Create({ prisonService, activitiesService }: Services): 
   const repeatHandler = new RepeatRoutes()
   const repeatPeriodAndCountHandler = new RepeatPeriodAndCountRoutes()
   const commentHandler = new CommentRoutes(editAppointmentService)
+  const bulkAppointmentCommentsHandler = new BulkAppointmentComments()
+  const bulkAppointmentAddCommentHanlder = new BulkAppointmentAddComment()
   const checkAnswersHandler = new CheckAnswersRoutes(activitiesService)
   const confirmationHandler = new ConfirmationRoutes()
   const howToAddPrisoners = new HowToAddPrisoners(editAppointmentService)
@@ -100,6 +106,10 @@ export default function Create({ prisonService, activitiesService }: Services): 
   get('/repeat-period-and-count', repeatPeriodAndCountHandler.GET, true)
   post('/repeat-period-and-count', repeatPeriodAndCountHandler.POST, RepeatPeriodAndCount)
   get('/comment', commentHandler.GET, true)
+  get('/bulk-appointment-comments', bulkAppointmentCommentsHandler.GET, true)
+  post('/bulk-appointment-comments', bulkAppointmentCommentsHandler.POST)
+  get('/bulk-appointment-comments/:prisonerNumber', bulkAppointmentAddCommentHanlder.GET, true)
+  post('/bulk-appointment-comments/:prisonerNumber', bulkAppointmentAddCommentHanlder.POST, BulkAppointmentComment)
   post('/comment', commentHandler.CREATE, Comment)
   get('/check-answers', checkAnswersHandler.GET, true)
   post('/check-answers', checkAnswersHandler.POST)

--- a/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentAddComment.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentAddComment.test.ts
@@ -1,0 +1,211 @@
+import { Request, Response } from 'express'
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import { associateErrorsWithProperty } from '../../../../../utils/utils'
+import BulkAppointmentAddComment, { BulkAppointmentComment } from './bulkAppointmentAddComment'
+import { BulkAppointmentJourney } from '../../bulkAppointmentJourney'
+
+describe('Route Handlers - Create Bulk Appointment - Add Comment', () => {
+  const handler = new BulkAppointmentAddComment()
+  let req: Request
+  let res: Response
+
+  beforeEach(() => {
+    res = {
+      locals: {
+        user: {
+          username: 'test.user',
+        },
+      },
+      render: jest.fn(),
+      redirect: jest.fn(),
+      redirectOrReturn: jest.fn(),
+      validationFailed: jest.fn(),
+    } as unknown as Response
+
+    req = {
+      session: {
+        bulkAppointmentJourney: {},
+      },
+      params: {},
+      flash: jest.fn(),
+    } as unknown as Request
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('GET', () => {
+    it('retrieves prisoner appointment and renders add comment page with correct context', async () => {
+      const testPrisonerAppointment = {
+        prisoner: {
+          number: 'A1234BC',
+        },
+        comment: 'An appointment comment',
+      }
+      req.session.bulkAppointmentJourney.appointments = [
+        testPrisonerAppointment,
+      ] as BulkAppointmentJourney['appointments']
+
+      req.params = {
+        prisonerNumber: 'A1234BC',
+      }
+
+      handler.GET(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/bulk-appointments/add-comment', {
+        prisoner: testPrisonerAppointment.prisoner,
+        comment: testPrisonerAppointment.comment,
+      })
+    })
+
+    it('fails to find prisoner appointment and redirect to bulk appointment comments review page', async () => {
+      const testPrisonerAppointment = {
+        prisoner: {
+          number: 'A1234BC',
+        },
+        comment: 'An appointment comment',
+      }
+      req.session.bulkAppointmentJourney.appointments = [
+        testPrisonerAppointment,
+      ] as BulkAppointmentJourney['appointments']
+
+      req.params = {
+        prisonerNumber: 'INVALID',
+      }
+
+      handler.GET(req, res)
+
+      expect(res.redirect).toHaveBeenCalledWith('../bulk-appointment-comments')
+      expect(res.render).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('POST', () => {
+    it('adds comment to appointment and redirects back to the comments review page', async () => {
+      const testPrisonerAppointment = {
+        prisoner: {
+          number: 'A1234BC',
+        },
+      }
+      req.session.bulkAppointmentJourney.appointments = [
+        testPrisonerAppointment,
+      ] as BulkAppointmentJourney['appointments']
+
+      req.body = {
+        comment: 'A comment',
+      }
+      req.params = {
+        prisonerNumber: 'A1234BC',
+      }
+
+      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toBeUndefined()
+
+      handler.POST(req, res)
+
+      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toEqual('A comment')
+      expect(res.redirect).toHaveBeenCalledWith('../bulk-appointment-comments')
+    })
+
+    it('updates existing comment and redirects back to the comments review page', async () => {
+      const testPrisonerAppointment = {
+        prisoner: {
+          number: 'A1234BC',
+        },
+        comment: 'A comment',
+      }
+      req.session.bulkAppointmentJourney.appointments = [
+        testPrisonerAppointment,
+      ] as BulkAppointmentJourney['appointments']
+
+      req.body = {
+        comment: 'A different comment',
+      }
+      req.params = {
+        prisonerNumber: 'A1234BC',
+      }
+
+      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toEqual('A comment')
+
+      handler.POST(req, res)
+
+      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toEqual('A different comment')
+      expect(res.redirect).toHaveBeenCalledWith('../bulk-appointment-comments')
+    })
+
+    it('updates existing comment and redirects back to the comments review page', async () => {
+      const testPrisonerAppointment = {
+        prisoner: {
+          number: 'A1234BC',
+        },
+        comment: 'A comment',
+      }
+      req.session.bulkAppointmentJourney.appointments = [
+        testPrisonerAppointment,
+      ] as BulkAppointmentJourney['appointments']
+
+      req.body = {
+        comment: 'A different comment',
+      }
+
+      req.params = {
+        prisonerNumber: 'A1234BC',
+      }
+
+      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toEqual('A comment')
+
+      handler.POST(req, res)
+
+      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toEqual('A different comment')
+      expect(res.redirect).toHaveBeenCalledWith('../bulk-appointment-comments')
+    })
+
+    it('fails to find prisoner and redirects back to the comments review page with session unchanged', async () => {
+      const testPrisonerAppointment = {
+        prisoner: {
+          number: 'A1234BC',
+        },
+        comment: 'A comment',
+      }
+      req.session.bulkAppointmentJourney.appointments = [
+        testPrisonerAppointment,
+      ] as BulkAppointmentJourney['appointments']
+
+      req.body = {
+        comment: 'A comment',
+      }
+      req.params = {
+        prisonerNumber: 'INVALID',
+      }
+
+      handler.POST(req, res)
+
+      expect(req.session.bulkAppointmentJourney.appointments).toHaveLength(1)
+      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toEqual('A comment')
+      expect(res.redirect).toHaveBeenCalledWith('../bulk-appointment-comments')
+    })
+  })
+
+  describe('Validation', () => {
+    it.each([
+      { comment: Array(4001).fill('a').join(''), isValid: false },
+      { comment: Array(4000).fill('a').join(''), isValid: true },
+      { comment: Array(3999).fill('a').join(''), isValid: true },
+    ])('should validate comment character length', async ({ comment, isValid }) => {
+      const body = {
+        comment,
+      }
+
+      const requestObject = plainToInstance(BulkAppointmentComment, body)
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+      if (isValid) {
+        expect(errors).toHaveLength(0)
+      } else {
+        expect(errors).toEqual([
+          { property: 'comment', error: 'You must enter a comment which has no more than 4,000 characters' },
+        ])
+      }
+    })
+  })
+})

--- a/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentAddComment.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentAddComment.test.ts
@@ -134,33 +134,6 @@ describe('Route Handlers - Create Bulk Appointment - Add Comment', () => {
       expect(res.redirect).toHaveBeenCalledWith('../bulk-appointment-comments')
     })
 
-    it('updates existing comment and redirects back to the comments review page', async () => {
-      const testPrisonerAppointment = {
-        prisoner: {
-          number: 'A1234BC',
-        },
-        comment: 'A comment',
-      }
-      req.session.bulkAppointmentJourney.appointments = [
-        testPrisonerAppointment,
-      ] as BulkAppointmentJourney['appointments']
-
-      req.body = {
-        comment: 'A different comment',
-      }
-
-      req.params = {
-        prisonerNumber: 'A1234BC',
-      }
-
-      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toEqual('A comment')
-
-      handler.POST(req, res)
-
-      expect(req.session.bulkAppointmentJourney.appointments[0].comment).toEqual('A different comment')
-      expect(res.redirect).toHaveBeenCalledWith('../bulk-appointment-comments')
-    })
-
     it('fails to find prisoner and redirects back to the comments review page with session unchanged', async () => {
       const testPrisonerAppointment = {
         prisoner: {

--- a/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentAddComment.ts
+++ b/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentAddComment.ts
@@ -1,0 +1,34 @@
+import { MaxLength } from 'class-validator'
+import { Request, Response } from 'express'
+
+export class BulkAppointmentComment {
+  @MaxLength(4000, { message: 'You must enter a comment which has no more than 4,000 characters' })
+  comment: string
+}
+
+export default class BulkAppointmentAddCommentRoutes {
+  GET = async (req: Request, res: Response) => {
+    const { appointments } = req.session.bulkAppointmentJourney
+    const { prisonerNumber } = req.params
+
+    // Prisoner not found, redirect back
+    const appointment = appointments.find(a => a?.prisoner.number === prisonerNumber)
+    if (!appointment) return res.redirect('../bulk-appointment-comments')
+
+    const { prisoner, comment } = appointment
+
+    return res.render('pages/appointments/create-and-edit/bulk-appointments/add-comment', { prisoner, comment })
+  }
+
+  POST = async (req: Request, res: Response) => {
+    const { comment } = req.body
+    const { appointments } = req.session.bulkAppointmentJourney
+    const { prisonerNumber } = req.params
+
+    const appointment = appointments.find(a => a?.prisoner.number === prisonerNumber)
+    if (appointment) appointment.comment = comment
+
+    if (req.query?.preserveHistory) res.redirect(`../check-answers`)
+    else res.redirect('../bulk-appointment-comments')
+  }
+}

--- a/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentComments.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentComments.test.ts
@@ -1,0 +1,68 @@
+import { Request, Response } from 'express'
+import { BulkAppointmentJourney } from '../../bulkAppointmentJourney'
+import BulkAppointmentCommentsRoutes from './bulkAppointmentComments'
+
+describe('Route Handlers - Create Bulk Appointment - Add Comment', () => {
+  const handler = new BulkAppointmentCommentsRoutes()
+  let req: Request
+  let res: Response
+
+  beforeEach(() => {
+    res = {
+      locals: {
+        user: {
+          username: 'test.user',
+        },
+      },
+      render: jest.fn(),
+      redirect: jest.fn(),
+    } as unknown as Response
+
+    req = {
+      session: {
+        bulkAppointmentJourney: {},
+      },
+    } as unknown as Request
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('GET', () => {
+    it('retrieves prisoner appointments and renders comments page with correct context', async () => {
+      const testPrisonerAppointments = [
+        {
+          prisoner: {
+            number: 'A1234BC',
+          },
+          comment: 'An appointment comment',
+        },
+        {
+          prisoner: {
+            number: 'Z4321YX',
+          },
+          comment: 'Another appointment comment',
+        },
+      ] as BulkAppointmentJourney['appointments']
+      req.session.bulkAppointmentJourney.appointments = testPrisonerAppointments
+
+      handler.GET(req, res)
+
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments',
+        {
+          appointments: testPrisonerAppointments,
+        },
+      )
+    })
+  })
+
+  describe('POST', () => {
+    it('redirects to the check answers page', async () => {
+      handler.POST(req, res)
+
+      expect(res.redirect).toHaveBeenCalledWith('check-answers')
+    })
+  })
+})

--- a/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentComments.ts
+++ b/server/routes/appointments/create-and-edit/handlers/bulk-appointments/bulkAppointmentComments.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express'
+
+export default class BulkAppointmentCommentsRoutes {
+  GET = async (req: Request, res: Response): Promise<void> => {
+    const { appointments } = req.session.bulkAppointmentJourney
+
+    res.render('pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments', { appointments })
+  }
+
+  POST = async (req: Request, res: Response): Promise<void> => res.redirect('check-answers')
+}

--- a/server/routes/appointments/create-and-edit/handlers/bulk-appointments/reviewBulkAppointment.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/bulk-appointments/reviewBulkAppointment.test.ts
@@ -201,7 +201,7 @@ describe('Route Handlers - Create Bulk Appointment - Review Bulk Appointment', (
           },
         },
       ])
-      expect(res.redirectOrReturn).toHaveBeenCalledWith(`comment`)
+      expect(res.redirectOrReturn).toHaveBeenCalledWith('bulk-appointment-comments')
     })
   })
 

--- a/server/routes/appointments/create-and-edit/handlers/bulk-appointments/reviewBulkAppointment.ts
+++ b/server/routes/appointments/create-and-edit/handlers/bulk-appointments/reviewBulkAppointment.ts
@@ -90,6 +90,6 @@ export default class ReviewBulkAppointmentRoutes {
 
     req.session.bulkAppointmentJourney.appointments = appointments
 
-    return res.redirectOrReturn(`comment`)
+    return res.redirectOrReturn(`bulk-appointment-comments`)
   }
 }

--- a/server/routes/appointments/create-and-edit/handlers/checkAnswers.ts
+++ b/server/routes/appointments/create-and-edit/handlers/checkAnswers.ts
@@ -73,6 +73,7 @@ export default class CheckAnswersRoutes {
         prisonerNumber: appointment.prisoner.number,
         startTime: plainToInstance(SimpleTime, appointment.startTime).toIsoString(),
         endTime: plainToInstance(SimpleTime, appointment.endTime).toIsoString(),
+        comment: appointment.comment,
       })),
     } as BulkAppointmentsRequest
 

--- a/server/services/editAppointmentService.test.ts
+++ b/server/services/editAppointmentService.test.ts
@@ -461,7 +461,7 @@ describe('Edit Appointment Service', () => {
         )
         expect(res.redirectWithSuccess).toHaveBeenCalledWith(
           `/appointments/${appointmentId}/occurrence/${occurrenceId}`,
-          "You've changed the heads up for this appointment",
+          "You've changed the comment for this appointment",
         )
         expect(req.session.appointmentJourney).toBeNull()
         expect(req.session.editAppointmentJourney).toBeNull()

--- a/server/services/editAppointmentService.test.ts
+++ b/server/services/editAppointmentService.test.ts
@@ -461,7 +461,7 @@ describe('Edit Appointment Service', () => {
         )
         expect(res.redirectWithSuccess).toHaveBeenCalledWith(
           `/appointments/${appointmentId}/occurrence/${occurrenceId}`,
-          "You've changed the comment for this appointment",
+          "You've changed the extra information for this appointment",
         )
         expect(req.session.appointmentJourney).toBeNull()
         expect(req.session.editAppointmentJourney).toBeNull()

--- a/server/utils/editAppointmentUtils.test.ts
+++ b/server/utils/editAppointmentUtils.test.ts
@@ -294,7 +294,7 @@ describe('Edit Appointment Utils', () => {
       req.session.editAppointmentJourney.comment = 'Updated comment'
 
       expect(getAppointmentEditMessage(req.session.appointmentJourney, req.session.editAppointmentJourney)).toEqual(
-        'change the comment for',
+        'change the extra information for',
       )
     })
 

--- a/server/utils/editAppointmentUtils.test.ts
+++ b/server/utils/editAppointmentUtils.test.ts
@@ -294,7 +294,7 @@ describe('Edit Appointment Utils', () => {
       req.session.editAppointmentJourney.comment = 'Updated comment'
 
       expect(getAppointmentEditMessage(req.session.appointmentJourney, req.session.editAppointmentJourney)).toEqual(
-        'change the heads up for',
+        'change the comment for',
       )
     })
 

--- a/server/utils/editAppointmentUtils.ts
+++ b/server/utils/editAppointmentUtils.ts
@@ -48,7 +48,7 @@ export const getAppointmentEditMessage = (
   }
 
   if (hasAppointmentCommentChanged(appointmentJourney, editAppointmentJourney)) {
-    updateProperties.push('comment')
+    updateProperties.push('extra information')
   }
 
   if (updateProperties.length > 0) {

--- a/server/utils/editAppointmentUtils.ts
+++ b/server/utils/editAppointmentUtils.ts
@@ -48,7 +48,7 @@ export const getAppointmentEditMessage = (
   }
 
   if (hasAppointmentCommentChanged(appointmentJourney, editAppointmentJourney)) {
-    updateProperties.push('heads up')
+    updateProperties.push('comment')
   }
 
   if (updateProperties.length > 0) {

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk
@@ -15,9 +15,9 @@
             <form method="POST">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {{ appointmentTypeCaption(session.appointmentJourney.type) }}
-                <h1 class="govuk-heading-l"><label for="comment">Add a comment for {{ prisoner.name | toTitleCase }}, {{ prisoner.number }}</label></h1>
+                <h1 class="govuk-heading-l"><label for="comment">Add extra information for {{ prisoner.name | toTitleCase }}, {{ prisoner.number }}</label></h1>
 
-                <p class='govuk-body'>Give the attendee a comment about their appointment. This will be printed on their movement slip.</p>
+                <p class='govuk-body'>Give the attendee extra information about their appointment. This will be printed on their movement slip.</p>
 
                 {{ govukCharacterCount({
                     hint: {

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk
@@ -1,0 +1,39 @@
+{% extends "layout.njk" %}
+
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "pages/appointments/partials/appointment-type-caption.njk" import appointmentTypeCaption %}
+{% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
+
+{% set pageTitle = appointmentJourneyTitle("Add Appointment Comment", session.appointmentJourney) %}
+{% set pageId = 'appointments-create-bulk-appointment-add-comment-page' %}
+{% set backLinkHref = 'bulk-appointment-comments' %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                {{ appointmentTypeCaption(session.appointmentJourney.type) }}
+                <h1 class="govuk-heading-l"><label for="comment">Add a comment for {{ prisoner.name | toTitleCase }}, {{ prisoner.number }}</label></h1>
+
+                <p class='govuk-body'>Give the attendee a comment about their appointment. This will be printed on their movement slip.</p>
+
+                {{ govukCharacterCount({
+                    hint: {
+                        text: 'For example, \'You need to bring all your documents about your case to this meeting with your solicitor.\''
+                    },
+                    id: "comment",
+                    name: "comment",
+                    errorMessage: validationErrors | findError("comment"),
+                    value: formResponses.comment or comment,
+                    maxlength: "4000"
+                }) }}
+
+                {{ govukButton({
+                    text: "Continue"
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk.test.ts
@@ -39,6 +39,6 @@ describe('Views - Create Bulk Appointment - Add Comment', () => {
 
     $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toEqual('Add a comment for John Smith, A1234AA')
+    expect($('h1').text()).toEqual('Add extra information for John Smith, A1234AA')
   })
 })

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk.test.ts
@@ -1,0 +1,44 @@
+import * as cheerio from 'cheerio'
+import { CheerioAPI } from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import fs from 'fs'
+import { registerNunjucks } from '../../../../../nunjucks/nunjucksSetup'
+import { AppointmentJourney } from '../../../../../routes/appointments/create-and-edit/appointmentJourney'
+
+let $: CheerioAPI
+const view = fs.readFileSync('server/views/pages/appointments/create-and-edit/bulk-appointments/add-comment.njk')
+
+describe('Views - Create Bulk Appointment - Add Comment', () => {
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown> = {}
+
+  const njkEnv = registerNunjucks()
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(view.toString(), njkEnv)
+    viewContext = {
+      session: {
+        appointmentJourney: {} as AppointmentJourney,
+      },
+    }
+  })
+
+  it('should display existing comment in textbox', () => {
+    viewContext.comment = 'existing comment'
+
+    $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#comment').val()).toEqual('existing comment')
+  })
+
+  it('should display prisoner information in the heading', () => {
+    viewContext.prisoner = {
+      number: 'A1234AA',
+      name: 'John Smith',
+    }
+
+    $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('h1').text()).toEqual('Add a comment for John Smith, A1234AA')
+  })
+})

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk
@@ -30,19 +30,19 @@
                                 prisonerNumber: appointment.prisoner.number,
                                 link: true
                             }),
-                            classes: 'govuk-table__celll--vertical-align-top',
+                            classes: 'govuk-table__cell--vertical-align-top',
                             attributes: {
                                 'data-qa': 'prisoner-info-cell'
                             }
                         }, {
                             html: '<span class="preserve-line-breaks">' + appointment.comment | escape + '</span>',
-                            classes: 'govuk-table__celll--vertical-align-top',
+                            classes: 'govuk-table__cell--vertical-align-top',
                             attributes: {
                                 'data-qa': 'comment-cell'
                             }
                         }, {
                             html: '<a href="bulk-appointment-comments/' + appointment.prisoner.number + '" class="govuk-link">' + ('Edit' if appointment.comment else 'Add') + ' extra information</a>',
-                            classes: 'govuk-!-text-align-right govuk-table__celll--vertical-align-top',
+                            classes: 'govuk-!-text-align-right govuk-table__cell--vertical-align-top',
                             attributes: {
                                 'data-qa': 'actions-cell'
                             }

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk
@@ -6,7 +6,7 @@
 {% from "pages/appointments/partials/appointment-type-caption.njk" import appointmentTypeCaption %}
 {% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
 
-{% set pageTitle = appointmentJourneyTitle("Appointment Comments", session.appointmentJourney) %}
+{% set pageTitle = appointmentJourneyTitle("Appointment extra information", session.appointmentJourney) %}
 {% set pageId = 'appointments-create-bulk-appointment-comments-page' %}
 {% set backLinkHref = 'review-bulk-appointment' %}
 
@@ -14,9 +14,9 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ appointmentTypeCaption(session.appointmentJourney.type) }}
-            <h1 class="govuk-heading-l">Add a comment to movement slips (optional)</h1>
-            <p class="govuk-body">Attendees may need information about how to prepare for their appointment. You can add this as a comment to their movement slip.</p>
-            <p class="govuk-body">Wing staff will be notified there is a comment on the printed unlock list, but for confidentiality the full details will only be visible when you view the details of the appointment in this service.</p>
+            <h1 class="govuk-heading-l">Add extra information to movement slips (optional)</h1>
+            <p class="govuk-body">Attendees may need information about how to prepare for their appointment. You can add this as extra information to their movement slip.</p>
+            <p class="govuk-body">Wing staff will be notified there is extra information on the printed unlock list, but for confidentiality the full details will only be visible when you view the details of the appointment in this service.</p>
 
             <form method="POST">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
@@ -41,7 +41,7 @@
                                 'data-qa': 'comment-cell'
                             }
                         }, {
-                            html: '<a href="bulk-appointment-comments/' + appointment.prisoner.number + '" class="govuk-link">' + ('Edit' if appointment.comment else 'Add') + ' comment</a>',
+                            html: '<a href="bulk-appointment-comments/' + appointment.prisoner.number + '" class="govuk-link">' + ('Edit' if appointment.comment else 'Add') + ' extra information</a>',
                             classes: 'govuk-!-text-align-right govuk-table__celll--vertical-align-top',
                             attributes: {
                                 'data-qa': 'actions-cell'
@@ -59,7 +59,7 @@
                             text: "Name",
                             classes: 'govuk-table__header'
                         }, {
-                            html: '<span class="govuk-visually-hidden">Comment</span>',
+                            html: '<span class="govuk-visually-hidden">Extra information</span>',
                             classes: 'govuk-!-width-one-half'
                         }, {
                             html: '<span class="govuk-visually-hidden">Actions</span>'

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk
@@ -1,0 +1,79 @@
+{% extends "layout.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "partials/showProfileLink.njk" import showProfileLink %}
+{% from "pages/appointments/partials/appointment-type-caption.njk" import appointmentTypeCaption %}
+{% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
+
+{% set pageTitle = appointmentJourneyTitle("Appointment Comments", session.appointmentJourney) %}
+{% set pageId = 'appointments-create-bulk-appointment-comments-page' %}
+{% set backLinkHref = 'review-bulk-appointment' %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ appointmentTypeCaption(session.appointmentJourney.type) }}
+            <h1 class="govuk-heading-l">Add a comment to movement slips (optional)</h1>
+            <p class="govuk-body">Attendees may need information about how to prepare for their appointment. You can add this as a comment to their movement slip.</p>
+            <p class="govuk-body">Wing staff will be notified there is a comment on the printed unlock list, but for confidentiality the full details will only be visible when you view the details of the appointment in this service.</p>
+
+            <form method="POST">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+                {% set prisonersList = [] %}
+                {% for appointment in appointments %}
+                    {% set prisonersList = (prisonersList.push([
+                        {
+                            html: showProfileLink({
+                                name: appointment.prisoner.name,
+                                prisonerNumber: appointment.prisoner.number,
+                                link: true
+                            }),
+                            classes: 'govuk-table__celll--vertical-align-top',
+                            attributes: {
+                                'data-qa': 'prisoner-info-cell'
+                            }
+                        }, {
+                            html: '<span class="preserve-line-breaks">' + appointment.comment | escape + '</span>',
+                            classes: 'govuk-table__celll--vertical-align-top',
+                            attributes: {
+                                'data-qa': 'comment-cell'
+                            }
+                        }, {
+                            html: '<a href="bulk-appointment-comments/' + appointment.prisoner.number + '" class="govuk-link">' + ('Edit' if appointment.comment else 'Add') + ' comment</a>',
+                            classes: 'govuk-!-text-align-right govuk-table__celll--vertical-align-top',
+                            attributes: {
+                                'data-qa': 'actions-cell'
+                            }
+                        }
+                    ]), prisonersList) %}
+                {% endfor %}
+
+                {{ govukTable({
+                    attributes: {
+                        'data-qa': 'comments-table'
+                    },
+                    head: [
+                        {
+                            text: "Name",
+                            classes: 'govuk-table__header'
+                        }, {
+                            html: '<span class="govuk-visually-hidden">Comment</span>',
+                            classes: 'govuk-!-width-one-half'
+                        }, {
+                            html: '<span class="govuk-visually-hidden">Actions</span>'
+                        }
+                    ],
+                    rows: prisonersList
+                }) }}
+
+                <div class="govuk-button-group">
+                    {{ govukButton({
+                        text: "Continue"
+                    }) }}
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk.test.ts
@@ -1,0 +1,78 @@
+import * as cheerio from 'cheerio'
+import { CheerioAPI } from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import fs from 'fs'
+import { registerNunjucks } from '../../../../../nunjucks/nunjucksSetup'
+import {
+  AppointmentType,
+  AppointmentJourney,
+} from '../../../../../routes/appointments/create-and-edit/appointmentJourney'
+import { BulkAppointmentJourney } from '../../../../../routes/appointments/create-and-edit/bulkAppointmentJourney'
+
+let $: CheerioAPI
+const view = fs.readFileSync(
+  'server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk',
+)
+
+const getPrisonerCommentRow = (prisonerNumber: string) =>
+  $(`[data-qa="comments-table"] tr td[data-qa="prisoner-info-cell"]:contains("${prisonerNumber}")`).parent()
+
+const getPrisonerCommentsTableCell = (prisonerNumber: string, cell: string) =>
+  getPrisonerCommentRow(prisonerNumber).find(`td[data-qa="${cell}"]`)
+
+describe('Views - Create Bulk Appointment - Add Comment', () => {
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown> = {}
+
+  const njkEnv = registerNunjucks()
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(view.toString(), njkEnv)
+    viewContext = {
+      session: {
+        appointmentJourney: {
+          type: AppointmentType.BULK,
+        } as AppointmentJourney,
+        bulkAppointmentJourney: {} as BulkAppointmentJourney,
+      },
+    }
+  })
+
+  it('should display appointments and existing comments', () => {
+    viewContext.appointments = [
+      {
+        prisoner: {
+          number: 'A1234AA',
+          name: 'John Smith',
+        },
+        comment: 'appointment comment',
+      },
+      {
+        prisoner: {
+          number: 'Z4321YX',
+          name: 'Joe Bloggs',
+          comment: '',
+        },
+      },
+      {
+        prisoner: {
+          number: 'B2222BB',
+          name: 'Lee Jacobson',
+        },
+      },
+    ]
+
+    $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('[data-qa="comments-table"] tr').length).toEqual(4)
+
+    expect(getPrisonerCommentsTableCell('A1234AA', 'comment-cell').text()).toEqual('appointment comment')
+    expect(getPrisonerCommentsTableCell('A1234AA', 'actions-cell').text()).toEqual('Edit comment')
+
+    expect(getPrisonerCommentsTableCell('Z4321YX', 'comment-cell').text()).toEqual('')
+    expect(getPrisonerCommentsTableCell('Z4321YX', 'actions-cell').text()).toEqual('Add comment')
+
+    expect(getPrisonerCommentsTableCell('B2222BB', 'comment-cell').text()).toEqual('')
+    expect(getPrisonerCommentsTableCell('B2222BB', 'actions-cell').text()).toEqual('Add comment')
+  })
+})

--- a/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/bulk-appointments/bulk-appointment-comments.njk.test.ts
@@ -67,12 +67,12 @@ describe('Views - Create Bulk Appointment - Add Comment', () => {
     expect($('[data-qa="comments-table"] tr').length).toEqual(4)
 
     expect(getPrisonerCommentsTableCell('A1234AA', 'comment-cell').text()).toEqual('appointment comment')
-    expect(getPrisonerCommentsTableCell('A1234AA', 'actions-cell').text()).toEqual('Edit comment')
+    expect(getPrisonerCommentsTableCell('A1234AA', 'actions-cell').text()).toEqual('Edit extra information')
 
     expect(getPrisonerCommentsTableCell('Z4321YX', 'comment-cell').text()).toEqual('')
-    expect(getPrisonerCommentsTableCell('Z4321YX', 'actions-cell').text()).toEqual('Add comment')
+    expect(getPrisonerCommentsTableCell('Z4321YX', 'actions-cell').text()).toEqual('Add extra information')
 
     expect(getPrisonerCommentsTableCell('B2222BB', 'comment-cell').text()).toEqual('')
-    expect(getPrisonerCommentsTableCell('B2222BB', 'actions-cell').text()).toEqual('Add comment')
+    expect(getPrisonerCommentsTableCell('B2222BB', 'actions-cell').text()).toEqual('Add extra information')
   })
 })

--- a/server/views/pages/appointments/create-and-edit/category.njk
+++ b/server/views/pages/appointments/create-and-edit/category.njk
@@ -7,10 +7,10 @@
 
 {% set pageTitle = appointmentJourneyTitle("Type", session.appointmentJourney) %}
 {% set pageId = 'appointments-create-category-page' %}
-{% if session.appointmentJourney.type == AppointmentType.BULK %}
-    {% set backLinkHref = "/appointments/create/review-prisoners" %}
-{% else %}
+{% if session.appointmentJourney.type == AppointmentType.INDIVIDUAL %}
     {% set backLinkHref = "/appointments/create/select-prisoner?query=" + session.appointmentJourney.prisoners[0].number %}
+{% else %}
+    {% set backLinkHref = "/appointments/create/review-prisoners" %}
 {% endif %}
 
 {% set options = [{ value: "-", text: "" }] %}

--- a/server/views/pages/appointments/create-and-edit/category.njk
+++ b/server/views/pages/appointments/create-and-edit/category.njk
@@ -7,7 +7,11 @@
 
 {% set pageTitle = appointmentJourneyTitle("Type", session.appointmentJourney) %}
 {% set pageId = 'appointments-create-category-page' %}
-{% set backLinkHref = "/appointments/create/select-prisoner?query=" + session.appointmentJourney.prisoners[0].number %}
+{% if session.appointmentJourney.type == AppointmentType.BULK %}
+    {% set backLinkHref = "/appointments/create/review-prisoners" %}
+{% else %}
+    {% set backLinkHref = "/appointments/create/select-prisoner?query=" + session.appointmentJourney.prisoners[0].number %}
+{% endif %}
 
 {% set options = [{ value: "-", text: "" }] %}
 {% for category in categories %}

--- a/server/views/pages/appointments/create-and-edit/category.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/category.njk.test.ts
@@ -1,0 +1,52 @@
+import * as cheerio from 'cheerio'
+import { CheerioAPI } from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import fs from 'fs'
+import { registerNunjucks } from '../../../../nunjucks/nunjucksSetup'
+import { AppointmentType, AppointmentJourney } from '../../../../routes/appointments/create-and-edit/appointmentJourney'
+
+let $: CheerioAPI
+const view = fs.readFileSync('server/views/pages/appointments/create-and-edit/category.njk')
+
+describe('Views - Create Appointment - Category', () => {
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown> = {}
+
+  const njkEnv = registerNunjucks()
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(view.toString(), njkEnv)
+    viewContext = {
+      session: {
+        appointmentJourney: {} as AppointmentJourney,
+      },
+    }
+  })
+
+  it('should link back to the select prisoner page if not a bulk appointment', () => {
+    viewContext.session = {
+      appointmentJourney: {
+        type: AppointmentType.INDIVIDUAL,
+        prisoners: [
+          {
+            number: 'A1234AA',
+          },
+        ],
+      },
+    }
+    $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.govuk-back-link').first().attr('href')).toEqual('/appointments/create/select-prisoner?query=A1234AA')
+  })
+
+  it('should link back to the review prisoners page if a bulk appointment', () => {
+    viewContext.session = {
+      appointmentJourney: {
+        type: AppointmentType.BULK,
+      },
+    }
+    $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.govuk-back-link').first().attr('href')).toEqual('/appointments/create/review-prisoners')
+  })
+})

--- a/server/views/pages/appointments/create-and-edit/check-answers.njk
+++ b/server/views/pages/appointments/create-and-edit/check-answers.njk
@@ -255,7 +255,7 @@
     {% set summaryListRows = (summaryListRows.push(
         {
             key: {
-                text: "Comment"
+                text: "Extra information"
             },
             value: {
                 html: '<span class="preserve-line-breaks">' + (session.appointmentJourney.comment | escape) + '</span>'
@@ -265,7 +265,7 @@
                     {
                         href: "comment?preserveHistory=true",
                         text: "Change",
-                        visuallyHiddenText: "change comment",
+                        visuallyHiddenText: "change extra information",
                         classes: "govuk-link--no-visited-state",
                         attributes: { 'data-qa': 'change-comment' }
                     }
@@ -420,7 +420,7 @@
                 }
             }, {
                 key: {
-                    text: "Comment"
+                    text: "Extra information"
                 },
                 value: {
                     html: '<span class="preserve-line-breaks">' + appointment.comment | escape + '</span>'
@@ -430,7 +430,7 @@
                         {
                             href: "bulk-appointment-comments/" + appointment.prisoner.number + "?preserveHistory=true",
                             text: "Change",
-                            visuallyHiddenText: "change comment"
+                            visuallyHiddenText: "change extra information"
                         }
                     ]
                 }

--- a/server/views/pages/appointments/create-and-edit/check-answers.njk
+++ b/server/views/pages/appointments/create-and-edit/check-answers.njk
@@ -251,27 +251,29 @@
       }
   }), summaryListRows) %}
 {% endif %}
-{% set summaryListRows = (summaryListRows.push(
-    {
-        key: {
-            text: "Heads up"
-        },
-        value: {
-            html: '<span class="preserve-line-breaks">' + (session.appointmentJourney.comment | safe) + '</span>'
-        },
-        actions: {
-            items: [
-                {
-                    href: "comment?preserveHistory=true",
-                    text: "Change",
-                    visuallyHiddenText: "change heads up",
-                    classes: "govuk-link--no-visited-state",
-                    attributes: { 'data-qa': 'change-comment' }
-                }
-            ]
+{% if session.appointmentJourney.type !== AppointmentType.BULK %}
+    {% set summaryListRows = (summaryListRows.push(
+        {
+            key: {
+                text: "Comment"
+            },
+            value: {
+                html: '<span class="preserve-line-breaks">' + (session.appointmentJourney.comment | escape) + '</span>'
+            },
+            actions: {
+                items: [
+                    {
+                        href: "comment?preserveHistory=true",
+                        text: "Change",
+                        visuallyHiddenText: "change comment",
+                        classes: "govuk-link--no-visited-state",
+                        attributes: { 'data-qa': 'change-comment' }
+                    }
+                ]
+            }
         }
-    }
-), summaryListRows) %}
+    ), summaryListRows) %}
+{% endif %}
 {% if session.appointmentJourney.type == AppointmentType.BULK %}
     {% set summaryListRows = (summaryListRows.push(
         {
@@ -290,17 +292,18 @@
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Check and confirm the appointment details</h1>
             <h2 class="govuk-heading-m">Appointment details</h2>
-            {{ govukSummaryList({
-                rows: summaryListRows,
-                attributes: { 'data-qa': 'appointment-details' }
-            }) }}
-
-            {{ prisonersList() if session.appointmentJourney.type == AppointmentType.GROUP }}
-
-            {{ bulkAppointments() if session.appointmentJourney.type == AppointmentType.BULK }}
 
             <form method="POST">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+                {{ govukSummaryList({
+                    rows: summaryListRows,
+                    attributes: { 'data-qa': 'appointment-details' }
+                }) }}
+
+                {{ prisonersList() if session.appointmentJourney.type == AppointmentType.GROUP }}
+
+                {{ bulkAppointments() if session.appointmentJourney.type == AppointmentType.BULK }}
 
                 <div class="govuk-button-group">
                     {{ govukButton({
@@ -355,7 +358,16 @@
     }) }}
 {% endmacro %}
 
-{% macro bulkAppointmentsList() %}
+{% macro bulkAppointments() %}
+    <div class="govuk-button-group">
+        {{ govukButton({
+            text: "Confirm and save",
+            preventDoubleClick: true
+        }) }}
+    </div>
+
+    <h2 class="govuk-heading-m">You are creating {{ session.bulkAppointmentJourney.appointments | length }} appointments</h2>
+
     {% for appointment in session.bulkAppointmentJourney.appointments %}
         {{ govukSummaryList({
             card: {
@@ -406,17 +418,23 @@
                         }
                     ]
                 }
+            }, {
+                key: {
+                    text: "Comment"
+                },
+                value: {
+                    html: '<span class="preserve-line-breaks">' + appointment.comment | escape + '</span>'
+                },
+                actions: {
+                    items: [
+                        {
+                            href: "bulk-appointment-comments/" + appointment.prisoner.number + "?preserveHistory=true",
+                            text: "Change",
+                            visuallyHiddenText: "change comment"
+                        }
+                    ]
+                }
             }]
         }) }}
     {% endfor %}
-{% endmacro %}
-
-{% macro bulkAppointments() %}
-    <h2 class="govuk-heading-m">Prisoner appointment details</h2>
-
-    {{ govukDetails({
-        summaryText: "View individual prisoner appointment details",
-        html: bulkAppointmentsList()
-    }) }}
-    
 {% endmacro %}

--- a/server/views/pages/appointments/create-and-edit/comment.njk
+++ b/server/views/pages/appointments/create-and-edit/comment.njk
@@ -5,7 +5,7 @@
 {% from "pages/appointments/partials/appointment-type-caption.njk" import appointmentTypeCaption %}
 {% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
 
-{% set pageTitle = appointmentJourneyTitle("Appointment Comment", session.appointmentJourney) %}
+{% set pageTitle = appointmentJourneyTitle("Appointment Extra information", session.appointmentJourney) %}
 {% set pageId = 'appointments-create-comment-page' %}
 {% set backLinkHref = backLinkHref %}
 
@@ -15,21 +15,21 @@
       {{ appointmentTypeCaption(session.appointmentJourney.type) }}
       {% if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT %}
         <h1 class="govuk-heading-l">
-            <label class="govuk-label govuk-label--l" for="comment">Change the comment for everyone attending the appointment (optional)</label>
+            <label class="govuk-label govuk-label--l" for="comment">Change the extra information for everyone attending the appointment (optional)</label>
         </h1>
         <p class="govuk-body" data-qa="first-paragraph">
           You can edit information for attendees about how to prepare for their appointment. Note that changes will not appear on any movement slips that have already been printed.
         </p>
       {% else %}
         <h1 class="govuk-heading-l">
-            <label class="govuk-label govuk-label--l" for="comment">Add a comment for everyone attending the appointment (optional)</label>
+            <label class="govuk-label govuk-label--l" for="comment">Add extra information for everyone attending the appointment (optional)</label>
         </h1>
         <p class="govuk-body" data-qa="first-paragraph">
-          Attendees may need information about how to prepare for their appointment. You can add this as a comment which will be printed on their movement slips.
+          Attendees may need information about how to prepare for their appointment. You can add this as extra information which will be printed on their movement slips.
         </p>
       {% endif %}
       <p class="govuk-body">
-        Wing staff will be notified there is a comment on the printed unlock list, but for confidentiality the full text will only be visible when you view the details of the appointment in this service.
+        Wing staff will be notified there is extra information on the printed unlock list, but for confidentiality the full text will only be visible when you view the details of the appointment in this service.
       </p>
       <form method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />

--- a/server/views/pages/appointments/create-and-edit/comment.njk
+++ b/server/views/pages/appointments/create-and-edit/comment.njk
@@ -5,7 +5,7 @@
 {% from "pages/appointments/partials/appointment-type-caption.njk" import appointmentTypeCaption %}
 {% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
 
-{% set pageTitle = appointmentJourneyTitle("Heads up", session.appointmentJourney) %}
+{% set pageTitle = appointmentJourneyTitle("Appointment Comment", session.appointmentJourney) %}
 {% set pageId = 'appointments-create-comment-page' %}
 {% set backLinkHref = backLinkHref %}
 
@@ -15,21 +15,21 @@
       {{ appointmentTypeCaption(session.appointmentJourney.type) }}
       {% if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT %}
         <h1 class="govuk-heading-l">
-            <label class="govuk-label govuk-label--l" for="comment">Change the heads up for everyone attending the appointment (optional)</label>
+            <label class="govuk-label govuk-label--l" for="comment">Change the comment for everyone attending the appointment (optional)</label>
         </h1>
         <p class="govuk-body" data-qa="first-paragraph">
           You can edit information for attendees about how to prepare for their appointment. Note that changes will not appear on any movement slips that have already been printed.
         </p>
       {% else %}
         <h1 class="govuk-heading-l">
-            <label class="govuk-label govuk-label--l" for="comment">Add a heads up for everyone attending the appointment (optional)</label>
+            <label class="govuk-label govuk-label--l" for="comment">Add a comment for everyone attending the appointment (optional)</label>
         </h1>
         <p class="govuk-body" data-qa="first-paragraph">
-          Attendees may need information about how to prepare for their appointment. You can add this as a heads up which will be printed on their movement slips.
+          Attendees may need information about how to prepare for their appointment. You can add this as a comment which will be printed on their movement slips.
         </p>
       {% endif %}
       <p class="govuk-body">
-        Wing staff will be notified there is a heads up on the printed unlock list, but for confidentiality the full text will only be visible when you view the details of the appointment in this service.
+        Wing staff will be notified there is a comment on the printed unlock list, but for confidentiality the full text will only be visible when you view the details of the appointment in this service.
       </p>
       <form method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />

--- a/server/views/pages/appointments/create-and-edit/comment.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/comment.njk.test.ts
@@ -70,9 +70,9 @@ describe('Views - Appointments Management - Comment', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toContain('Add a comment')
+    expect($('h1').text()).toContain('Add extra information')
     expect($('[data-qa=first-paragraph]').text().trim()).toEqual(
-      'Attendees may need information about how to prepare for their appointment. You can add this as a comment which will be printed on their movement slips.',
+      'Attendees may need information about how to prepare for their appointment. You can add this as extra information which will be printed on their movement slips.',
     )
   })
 
@@ -81,7 +81,7 @@ describe('Views - Appointments Management - Comment', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toContain('Change the comment')
+    expect($('h1').text()).toContain('Change the extra information')
     expect($('[data-qa=first-paragraph]').text().trim()).toEqual(
       'You can edit information for attendees about how to prepare for their appointment. Note that changes will not appear on any movement slips that have already been printed.',
     )

--- a/server/views/pages/appointments/create-and-edit/comment.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/comment.njk.test.ts
@@ -12,7 +12,7 @@ import { EditAppointmentJourney } from '../../../../routes/appointments/create-a
 
 const view = fs.readFileSync('server/views/pages/appointments/create-and-edit/comment.njk')
 
-describe('Views - Appointments Management - Heads up', () => {
+describe('Views - Appointments Management - Comment', () => {
   const weekTomorrow = addDays(new Date(), 8)
   let compiledTemplate: Template
   let viewContext = {
@@ -70,9 +70,9 @@ describe('Views - Appointments Management - Heads up', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toContain('Add a heads up')
+    expect($('h1').text()).toContain('Add a comment')
     expect($('[data-qa=first-paragraph]').text().trim()).toEqual(
-      'Attendees may need information about how to prepare for their appointment. You can add this as a heads up which will be printed on their movement slips.',
+      'Attendees may need information about how to prepare for their appointment. You can add this as a comment which will be printed on their movement slips.',
     )
   })
 
@@ -81,7 +81,7 @@ describe('Views - Appointments Management - Heads up', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('h1').text()).toContain('Change the heads up')
+    expect($('h1').text()).toContain('Change the comment')
     expect($('[data-qa=first-paragraph]').text().trim()).toEqual(
       'You can edit information for attendees about how to prepare for their appointment. Note that changes will not appear on any movement slips that have already been printed.',
     )

--- a/server/views/pages/appointments/movement-slip/occurrence.njk.test.ts
+++ b/server/views/pages/appointments/movement-slip/occurrence.njk.test.ts
@@ -77,7 +77,7 @@ describe('Views - Appointments Management - Occurrence Movement Slip', () => {
     expect($('[data-qa=appointment]').text().trim()).toEqual('Medical - Other')
     expect($('[data-qa=time]').text().trim()).toEqual(`13:00 to 13:15${formatDate(tomorrow, 'EEEE, d MMMM yyyy')}`)
     expect($('[data-qa=location]').text().trim()).toEqual('HB1 Doctors')
-    expect($('[data-qa=comment]').text().trim()).toEqual('Appointment occurrence level comment')
+    expect($('[data-qa=extra-information]').text().trim()).toEqual('Appointment occurrence level comment')
   })
 
   it('should display appointment description', () => {

--- a/server/views/pages/appointments/movement-slip/occurrence.njk.test.ts
+++ b/server/views/pages/appointments/movement-slip/occurrence.njk.test.ts
@@ -77,7 +77,7 @@ describe('Views - Appointments Management - Occurrence Movement Slip', () => {
     expect($('[data-qa=appointment]').text().trim()).toEqual('Medical - Other')
     expect($('[data-qa=time]').text().trim()).toEqual(`13:00 to 13:15${formatDate(tomorrow, 'EEEE, d MMMM yyyy')}`)
     expect($('[data-qa=location]').text().trim()).toEqual('HB1 Doctors')
-    expect($('[data-qa=heads-up]').text().trim()).toEqual('Appointment occurrence level comment')
+    expect($('[data-qa=comment]').text().trim()).toEqual('Appointment occurrence level comment')
   })
 
   it('should display appointment description', () => {
@@ -88,11 +88,11 @@ describe('Views - Appointments Management - Occurrence Movement Slip', () => {
     expect($('[data-qa=appointment]').text().trim()).toEqual('Medical - OtherChoir')
   })
 
-  it('should not display heads up when there are no comments', () => {
+  it('should not display comment when there are no comments', () => {
     viewContext.appointmentOccurrence.comment = ''
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('[data-qa=heads-up]').length).toBe(0)
+    expect($('[data-qa=comment]').length).toBe(0)
   })
 })

--- a/server/views/pages/appointments/occurrence-details/occurrence.njk
+++ b/server/views/pages/appointments/occurrence-details/occurrence.njk
@@ -171,7 +171,7 @@
                         } if occurrence.isCancelled == false and occurrence.isExpired == false
                     }, {
                         key: {
-                            text: "Comment"
+                            text: "Extra information"
                         },
                         value: {
                             html: '<span class="preserve-line-breaks">' + (occurrence.comment | escape) + '</span>'

--- a/server/views/pages/appointments/occurrence-details/occurrence.njk
+++ b/server/views/pages/appointments/occurrence-details/occurrence.njk
@@ -171,10 +171,10 @@
                         } if occurrence.isCancelled == false and occurrence.isExpired == false
                     }, {
                         key: {
-                            text: "Heads up"
+                            text: "Comment"
                         },
                         value: {
-                            html: '<span class="preserve-line-breaks">' + (occurrence.comment | safe) + '</span>'
+                            html: '<span class="preserve-line-breaks">' + (occurrence.comment | escape) + '</span>'
                         },
                         actions: {
                             items: [

--- a/server/views/pages/appointments/partials/occurrence-movement-slip.njk
+++ b/server/views/pages/appointments/partials/occurrence-movement-slip.njk
@@ -22,7 +22,7 @@
                     '<li>' + (appointmentOccurrence.startDate | toDate | formatDate('EEEE, d MMMM yyyy')) + '</li>' +
                 '</ul>') }}
                 {{ labelAndValue('Location', appointmentOccurrence.internalLocation.description) }}
-                {{ labelAndValue('Heads up', appointmentOccurrence.comment, 'movement-slip__row--no-border', 'preserve-line-breaks') if appointmentOccurrence.comment }}
+                {{ labelAndValue('Comment', appointmentOccurrence.comment | escape, 'movement-slip__row--no-border', 'preserve-line-breaks') if appointmentOccurrence.comment }}
             </dl>
 
             <p class="govuk-body-s movement-slip-footer">Printed at {{ printedAt | formatDate("HH:mm 'on' EEEE, d MMMM yyyy") }}</p>

--- a/server/views/pages/appointments/partials/occurrence-movement-slip.njk
+++ b/server/views/pages/appointments/partials/occurrence-movement-slip.njk
@@ -22,7 +22,7 @@
                     '<li>' + (appointmentOccurrence.startDate | toDate | formatDate('EEEE, d MMMM yyyy')) + '</li>' +
                 '</ul>') }}
                 {{ labelAndValue('Location', appointmentOccurrence.internalLocation.description) }}
-                {{ labelAndValue('Comment', appointmentOccurrence.comment | escape, 'movement-slip__row--no-border', 'preserve-line-breaks') if appointmentOccurrence.comment }}
+                {{ labelAndValue('Extra information', appointmentOccurrence.comment | escape, 'movement-slip__row--no-border', 'preserve-line-breaks') if appointmentOccurrence.comment }}
             </dl>
 
             <p class="govuk-body-s movement-slip-footer">Printed at {{ printedAt | formatDate("HH:mm 'on' EEEE, d MMMM yyyy") }}</p>


### PR DESCRIPTION
## Overview

This change primarily adds support for bulk appointment comments via two new pages in the bulk appointment journey (screenshots below).

There are also a few minor fixes and content changes included with this PR:

- Fix to escape comments containing HTML on the movement slip, check answers and occurrence details pages
- Fixed back button href on the category page
- Renames all old "heads up" references to "extra information" (screenshots out of date)

### Screenshots

<img width="1169" alt="Screenshot at Jun 15 18-45-09" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/1fcbe9b5-0083-42bf-b666-814499d1f023">

<img width="1229" alt="Screenshot at Jun 15 18-45-19" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/6bcd36a3-6e8b-4558-89d2-44f45c140400">

<img width="1190" alt="Screenshot at Jun 15 18-45-40" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/6bfdc418-48d3-4d99-8da9-8c4d4525aae3">
