### PR TITLE
SAA-1037: Updated edit pay journey

### DIFF
--- a/server/routes/activities/create-an-activity/handlers/payRateType.test.ts
+++ b/server/routes/activities/create-an-activity/handlers/payRateType.test.ts
@@ -24,6 +24,7 @@ describe('Route Handlers - Create an activity schedule - Pay Rate Type', () => {
       session: {
         createJourney: {},
       },
+      query: {},
     } as unknown as Request
   })
 
@@ -43,6 +44,32 @@ describe('Route Handlers - Create an activity schedule - Pay Rate Type', () => {
       await handler.POST(req, res)
 
       expect(res.redirect).toHaveBeenCalledWith('pay/single')
+    })
+
+    it('should redirect with fromEditActivity flag', async () => {
+      req.body = {
+        payRateTypeOption: 'single',
+      }
+      req.query = {
+        fromEditActivity: 'true',
+      }
+
+      await handler.POST(req, res)
+
+      expect(res.redirect).toHaveBeenCalledWith('pay/single?fromEditActivity=true')
+    })
+
+    it('should redirect with preserveHistory flag', async () => {
+      req.body = {
+        payRateTypeOption: 'single',
+      }
+      req.query = {
+        preserveHistory: 'true',
+      }
+
+      await handler.POST(req, res)
+
+      expect(res.redirect).toHaveBeenCalledWith('pay/single?preserveHistory=true')
     })
   })
 

--- a/server/routes/activities/create-an-activity/handlers/payRateType.ts
+++ b/server/routes/activities/create-an-activity/handlers/payRateType.ts
@@ -15,8 +15,9 @@ export default class PayRateTypeRoutes {
 
   POST = async (req: Request, res: Response): Promise<void> => {
     const { payRateTypeOption } = req.body
-    if (req.query && req.query.fromEditActivity) {
+    const { fromEditActivity, preserveHistory } = req.query
+    if (fromEditActivity) {
       res.redirect(`pay/${payRateTypeOption}?fromEditActivity=true`)
-    } else res.redirect(`pay/${payRateTypeOption}`)
+    } else res.redirect(`pay/${payRateTypeOption}${preserveHistory ? '?preserveHistory=true' : ''}`)
   }
 }

--- a/server/routes/activities/create-an-activity/handlers/removePay.ts
+++ b/server/routes/activities/create-an-activity/handlers/removePay.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from 'express'
 import { Expose } from 'class-transformer'
 import { IsIn } from 'class-validator'
+import ActivitiesService from '../../../../services/activitiesService'
+import PrisonService from '../../../../services/prisonService'
+import { ActivityUpdateRequest } from '../../../../@types/activitiesAPI/types'
 
 export class ConfirmRemoveOptions {
   @Expose()
@@ -9,6 +12,8 @@ export class ConfirmRemoveOptions {
 }
 
 export default class RemovePayRoutes {
+  constructor(private readonly activitiesService: ActivitiesService, private readonly prisonService: PrisonService) {}
+
   GET = async (req: Request, res: Response): Promise<void> => {
     const { iep } = req.query
     const bandId = +req.query.bandId
@@ -44,16 +49,46 @@ export default class RemovePayRoutes {
     req.session.createJourney.pay.splice(payIndex, 1)
 
     if (req.query && req.query.fromEditActivity) {
-      const returnTo = '/activities/schedule/check-pay'
-      req.session.returnTo = returnTo
-      return res.redirectWithSuccess(
-        returnTo,
-        `${payInfo.incentiveLevel} incentive level rate ${payInfo.bandAlias} removed`,
-      )
+      return this.updateActivity(req, res)
     }
     return res.redirectWithSuccess(
       'check-pay',
       `${payInfo.incentiveLevel} incentive level rate ${payInfo.bandAlias} removed`,
+    )
+  }
+
+  updateActivity = async (req: Request, res: Response) => {
+    const { user } = res.locals
+    const { activityId } = req.session.createJourney
+
+    const updatedPayRates = req.session.createJourney.pay.map(p => ({
+      incentiveNomisCode: p.incentiveNomisCode,
+      incentiveLevel: p.incentiveLevel,
+      payBandId: p.bandId,
+      rate: p.rate,
+    }))
+
+    const incentiveLevels = await this.prisonService.getIncentiveLevels(user.activeCaseLoadId, user)
+
+    const minimumIncentiveLevel =
+      incentiveLevels.find(l => req.session.createJourney.pay.find(p => p.incentiveLevel === l.levelName)) ??
+      incentiveLevels[0]
+
+    req.session.createJourney.minimumIncentiveNomisCode = minimumIncentiveLevel.levelCode
+    req.session.createJourney.minimumIncentiveLevel = minimumIncentiveLevel.levelName
+
+    const updatedActivity = {
+      pay: updatedPayRates,
+      minimumIncentiveNomisCode: req.session.createJourney.minimumIncentiveNomisCode,
+      minimumIncentiveLevel: req.session.createJourney.minimumIncentiveLevel,
+    } as ActivityUpdateRequest
+    await this.activitiesService.updateActivity(user.activeCaseLoadId, activityId, updatedActivity)
+    const successMessage = `We've updated the pay for ${req.session.createJourney.name}`
+
+    return res.redirectWithSuccess(
+      '/activities/schedule/check-pay?preserveHistory=true',
+      'Activity updated',
+      successMessage,
     )
   }
 }

--- a/server/routes/activities/create-an-activity/index.ts
+++ b/server/routes/activities/create-an-activity/index.ts
@@ -41,7 +41,7 @@ export default function Index({ activitiesService, prisonService }: Services): R
   const riskLevelHandler = new RiskLevelRoutes(activitiesService)
   const payRateTypeHandler = new PayRateTypeRoutes()
   const payHandler = new PayRoutes(prisonService, activitiesService)
-  const removePayHandler = new RemovePayRoutes()
+  const removePayHandler = new RemovePayRoutes(activitiesService, prisonService)
   const removeFlatRateHandler = new RemoveFlatRateRoutes()
   const checkPayHandler = new CheckPayRoutes(activitiesService, prisonService)
   const qualificationHandler = new QualificationRoutes()

--- a/server/routes/activities/manage-schedules/handlers/checkPay.test.ts
+++ b/server/routes/activities/manage-schedules/handlers/checkPay.test.ts
@@ -1,0 +1,139 @@
+import { Request, Response } from 'express'
+import { when } from 'jest-when'
+import CheckPayRoutes from './checkPay'
+import ActivitiesService from '../../../../services/activitiesService'
+import atLeast from '../../../../../jest.setup'
+import { Activity } from '../../../../@types/activitiesAPI/types'
+import PrisonService from '../../../../services/prisonService'
+import { IncentiveLevel } from '../../../../@types/incentivesApi/types'
+import { Prisoner } from '../../../../@types/prisonerOffenderSearchImport/types'
+import IncentiveLevelPayMappingUtil from './helpers/incentiveLevelPayMappingUtil'
+import { CreateAnActivityJourney } from '../../create-an-activity/journey'
+
+jest.mock('../../../../services/activitiesService')
+jest.mock('../../../../services/prisonService')
+
+const activitiesService = new ActivitiesService(null) as jest.Mocked<ActivitiesService>
+const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+const incentiveLevelPayMappingUtil = new IncentiveLevelPayMappingUtil(prisonService)
+
+describe('Route Handlers - Edit an activity - Check pay', () => {
+  const handler = new CheckPayRoutes(activitiesService, prisonService)
+  let req: Request
+  let res: Response
+
+  const activity = {
+    id: 1,
+    schedules: [
+      {
+        id: 2,
+        allocations: [
+          {
+            id: 1,
+            prisonerNumber: 'AB1234C',
+            prisonPayBand: {
+              id: 1,
+            },
+          },
+          {
+            id: 2,
+            prisonerNumber: 'CB4321A',
+            prisonPayBand: {
+              id: 1,
+            },
+          },
+        ],
+      },
+    ],
+  } as Activity
+
+  const incentiveLevels = [
+    { levelCode: 'BAS', levelName: 'Basic' },
+    { levelCode: 'STD', levelName: 'Standard' },
+    { levelCode: 'ENH', levelName: 'Enhanced' },
+  ] as IncentiveLevel[]
+
+  const prisoners = [
+    {
+      prisonerNumber: 'AB1234C',
+      currentIncentive: {
+        level: {
+          description: 'Basic',
+        },
+      },
+    },
+    {
+      prisonerNumber: 'CB4321A',
+      currentIncentive: {
+        level: {
+          description: 'Enhanced',
+        },
+      },
+    },
+  ] as Prisoner[]
+
+  const activityPay = [
+    {
+      bandId: 1,
+      incentiveLevel: 'Basic',
+      rate: 100,
+    },
+    {
+      bandId: 1,
+      incentiveLevel: 'Enhanced',
+      rate: 150,
+    },
+  ] as CreateAnActivityJourney['pay']
+
+  const activityFlatPay = [
+    {
+      bandId: 2,
+      rate: 120,
+    },
+  ]
+
+  beforeEach(() => {
+    res = {
+      locals: {
+        user: {
+          username: 'joebloggs',
+          activeCaseLoadId: 'MDI',
+        },
+      },
+      render: jest.fn(),
+    } as unknown as Response
+
+    req = {
+      session: {
+        createJourney: {
+          activityId: 1,
+          pay: activityPay,
+          flat: activityFlatPay,
+        },
+      },
+    } as unknown as Request
+  })
+
+  describe('GET', () => {
+    it('should render the expected view', async () => {
+      when(activitiesService.getActivity).calledWith(atLeast(1)).mockResolvedValue(activity)
+      when(prisonService.getIncentiveLevels).calledWith(atLeast('MDI')).mockResolvedValue(incentiveLevels)
+      when(prisonService.searchInmatesByPrisonerNumbers)
+        .calledWith(atLeast(['AB1234C', 'CB4321A']))
+        .mockResolvedValue(prisoners)
+
+      const incentiveLevelPays = await incentiveLevelPayMappingUtil.getPayGroupedByIncentiveLevel(
+        activityPay,
+        expect.anything(),
+        activity,
+      )
+
+      await handler.GET(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/activities/manage-schedules/check-pay', {
+        incentiveLevelPays,
+        flatPay: activityFlatPay,
+      })
+    })
+  })
+})

--- a/server/routes/activities/manage-schedules/handlers/checkPay.ts
+++ b/server/routes/activities/manage-schedules/handlers/checkPay.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express'
 import PrisonService from '../../../../services/prisonService'
 import IncentiveLevelPayMappingUtil from './helpers/incentiveLevelPayMappingUtil'
-import { ActivityUpdateRequest } from '../../../../@types/activitiesAPI/types'
 import ActivitiesService from '../../../../services/activitiesService'
 
 export default class CheckPayRoutes {
@@ -16,61 +15,10 @@ export default class CheckPayRoutes {
 
     const { activityId, pay } = req.session.createJourney
     const activity = await this.activitiesService.getActivity(activityId, user)
+
     const incentiveLevelPays = await this.helper.getPayGroupedByIncentiveLevel(pay, user, activity)
     const flatPay = req.session.createJourney.flat
 
     res.render(`pages/activities/manage-schedules/check-pay`, { incentiveLevelPays, flatPay })
-  }
-
-  POST = async (req: Request, res: Response): Promise<void> => {
-    const { user } = res.locals
-    const { pay, flat } = req.session.createJourney
-
-    if (pay.length === 0 && flat.length === 0) {
-      return res.validationFailed('', `Add at least one pay rate`)
-    }
-
-    const minimumIncentiveLevel = await this.prisonService
-      .getIncentiveLevels(user.activeCaseLoadId, user)
-      .then(levels => {
-        if (pay.length === 0) return levels[0]
-        return levels.find(l => pay.find(p => p.incentiveLevel === l.levelName))
-      })
-
-    req.session.createJourney.minimumIncentiveNomisCode = minimumIncentiveLevel.levelCode
-    req.session.createJourney.minimumIncentiveLevel = minimumIncentiveLevel.levelName
-
-    const { activityId } = req.session.createJourney
-    const prisonCode = user.activeCaseLoadId
-    const activity = {
-      pay: req.session.createJourney.pay.map(p => ({
-        incentiveNomisCode: p.incentiveNomisCode,
-        incentiveLevel: p.incentiveLevel,
-        payBandId: p.bandId,
-        rate: p.rate,
-      })),
-    } as ActivityUpdateRequest
-
-    if (req.session.createJourney.flat && req.session.createJourney.flat.length > 0) {
-      const incentiveLevels = await this.prisonService.getIncentiveLevels(user.activeCaseLoadId, user)
-
-      req.session.createJourney.flat.forEach(flatRate => {
-        incentiveLevels.forEach(iep =>
-          activity.pay.push({
-            incentiveNomisCode: iep.levelCode,
-            incentiveLevel: iep.levelName,
-            payBandId: flatRate.bandId,
-            rate: flatRate.rate,
-          }),
-        )
-      })
-    }
-
-    await this.activitiesService.updateActivity(prisonCode, activityId, activity)
-    const successMessage = `We've updated the pay for ${req.session.createJourney.name}`
-
-    const returnTo = `/activities/schedule/activities/${req.session.createJourney.activityId}`
-    req.session.returnTo = returnTo
-    return res.redirectOrReturnWithSuccess(returnTo, 'Activity updated', successMessage)
   }
 }

--- a/server/routes/activities/manage-schedules/index.ts
+++ b/server/routes/activities/manage-schedules/index.ts
@@ -13,6 +13,5 @@ export default function Index(services: Services): Router {
   router.get('/activities/:activityId', asyncMiddleware(activityRouteHandler.GET))
   const checkPayRouteHandler = new CheckPayRoutes(services.activitiesService, services.prisonService)
   router.get('/check-pay', asyncMiddleware(checkPayRouteHandler.GET))
-  router.post('/check-pay', asyncMiddleware(checkPayRouteHandler.POST))
   return router
 }

--- a/server/views/pages/activities/create-an-activity/check-pay.njk
+++ b/server/views/pages/activities/create-an-activity/check-pay.njk
@@ -9,11 +9,8 @@
 {% set backLinkHref = "pay" %}
 
 {% block content %}
-    {% if session.req.query.fromEditActivity %}
-        {% set fromEditText = "&fromEditActivity=true" %}
-    {% else %}
-        {% set fromEditText = "" %}
-    {% endif %}
+    {% set preserveHistoryText = "?preserveHistory=true" if session.req.query.preserveHistory else "" %}
+    {% set fromEditText = "&fromEditActivity=true" if preserveHistoryText and session.req.query.fromEditActivity else "" %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ activityJourneyCaption(session.createJourney) }}
@@ -69,7 +66,7 @@
                         actions: {
                             items: [
                                 {
-                                    href: "pay/flat?bandId=" + flatRate.bandId,
+                                    href: "pay/flat?bandId=" + flatRate.bandId + "&preserveHistory=true",
                                     text: "Change",
                                     visuallyHiddenText: "change pay rate"
                                 },
@@ -95,7 +92,7 @@
                     }) }}
                     {{ govukButton({
                         text: "Add another pay rate",
-                        href: 'pay-rate-type?preserveHistory=true' + fromEditText,
+                        href: 'pay-rate-type' + preserveHistoryText + fromEditText,
                         classes: "govuk-button--secondary"
                     }) }}
                 </div>

--- a/server/views/pages/activities/manage-schedules/check-pay.njk
+++ b/server/views/pages/activities/manage-schedules/check-pay.njk
@@ -2,19 +2,30 @@
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "components/card.njk" import card %}
 {% from "partials/activities/activity-journey-caption.njk" import activityJourneyCaption %}
 
 {% set pageTitle = applicationName + " - Edit activity - Check pay" %}
 {% set pageId = 'check-pay-page' %}
+{% set backLinkText = 'Back to edit activity details' %}
 {% set backLinkHref = "activities/" + session.createJourney.activityId %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ activityJourneyCaption(session.createJourney) }}
-            <h1 class="govuk-heading-l">Review pay rates for {{ session.createJourney.name }}</h1>
-            <p class="govuk-body">You can add new pay rates. You can only edit or delete pay rates if no one is allocated to them.</p>
+            <h1 class="govuk-heading-l">Edit pay rates for {{ session.createJourney.name }}</h1>
+
+            {{ govukButton({
+                text: "Add new pay rate",
+                href: '/activities/create/pay-rate-type?fromEditActivity=true&preserveHistory=true',
+                classes: 'govuk-!-margin-0'
+            }) }}
+
+            {{ govukInsetText({
+                text: 'You can add new pay rates. You can only edit or delete pay rates if no one is allocated to them.'
+            }) }}
 
             {% for incentiveLevelPay in incentiveLevelPays %}
                 <h2 class="govuk-heading-m">{{ incentiveLevelPay.incentiveLevel }} incentive level pay rates</h2>
@@ -106,21 +117,11 @@
             {% endfor %}
             {{ govukSummaryList({
                 rows: rows
-            }) }}
+            }) if rows | length }}
 
-            <form method="POST">
-                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-                <div class="govuk-button-group">
-                    {{ govukButton({
-                        text: "Confirm"
-                    }) }}
-                    {{ govukButton({
-                        text: "Add another pay rate",
-                        href: '/activities/create/pay-rate-type?fromEditActivity=true&preserveHistory=true',
-                        classes: "govuk-button--secondary"
-                    }) }}
-                </div>
-            </form>
+            <div class="govuk-!-margin-bottom-6 govuk-body">
+                <a href="activities/{{ session.createJourney.activityId }}" class="govuk-link govuk-link--no-visited-state gov-!-margin-bottom-6">Return to edit activity page</a>
+            </div>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## Overview

Updates the edit pay journey to save updated pay rates immediately when creating, editing or deleting pay. This removes the need to "confirm" changes from the check pay page.