### PR TITLE
SAA-1193 resolving issue where we are using the activity id to look up a schedule when trying edit the end date of an activity.

### DIFF
--- a/server/routes/activities/create-an-activity/handlers/endDate.test.ts
+++ b/server/routes/activities/create-an-activity/handlers/endDate.test.ts
@@ -9,7 +9,7 @@ import EndDateRoutes, { EndDate } from './endDate'
 import ActivitiesService from '../../../../services/activitiesService'
 import atLeast from '../../../../../jest.setup'
 import activity from '../../../../services/fixtures/activity_1.json'
-import { Activity } from '../../../../@types/activitiesAPI/types'
+import { Activity, ActivitySchedule } from '../../../../@types/activitiesAPI/types'
 
 jest.mock('../../../../services/activitiesService')
 
@@ -49,6 +49,35 @@ describe('Route Handlers - Create an activity schedule - End date', () => {
         endDate: undefined,
         startDate: formatDate(new Date(), 'yyyy-MM-dd'),
       })
+    })
+
+    it('should render the expected view in edit mode', async () => {
+      when(activitiesService.getActivitySchedule)
+        .calledWith(atLeast(2))
+        .mockResolvedValueOnce({
+          id: 1,
+          activity: { id: 1 },
+          description: 'Maths',
+          internalLocation: { description: 'Education room 1' },
+          startDate: '2023-07-26',
+          allocations: [{ startDate: '2023-07-26' }],
+        } as unknown as ActivitySchedule)
+
+      req = {
+        session: {
+          createJourney: { startDate: simpleDateFromDate(new Date()), activityId: 1, scheduleId: 2 },
+        },
+        query: {
+          fromEditActivity: true,
+        },
+      } as unknown as Request
+
+      await handler.GET(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/activities/create-an-activity/end-date', {
+        endDate: undefined,
+        startDate: formatDate(new Date(), 'yyyy-MM-dd'),
+      })
+      expect(req.session.createJourney.latestAllocationStartDate).toEqual(new Date('2023-07-26'))
     })
   })
 

--- a/server/routes/activities/create-an-activity/handlers/endDate.ts
+++ b/server/routes/activities/create-an-activity/handlers/endDate.ts
@@ -35,8 +35,8 @@ export default class EndDateRoutes {
     const { user } = res.locals
     let allocations: Allocation[]
     if (req.query && req.query.fromEditActivity) {
-      const { activityId } = req.session.createJourney
-      const schedule = await this.activitiesService.getActivitySchedule(activityId, user)
+      const { scheduleId } = req.session.createJourney
+      const schedule = await this.activitiesService.getActivitySchedule(scheduleId, user)
       if (schedule.allocations.length > 0) {
         allocations = schedule.allocations.sort((a, b) => (a.startDate < b.startDate ? -1 : 1))
         req.session.createJourney.latestAllocationStartDate = new Date(allocations[allocations.length - 1].startDate)

--- a/server/routes/activities/create-an-activity/journey.ts
+++ b/server/routes/activities/create-an-activity/journey.ts
@@ -19,6 +19,7 @@ export type Slots = {
 
 export type CreateAnActivityJourney = {
   activityId?: number
+  scheduleId?: number
   category?: {
     id: number
     code: string

--- a/server/routes/activities/manage-schedules/handlers/activity.test.ts
+++ b/server/routes/activities/manage-schedules/handlers/activity.test.ts
@@ -146,6 +146,7 @@ describe('Route Handlers - View Activity', () => {
         currentWeek: 1,
         attendanceCount: 0,
       })
+      expect(req.session.createJourney.scheduleId).toEqual([activitySchedule][0].id)
     })
   })
 })

--- a/server/routes/activities/manage-schedules/handlers/activity.ts
+++ b/server/routes/activities/manage-schedules/handlers/activity.ts
@@ -39,6 +39,7 @@ export default class ActivityRoutes {
 
     req.session.createJourney = {}
     req.session.createJourney.activityId = activity.id
+    req.session.createJourney.scheduleId = activity.schedules[0].id
     req.session.createJourney.category = activity.category
     req.session.createJourney.name = activity.summary
     req.session.createJourney.inCell = activity.inCell


### PR DESCRIPTION
When editing an activity end date from this page, getting 404.  This was because behind the scenes it is looking up the activity schedule using the activity id.

![image](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/00fb387e-bc88-4070-9024-75f2c627cfb4)
