### PR TITLE
SAA-1056: Remove CSV mime type test to support browsers that send incorrect mime type

### DIFF
--- a/server/routes/appointments/create-and-edit/handlers/bulk-appointments/uploadBulkAppointment.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/bulk-appointments/uploadBulkAppointment.test.ts
@@ -390,26 +390,6 @@ describe('Route Handlers - Create Bulk Appointment - Upload Bulk Appointment', (
       expect(errors).toEqual(expect.arrayContaining([{ property: 'file', error: 'The selected file is empty' }]))
     })
 
-    it('validation fails when invalid CSV file is uploaded', async () => {
-      const body = {
-        file: {
-          path: 'uploads/non-csv.xlsx',
-          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        },
-      }
-
-      const requestObject = plainToInstance(AppointmentsList, body)
-
-      when(fsMock.existsSync).calledWith('uploads/non-csv.xlsx').mockReturnValue(true)
-      when(fsMock.lstatSync)
-        .calledWith('uploads/non-csv.xlsx')
-        .mockReturnValue(plainToInstance(Stats, { size: 1 }))
-
-      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
-
-      expect(errors).toEqual(expect.arrayContaining([{ property: 'file', error: 'You must upload a CSV file' }]))
-    })
-
     it('passes validation when valid CSV file is uploaded', async () => {
       const body = {
         file: {

--- a/server/routes/appointments/create-and-edit/handlers/uploadPrisonerList.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/uploadPrisonerList.test.ts
@@ -461,26 +461,6 @@ describe('Route Handlers - Create Appointment - Upload Prisoner List', () => {
       expect(errors).toEqual(expect.arrayContaining([{ property: 'file', error: 'The selected file is empty' }]))
     })
 
-    it('validation fails when invalid CSV file is uploaded', async () => {
-      const body = {
-        file: {
-          path: 'uploads/non-csv.xlsx',
-          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        },
-      }
-
-      const requestObject = plainToInstance(PrisonerList, body)
-
-      when(fsMock.existsSync).calledWith('uploads/non-csv.xlsx').mockReturnValue(true)
-      when(fsMock.lstatSync)
-        .calledWith('uploads/non-csv.xlsx')
-        .mockReturnValue(plainToInstance(Stats, { size: 1 }))
-
-      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
-
-      expect(errors).toEqual(expect.arrayContaining([{ property: 'file', error: 'You must upload a CSV file' }]))
-    })
-
     it('passes validation when valid CSV file is uploaded', async () => {
       const body = {
         file: {

--- a/server/validators/isValidCsvFile.test.ts
+++ b/server/validators/isValidCsvFile.test.ts
@@ -52,24 +52,6 @@ describe('isValidCsvFile', () => {
     expect(fsMock.unlinkSync).not.toHaveBeenCalled()
   })
 
-  it('should fail validation for a non csv mime type', async () => {
-    const body = {
-      file: {
-        path: 'uploads/non-csv.xlsx',
-        mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      },
-    }
-
-    const requestObject = plainToInstance(DummyForm, body)
-
-    when(fsMock.existsSync).calledWith('uploads/non-csv.xlsx').mockReturnValue(true)
-
-    const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
-
-    expect(errors).toEqual([{ property: 'file', error: 'The selected file must be a CSV' }])
-    expect(fsMock.unlinkSync).toHaveBeenCalledWith('uploads/non-csv.xlsx')
-  })
-
   it('should fail validation for a binary file', async () => {
     const body = {
       file: {

--- a/server/validators/isValidCsvFile.ts
+++ b/server/validators/isValidCsvFile.ts
@@ -15,8 +15,7 @@ export default function IsValidCsvFile(validationOptions?: ValidationOptions) {
 
           let result = true
 
-          if (value.mimetype !== 'text/csv') result = false
-          else if (isBinaryFileSync(value.path)) result = false
+          if (isBinaryFileSync(value.path)) result = false
 
           if (!result) fs.unlinkSync(value.path)
 


### PR DESCRIPTION
The pen testing process uncovered an as yet unidentified way of getting a valid CSV file to report with an Excel mime type. The existing validation expects the file to be uploaded with mime type text/csv.

Mime types are easily spoofed and the CSV validation checker also applies the more rigorous isBinaryFile check. This more effective check makes the mime type check redundant.

Resolution of this bug is to remove the mime type check. 