### PR TITLE
SAA-770 small tweak to label on edit activity location screen and now displays warning if editing location.

### DIFF
--- a/server/views/pages/activities/create-an-activity/location.njk
+++ b/server/views/pages/activities/create-an-activity/location.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set pageTitle = applicationName + " - Create a schedule - Location" %}
 {% set pageId = 'create-schedule-location-page' %}
@@ -33,7 +34,7 @@
                     name: "inCell",
                     fieldset: {
                         legend: {
-                            text: "Where does this activity take place?",
+                            text: 'Enter the new activity location' if session.req.query.fromEditActivity else 'Where does this activity take place?',
                             classes: "govuk-label--xl",
                             isPageHeading: true
                         }
@@ -68,9 +69,13 @@
                 }) }}
 
                 {% if session.req.query.fromEditActivity %}
+                    {{ govukWarningText({
+                        text: "Changing the location may affect the security risk and the capacity of this activity.",
+                        iconFallbackText: "Warning"
+                    }) }}
                     <div class="govuk-button-group">
                       {{ govukButton({
-                        text: "Update location"
+                        text: "Update activity location"
                       }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>


### PR DESCRIPTION
Small changes to the edit activity location screen:

**Before:**

![image](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/33805db9-805d-4738-ad8e-2d156f268b09)

**After:**

![image](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/581da709-8bed-4c6a-a977-5d83ac149080)
