### PR TITLE
SAA-1179 fixing the back link on the create activites enter pay screen.

### DIFF
--- a/server/views/pages/activities/create-an-activity/pay.njk
+++ b/server/views/pages/activities/create-an-activity/pay.njk
@@ -8,7 +8,7 @@
 
 {% set pageTitle = applicationName + " - Create an activity - Pay" %}
 {% set pageId = 'pay-page' %}
-{% set backLinkHref = "pay-rate-type" %}
+{% set backLinkHref = "/activities/create/pay-rate-type" %}
 
 {% block content %}
     <div class="govuk-grid-row">


### PR DESCRIPTION
Fixes the back link on the enter pay screen

![image](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/fdf91ae8-e157-49a4-93c3-ad0f4389a9af)
