### PR TITLE
SAA-997: Limit appointment occurrence allocations

### DIFF
--- a/server/routes/appointments/create-and-edit/handlers/repeatPeriodAndCount.ts
+++ b/server/routes/appointments/create-and-edit/handlers/repeatPeriodAndCount.ts
@@ -38,12 +38,24 @@ export default class RepeatPeriodAndCountRoutes {
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
+    const maxOccurrenceAllocations = 20000
+
     const { repeatPeriod, repeatCount } = req.body
+    const prisonersCount = req.session.appointmentJourney.prisoners.length
+
+    if (prisonersCount * repeatCount > maxOccurrenceAllocations) {
+      return res.validationFailed(
+        'repeatCount',
+        `You cannot schedule more than ${Math.floor(
+          maxOccurrenceAllocations / prisonersCount,
+        )} appointments for this number of attendees.`,
+      )
+    }
 
     req.session.appointmentJourney.repeat = YesNo.YES
     req.session.appointmentJourney.repeatPeriod = repeatPeriod
     req.session.appointmentJourney.repeatCount = repeatCount
 
-    res.redirectOrReturn(`schedule`)
+    return res.redirectOrReturn(`schedule`)
   }
 }


### PR DESCRIPTION
## Overview

Adds validation to the "How often will the appointment repeat?" page, limiting the number of repeats that can be entered to prevent creation of extremely large appointments.

### Screenshots

<img width="1221" alt="Screenshot at Aug 02 14-10-01" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/5c78f9d6-6593-4c3e-b618-0d4ba0635de8">
