### PR TITLE
Appointments search should default to sorting by (start) time

### DIFF
--- a/server/views/pages/appointments/search/results.njk
+++ b/server/views/pages/appointments/search/results.njk
@@ -310,7 +310,7 @@
                 head: [
                 {
                     text: "Time",
-                    attributes: { "aria-sort": "none" }
+                    attributes: { "aria-sort": "ascending" }
                 },
                 {
                     text: "Appointment name",


### PR DESCRIPTION
Before
<img width="820" alt="image" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/9396346/7f7d45d3-6250-41ea-bcba-b520cb7241cb">
After
<img width="799" alt="image" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/9396346/fd2527a2-0a01-4436-82cd-96cbe6fc5248">
