### PR TITLE
Fix overflow in the attendance stats whilst still maintaining the 'blue toolbar' overflow on the candidates tab

### DIFF
--- a/frontend/components/tabs/_tabs.scss
+++ b/frontend/components/tabs/_tabs.scss
@@ -1,6 +1,9 @@
 .govuk-tabs--borderless {
   margin: 0;
-  overflow-x: hidden;
+
+  .govuk-grid-row {
+    margin-right: 0;
+  }
 
   .govuk-tabs__panel {
     border: none;


### PR DESCRIPTION
![screencapture-localhost-3000-allocation-dashboard-30-2023-06-19-20_52_43](https://github.com/ministryofjustice/hmpps-activities-management/assets/30229564/aa3dc17d-dfef-46af-942d-cccc3ceb1fbe)
![screencapture-localhost-3000-attendance-summary-summary-2023-06-19-20_53_09](https://github.com/ministryofjustice/hmpps-activities-management/assets/30229564/4f4ae2b9-b17d-4764-be4d-b91b14e53494)
