### PR TITLE
SAA-752: Bug fix & unlock list print improvements

### DIFF
--- a/frontend/utilities/_all.scss
+++ b/frontend/utilities/_all.scss
@@ -1,7 +1,7 @@
 @import './button';
 @import './misc';
 @import './movement-slip';
-@import './print';
 @import './typography';
+@import './print';
 @import './width';
 @import './table';

--- a/frontend/utilities/_print.scss
+++ b/frontend/utilities/_print.scss
@@ -26,12 +26,20 @@
     font-size: 12pt;
   }
 
+  .govuk-body {
+    font-size: 11pt;
+  }
+
+  .govuk-body-s {
+    font-size: 10pt;
+  }
+
   .printed-page {
     background: none;
   }
 
   .govuk-table {
-    font-size: 12pt;
+    font-size: 11pt;
 
     &__header {
       vertical-align: bottom;
@@ -85,7 +93,7 @@
 
   .print-checkbox {
     display: inline-block;
-    $_checkbox-size: 30px;
+    $_checkbox-size: 28px;
     width: $_checkbox-size;
     height: $_checkbox-size;
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
@@ -93,6 +101,51 @@
     color: govuk-colour("mid-grey");
     line-height: $_checkbox-size;
     text-align: center;
+  }
+}
+
+@include govuk-media-query($until: tablet, $media-type: print) {
+  .govuk-heading-l {
+    font-size: 17pt;
+  }
+
+  .govuk-heading-m {
+    font-size: 14pt;
+  }
+
+  .govuk-heading-s {
+    font-size: 12pt;
+  }
+
+  .govuk-body-l {
+    font-size: 10pt;
+  }
+
+  .govuk-body {
+    font-size: 9pt;
+  }
+
+  .govuk-body-s {
+    font-size: 8pt;
+  }
+
+  .govuk-table {
+    font-size: 9pt;
+  }
+
+  .print-checkbox {
+    $_checkbox-size: 22px;
+    width: $_checkbox-size;
+    height: $_checkbox-size;
+    line-height: $_checkbox-size;
+  }
+
+  .hmpps-table {
+    &__header {
+      &--angled-table-header {
+        width: 34px;
+      }
+    }
   }
 }
 

--- a/frontend/utilities/_typography.scss
+++ b/frontend/utilities/_typography.scss
@@ -17,7 +17,7 @@
         &--angled-table-header {
             &, &[aria-sort] {
                 position: relative;
-                width: 50px;
+                width: 46px;
                 height: 60px;
 
                 > *, button {

--- a/server/views/pages/unlock-list/planned-events.njk
+++ b/server/views/pages/unlock-list/planned-events.njk
@@ -244,7 +244,7 @@
                         {
                             html: "Activity",
                             attributes: { "aria-sort": "none" },
-                            classes: 'govuk-table__header govuk-!-width-one-third'
+                            classes: 'govuk-table__header'
                         },
                         {
                             html: "<span>Refused</span>",

--- a/server/views/partials/showProfileLink.njk
+++ b/server/views/partials/showProfileLink.njk
@@ -12,10 +12,10 @@
         {% endif %}
       </div>
       {% if options.prisonerNumber %}
-        <div class="govuk-!-font-size-14" data-qa="prisoner-number">{{ options.prisonerNumber }}</div>
+        <div class="govuk-body-s govuk-!-margin-0" data-qa="prisoner-number">{{ options.prisonerNumber }}</div>
       {% endif %}
       {% if options.cellLocation %}
-        <div class="govuk-!-font-size-14" data-qa="prisoner-cell-location">{{ options.cellLocation }}</div>
+        <div class="govuk-body-s govuk-!-margin-0" data-qa="prisoner-cell-location">{{ options.cellLocation }}</div>
       {% endif %}
     </div>
 {% endmacro %}

--- a/server/views/partials/showUnlockEvents.njk
+++ b/server/views/partials/showUnlockEvents.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
 {% macro showUnlockEvents(events) %}
-    <div class="govuk-body govuk-!-margin-0 govuk-!-font-size-16">
+    <div class="govuk-body-s govuk-!-margin-0">
         {% for e in events %}
             {% if not loop.first %}<hr class="mid-grey-tint-20-hr" />{% endif %}
 
@@ -32,7 +32,7 @@
             </div>
 
             {% if e.suspended %}
-                <strong class="govuk-tag govuk-tag--red-border govuk-!-font-size-14">Prisoner suspended</strong>
+                <strong class="govuk-tag govuk-tag--red-border govuk-tag--small">Prisoner suspended</strong>
             {% endif %}
 
             {% if e.eventType != 'EXTERNAL_TRANSFER' and e.eventType != 'COURT_HEARING' %}


### PR DESCRIPTION
## Overview

- Removes width token to prevent 100% table column width on mobile viewports.
- Adds styling improvements for small print viewports

### Screenshots

**Before**
<img width="705" alt="Screenshot at Jun 22 12-59-42" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/c56b0790-51c7-411d-b70d-46aaba9e9274">

**After**
<img width="692" alt="Screenshot at Jun 22 13-00-07" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/693affd6-19f3-4aa9-a6af-420bb6a5a3c9">

