### PR TITLE
SAA-574: Unlock list updates

### DIFF
--- a/frontend/utilities/_print.scss
+++ b/frontend/utilities/_print.scss
@@ -53,7 +53,10 @@
 
     // Remove styling from MOJ sortable table colum headers
     [aria-sort] button {
+      // Fallback to `inline` since `contents` isn't well supported
       display: inline;
+      // This fixes an issue where table headers will not span multiple print
+      // pages when the heading is a button (as required by MoJ table sort)
       display: contents;
       position: static;
       color: black;

--- a/frontend/utilities/_print.scss
+++ b/frontend/utilities/_print.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @page {
   margin: 10px;
 }
@@ -38,6 +40,10 @@
     background: none;
   }
 
+  .govuk-textarea {
+    font-size: 12pt;
+  }
+
   .govuk-table {
     font-size: 11pt;
 
@@ -48,6 +54,7 @@
     // Remove styling from MOJ sortable table colum headers
     [aria-sort] button {
       display: inline;
+      display: contents;
       position: static;
       color: black;
       padding: 0;
@@ -102,6 +109,15 @@
     line-height: $_checkbox-size;
     text-align: center;
   }
+
+  .govuk-\!-print-grid-column-one-third {
+    float: left;
+    width: math.percentage(math.div(1,3));
+  }
+  .govuk-\!-print-grid-column-two-thirds {
+    float: left;
+    width: math.percentage(math.div(2,3));
+  }
 }
 
 @include govuk-media-query($until: tablet, $media-type: print) {
@@ -138,14 +154,6 @@
     width: $_checkbox-size;
     height: $_checkbox-size;
     line-height: $_checkbox-size;
-  }
-
-  .hmpps-table {
-    &__header {
-      &--angled-table-header {
-        width: 34px;
-      }
-    }
   }
 }
 

--- a/frontend/utilities/_typography.scss
+++ b/frontend/utilities/_typography.scss
@@ -17,8 +17,13 @@
         &--angled-table-header {
             &, &[aria-sort] {
                 position: relative;
-                width: 46px;
-                height: 60px;
+                width: 55px;
+                height: 64px;
+
+                @include govuk-media-query($until: tablet, $media-type: print) {
+                    width: 44px;
+                    height: 52px;
+                }
 
                 > *, button {
                     position: absolute;
@@ -26,10 +31,7 @@
                     bottom: govuk-spacing(2);
                     transform: rotate(-45deg);
                     transform-origin: 3px center;
-
-                    &:first-letter { 
-                        text-decoration: underline;
-                    }
+                    white-space: nowrap;
                 }
             }
         }
@@ -38,4 +40,8 @@
 
 .preserve-line-breaks {
     white-space: pre-line;
+}
+
+.text-underline {
+    text-decoration: underline;
 }

--- a/server/@types/activities.ts
+++ b/server/@types/activities.ts
@@ -43,6 +43,7 @@ export type UnlockListItem = {
   alerts?: Alert[]
   events?: ScheduledEvent[]
   status: string
+  isLeavingWing: boolean
 }
 
 export type FilterItem = {

--- a/server/routes/activities/unlock-list/handlers/plannedEvents.test.ts
+++ b/server/routes/activities/unlock-list/handlers/plannedEvents.test.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import { FilterItem, UnlockFilters } from '../../../../@types/activities'
+import { FilterItem, UnlockFilters, UnlockListItem } from '../../../../@types/activities'
 import { toDate, formatDate } from '../../../../utils/utils'
 import PlannedEventRoutes from './plannedEvents'
 import ActivitiesService from '../../../../services/activitiesService'
@@ -65,10 +65,25 @@ describe('Unlock list routes - planned events', () => {
         session: {}, // No filters supplied in session
       } as unknown as Request
 
+      const unlockListItems = [
+        {
+          prisonerNumber: 'A1111AA',
+          isLeavingWing: true,
+        },
+        {
+          prisonerNumber: 'B2222BB',
+          isLeavingWing: true,
+        },
+        {
+          prisonerNumber: 'C3333CC',
+          isLeavingWing: false,
+        },
+      ] as UnlockListItem[]
+
       // Mocked responses
       activitiesService.getLocationPrefix.mockResolvedValue({ locationPrefix: 'MDI-1-' })
       activitiesService.getLocationGroups.mockResolvedValue(locationsAtPrison)
-      unlockListService.getFilteredUnlockList.mockResolvedValue([])
+      unlockListService.getFilteredUnlockList.mockResolvedValue(unlockListItems)
 
       await handler.GET(req, res)
 
@@ -77,7 +92,11 @@ describe('Unlock list routes - planned events', () => {
       expect(unlockListService.getFilteredUnlockList).toHaveBeenCalledWith(unlockFilters, res.locals.user)
       expect(res.render).toHaveBeenCalledWith('pages/activities/unlock-list/planned-events', {
         unlockFilters,
-        unlockListItems: [],
+        unlockListItems,
+        movementCounts: {
+          leavingWing: 2,
+          stayingOnWing: 1,
+        },
       })
     })
 
@@ -113,6 +132,10 @@ describe('Unlock list routes - planned events', () => {
       expect(res.render).toHaveBeenCalledWith('pages/activities/unlock-list/planned-events', {
         unlockFilters,
         unlockListItems: [],
+        movementCounts: {
+          leavingWing: 0,
+          stayingOnWing: 0,
+        },
       })
     })
   })

--- a/server/views/pages/activities/unlock-list/planned-events.njk
+++ b/server/views/pages/activities/unlock-list/planned-events.njk
@@ -16,24 +16,28 @@
 
 {% block content %}
     <div class="govuk-grid-row govuk-!-margin-bottom-2">
-        <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds govuk-!-print-grid-column-two-thirds govuk-!-margin-bottom-2">
             <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ unlockFilters.location }} - Unlock list</h1>
-            <div class="govuk-body govuk-!-margin-top-1">{{ unlockFilters.timeSlot | upper }} session</div>
-            <div class="govuk-body govuk-!-margin-top-1">{{ unlockFilters.unlockDate|formatDate('cccc d LLLL y') }}</div>
-
-            {% set todayOrBefore = unlockFilters.unlockDate | formatDate('yyyy-MM-dd') | todayOrBefore %}
-
-            <div class="govuk-grid-row govuk-!-margin-top-4">
-                <div class="govuk-grid-column-full govuk-body govuk-!-font-weight-bold">
-                    {{ unlockListItems.length }} prisoners
+            <div class="govuk-body govuk-!-margin-top-1">
+                {{ unlockFilters.unlockDate|formatDate('cccc d LLLL y') }} - {{ unlockFilters.timeSlot | upper }}
+            </div>
+            <div class="govuk-!-margin-top-4">
+                <div class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">
+                    {{ unlockListItems.length }} prisoners to unlock
                 </div>
+                <div class="govuk-body govuk-!-margin-bottom-0">{{ movementCounts.leavingWing }} leaving wing</div>
+                <div class="govuk-body govuk-!-margin-bottom-0">{{ movementCounts.stayingOnWing }} staying on wing</div>
             </div>
         </div>
-        <div class="govuk-grid-column-one-third">
+        <div class="govuk-grid-column-one-third govuk-!-print-grid-column-one-third">
             <div class="print-only">
                 {{ govukTextarea({
                     attributes: { placeholder: 'Notes' },
-                    id: "notes-textarea"
+                    id: "notes-textarea",
+                    formGroup: {
+                        classes: "govuk-!-margin-bottom-3"
+                    },
+                    classes: "govuk-!-margin-bottom-2"
                 }) }}
             </div>
         </div>
@@ -197,7 +201,7 @@
                             classes: 'govuk-table_cell govuk-!-padding-top-2 govuk-!-padding-bottom-2 print-only'
                         },
                         {
-                            html: '<span class="print-checkbox">S</span>',
+                            html: '<span class="print-checkbox">C</span>',
                             classes: 'govuk-table__cell govuk-!-padding-top-2 govuk-!-padding-bottom-2 print-only'
                         },
                         {
@@ -210,53 +214,60 @@
                         }
                     ]), rows) %}
                 {% endfor %}
-                {{ govukTable({
-                    attributes: {
-                        'data-module': 'moj-sortable-table',
-                        id: 'unlock-list-table'
-                    },
-                    caption: "Prisoners",
-                    classes: "alternating-row-shading fixed-layout-table",
-                    captionClasses: "govuk-visually-hidden",
-                    head: [
-                        {
-                            text: "Name",
-                            attributes: { "aria-sort": "none" },
-                            classes: 'govuk-table__header'
+                <table>
+                    <tbody><tr><td>
+                    {{ govukTable({
+                        attributes: {
+                            'data-module': 'moj-sortable-table',
+                            id: 'unlock-list-table'
                         },
-                        {
-                            text: "Cell location",
-                            attributes: { "aria-sort": "ascending" },
-                            classes: 'govuk-table__header'
-                        },
-                        {
-                            text: "Relevant alerts",
-                            classes: 'govuk-table__header'
-                        },
-                        {
-                            html: "Activity",
-                            attributes: { "aria-sort": "none" },
-                            classes: 'govuk-table__header'
-                        },
-                        {
-                            html: "<span>Refused</span>",
-                            classes: 'govuk-table__header hmpps-table__header--angled-table-header govuk-!-padding-right-1 print-only'
-                        },
-                        {
-                            html: "<span>Sick</span>",
-                            classes: 'govuk-table__header hmpps-table__header--angled-table-header govuk-!-padding-right-1 print-only'
-                        },
-                        {
-                            html: "<span>Gone</span>",
-                            classes: 'govuk-table__header hmpps-table__header--angled-table-header govuk-!-padding-right-1 print-only'
-                        },
-                        {
-                            text: "Notes",
-                            classes: 'govuk-table__header print-only hmpps-width-20-percent'
-                        }
-                    ],
-                    rows: rows
-                }) }}
+                        caption: "Prisoners",
+                        classes: "alternating-row-shading fixed-layout-table",
+                        captionClasses: "govuk-visually-hidden",
+                        head: [
+                            {
+                                text: "Name",
+                                attributes: { "aria-sort": "none" },
+                                classes: 'govuk-table__header'
+                            },
+                            {
+                                text: "Cell location",
+                                attributes: { "aria-sort": "ascending" },
+                                classes: 'govuk-table__header'
+                            },
+                            {
+                                text: "Relevant alerts",
+                                classes: 'govuk-table__header'
+                            },
+                            {
+                                html: "Activity",
+                                attributes: { "aria-sort": "none" },
+                                classes: 'govuk-table__header'
+                            },
+                            {
+                                html: "<span><span class=\"text-underline\">R</span>efused</span>",
+                                classes: 'govuk-table__header hmpps-table__header--angled-table-header govuk-!-padding-right-1 print-only'
+                            },
+                            {
+                                html: "<span>Rest in <span class=\"text-underline\">C</span>ell</span>",
+                                classes: 'govuk-table__header hmpps-table__header--angled-table-header govuk-!-padding-right-1 print-only'
+                            },
+                            {
+                                html: "<span><span class=\"text-underline\">G</span>one</span>",
+                                classes: 'govuk-table__header hmpps-table__header--angled-table-header govuk-!-padding-right-1 print-only'
+                            },
+                            {
+                                text: "Notes",
+                                classes: 'govuk-table__header print-only hmpps-width-20-percent'
+                            }
+                        ],
+                        rows: rows
+                    }) }}
+                    </td></tr></tbody>
+                    <tfoot class="print-only"><tr><td class="govuk-!-padding-top-4 govuk-!-padding-bottom-2 govuk-body">
+                        Printed at {{ now | formatDate('h:mmbbb \'on\' EEEE, dd MMMM yyyy') }}
+                    </td></tr></tfoot>
+                </table>
             </div>
         </form>
     </div>


### PR DESCRIPTION
## Overview

Some minor content changes to the printed unlock list.

I'm very uncomfortable with wrapping the content in a table for a printable footer but this seems to be the only way to do it?

I also don't like forcing the notes to be right positioned since it will be squashed at smaller printable viewports (A5 portrait), but since that combination seems unlikely from UR I've removed the responsive styling from the printable grid layout.

### Screenshots

<img width="494" alt="Screenshot at Jul 10 16-46-11" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/440f24da-9269-488f-9dfa-2164e3133c95">

<img width="581" alt="Screenshot at Jul 10 16-45-52" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/a033ba2c-1f42-40df-9afd-489cf909b994">

