### PR TITLE
SAA-1177 check answers was passing through the schedule id when it should be the activity id.

### DIFF
--- a/server/routes/activities/create-an-activity/handlers/checkAnswers.ts
+++ b/server/routes/activities/create-an-activity/handlers/checkAnswers.ts
@@ -85,6 +85,6 @@ export default class CheckAnswersRoutes {
 
     const response = await this.activitiesService.createActivity(activity, user)
 
-    res.redirect(`confirmation/${response.schedules[0].id}`)
+    res.redirect(`confirmation/${response.id}`)
   }
 }

--- a/server/services/fixtures/activity_1.json
+++ b/server/services/fixtures/activity_1.json
@@ -119,7 +119,7 @@
   "minimumEducationLevel": [{ "educationLevelCode": "1", "educationLevelDescription": "" }],
   "schedules": [
     {
-      "id": 1,
+      "id": 2,
       "instances": [],
       "allocations": [],
       "description": "Maths level 1",


### PR DESCRIPTION
Fixes the start allocating link below:

![image](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/20a0b561-0ee0-4b0a-96d0-22f11172b0fa)
