### PR TITLE
SAA-1039 validating allocation start date on edit allocation  against the activity end date (if the activity has one).

### DIFF
--- a/server/routes/activities/allocation-dashboard/handlers/startDate.test.ts
+++ b/server/routes/activities/allocation-dashboard/handlers/startDate.test.ts
@@ -157,6 +157,11 @@ describe('Route Handlers - Edit allocation - Start date', () => {
 
       const body = {
         startDate,
+        allocateJourney: {
+          activity: {
+            startDate: yesterday,
+          },
+        },
       }
 
       const requestObject = plainToInstance(StartDate, body)
@@ -171,16 +176,44 @@ describe('Route Handlers - Edit allocation - Start date', () => {
 
       const body = {
         startDate,
-        endDate: formatDate(subDays(today, 1), 'yyyy-MM-dd'),
+        endDate: formatDate(addDays(today, 1), 'yyyy-MM-dd'),
         allocationId: 1,
         scheduleId: 1,
         prisonerNumber: 'ABC123',
       }
 
-      const requestObject = plainToInstance(StartDate, body)
+      const requestObject = plainToInstance(StartDate, {
+        ...body,
+        allocateJourney: {
+          activity: {
+            startDate: addDays(today, 1),
+          },
+        },
+      })
       const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
 
-      expect(errors).toEqual([{ property: 'startDate', error: 'Enter a date before the end date' }])
+      expect(errors).toEqual([{ property: 'startDate', error: 'Enter a date on or after the activity start date' }])
+    })
+
+    it('validation fails if start date is after activity end date', async () => {
+      const tomorrow = addDays(new Date(), 1)
+
+      const body = {
+        startDate: simpleDateFromDate(addDays(tomorrow, 1)),
+      }
+
+      const requestObject = plainToInstance(StartDate, {
+        ...body,
+        allocateJourney: {
+          activity: {
+            startDate: new Date('2022-04-04'),
+            endDate: new Date('2022-04-04'),
+          },
+        },
+      })
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+      expect(errors).toEqual([{ property: 'startDate', error: 'Enter a date on or before the activity end date' }])
     })
   })
 })

--- a/server/routes/activities/allocation-dashboard/handlers/startDate.ts
+++ b/server/routes/activities/allocation-dashboard/handlers/startDate.ts
@@ -9,11 +9,18 @@ import { convertToTitleCase, formatDate } from '../../../../utils/utils'
 import { AllocationUpdateRequest } from '../../../../@types/activitiesAPI/types'
 import ActivitiesService from '../../../../services/activitiesService'
 import PrisonService from '../../../../services/prisonService'
+import DateIsSameOrBefore from '../../../../validators/dateIsSameOrBefore'
 
 export class StartDate {
   @Expose()
   @Type(() => SimpleDate)
   @ValidateNested()
+  @DateIsSameOrAfter(o => o.allocateJourney.activity.startDate, {
+    message: 'Enter a date on or after the activity start date',
+  })
+  @DateIsSameOrBefore(o => o.allocateJourney.activity.endDate, {
+    message: 'Enter a date on or before the activity end date',
+  })
   @DateIsSameOrAfter(() => new Date(), { message: "Enter a date on or after today's date" })
   @DateIsBeforeOtherProperty('endDate', { message: 'Enter a date before the end date' })
   @IsNotEmpty({ message: 'Enter a valid start date' })

--- a/server/validators/dateIsSameOrBefore.test.ts
+++ b/server/validators/dateIsSameOrBefore.test.ts
@@ -11,9 +11,9 @@ describe('dateIsSameOrBefore', () => {
     date: SimpleDate
   }
 
-  class DummyFormWithNullDate {
+  class DummyFormWithObject {
     @Expose()
-    @DateIsSameOrBefore(() => null, { message: "Enter date on or before today's date" })
+    @DateIsSameOrBefore(o => o.date, { message: "Enter date on or before today's date" })
     date: SimpleDate
   }
 
@@ -62,7 +62,7 @@ describe('dateIsSameOrBefore', () => {
     expect(errors).toHaveLength(0)
   })
 
-  it('should pass validation for a null date', async () => {
+  it('should pass validation for null date', async () => {
     const body = {
       date: plainToInstance(SimpleDate, {
         day: 21,
@@ -71,7 +71,22 @@ describe('dateIsSameOrBefore', () => {
       }),
     }
 
-    const requestObject = plainToInstance(DummyFormWithNullDate, body)
+    const requestObject = plainToInstance(DummyFormWithObject, { ...body, dateToCompare: null })
+    const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('should pass validation for undefined date', async () => {
+    const body = {
+      date: plainToInstance(SimpleDate, {
+        day: 21,
+        month: 12,
+        year: 2022,
+      }),
+    }
+
+    const requestObject = plainToInstance(DummyFormWithObject, { ...body, dateToCompare: undefined })
     const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
 
     expect(errors).toHaveLength(0)

--- a/server/validators/dateIsSameOrBefore.ts
+++ b/server/validators/dateIsSameOrBefore.ts
@@ -6,7 +6,7 @@ import SimpleDate from '../commonValidationTypes/simpleDate'
 export default function DateIsSameOrBefore(dateToCompare: (o: any) => Date, validationOptions?: ValidationOptions) {
   const dateIsSameOrBefore = (date: SimpleDate, args: ValidationArguments) =>
     isValid(date.toRichDate())
-      ? dateToCompare(args.object) === null || date.toRichDate() <= startOfDay(new Date(dateToCompare(args.object)))
+      ? dateToCompare(args.object) == null || date.toRichDate() <= startOfDay(new Date(dateToCompare(args.object)))
       : true
 
   return (object: unknown, propertyName: string) => {


### PR DESCRIPTION
![image](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/bc9a4d8a-d8ac-4038-bd2e-44a8e8e620e6)

![image](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/72c9c7d1-dccb-489f-b47c-cd2efa99fcd2)
