### PR TITLE
SAA-752: Unlock list appointment event updates

### DIFF
--- a/server/services/unlockListService.ts
+++ b/server/services/unlockListService.ts
@@ -4,7 +4,7 @@ import PrisonerSearchApiClient from '../data/prisonerSearchApiClient'
 import ActivitiesApiClient from '../data/activitiesApiClient'
 import { ServiceUser } from '../@types/express'
 import { ScheduledEvent } from '../@types/activitiesAPI/types'
-import { convertToTitleCase, toDateString } from '../utils/utils'
+import { toDateString } from '../utils/utils'
 
 export default class UnlockListService {
   constructor(
@@ -90,7 +90,6 @@ export default class UnlockListService {
 
       return {
         ...prisoner,
-        displayName: convertToTitleCase(`${prisoner.lastName}, ${prisoner.firstName}`),
         events: this.unlockListSort(allEventsForPrisoner),
       } as UnlockListItem
     })

--- a/server/utils/editAppointmentUtils.test.ts
+++ b/server/utils/editAppointmentUtils.test.ts
@@ -298,6 +298,14 @@ describe('Edit Appointment Utils', () => {
       )
     })
 
+    it('when removing the comment', () => {
+      req.session.editAppointmentJourney.comment = ''
+
+      expect(getAppointmentEditMessage(req.session.appointmentJourney, req.session.editAppointmentJourney)).toEqual(
+        'change the extra information for',
+      )
+    })
+
     it('when adding one person', () => {
       req.session.editAppointmentJourney.addPrisoners = [
         {

--- a/server/utils/editAppointmentUtils.ts
+++ b/server/utils/editAppointmentUtils.ts
@@ -211,4 +211,4 @@ export const hasAppointmentEndTimeChanged = (
 export const hasAppointmentCommentChanged = (
   appointmentJourney: AppointmentJourney,
   editAppointmentJourney: EditAppointmentJourney,
-) => editAppointmentJourney.comment && appointmentJourney.comment !== editAppointmentJourney.comment
+) => editAppointmentJourney.comment !== undefined && appointmentJourney.comment !== editAppointmentJourney.comment

--- a/server/views/pages/unlock-list/planned-events.njk
+++ b/server/views/pages/unlock-list/planned-events.njk
@@ -244,7 +244,7 @@
                         {
                             html: "Activity",
                             attributes: { "aria-sort": "none" },
-                            classes: 'govuk-table__header'
+                            classes: 'govuk-table__header govuk-!-width-one-third'
                         },
                         {
                             html: "<span>Refused</span>",

--- a/server/views/pages/unlock-list/planned-events.njk
+++ b/server/views/pages/unlock-list/planned-events.njk
@@ -179,7 +179,7 @@
                         {
                             attributes: { id: 'activity-' + loop.index, "data-sort-value": item.displayName },
                             html: showProfileLink({
-                                name: item.displayName,
+                                name: item.firstName + " " + item.lastName,
                                 prisonerNumber: item.prisonerNumber,
                                 link: true,
                                 classes: 'hmpps-inline-block'

--- a/server/views/partials/showUnlockEvents.njk
+++ b/server/views/partials/showUnlockEvents.njk
@@ -16,7 +16,12 @@
                     class="govuk-link govuk-link--no-visited-state">
                         {{ e.summary | trim }}
                     </a>
-                    <div>{{ govukTag({ text: 'Appointment', classes: 'govuk-tag--small' }) }}</div>
+                    <div>
+                        {{ govukTag({ text: 'Appointment', classes: 'govuk-tag--small' }) }}
+                        {% if e.comments %}
+                            {{ govukTag({ text: 'Extra information', classes: 'govuk-tag--small govuk-tag--yellow' }) }}
+                        {% endif %}
+                    </div>
                 {% else %}
                     {{ e.summary | trim }}
                 {% endif %}
@@ -29,10 +34,6 @@
             {% if e.eventType != 'EXTERNAL_TRANSFER' and e.eventType != 'COURT_HEARING' %}
                 <div>{{ e.startTime }}{% if e.endTime %} - {{ e.endTime }}{% endif %}</div>
                 <div>{{ "In cell" if e.inCell else e.internalLocationDescription | trim | title }}</div>
-            {% endif %}
-
-            {% if e.eventType === 'APPOINTMENT' and e.comments %}
-                <div>{{ e.comments | trim | truncate(40) }}</div>
             {% endif %}
         {% endfor %}
     </div>


### PR DESCRIPTION
## Overview

Adds "extra information" tag to appointments with comments.

I've also included fixes to correct the prisoner name formatting on the unlock list and fixed the bug preventing appointment comments being removed in the edit journey.

### Screenshots

<img width="1280" alt="Screenshot at Jun 19 11-55-21" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/e9824bd2-aef2-4c48-a3f9-73b0f969561f">
