### PR TITLE
SAA-1197 resolving issue where we are using the activity id to look up a schedule when trying edit the start date of an activity.

### DIFF
--- a/server/routes/activities/create-an-activity/handlers/startDate.test.ts
+++ b/server/routes/activities/create-an-activity/handlers/startDate.test.ts
@@ -9,7 +9,7 @@ import { simpleDateFromDate } from '../../../../commonValidationTypes/simpleDate
 import ActivitiesService from '../../../../services/activitiesService'
 import atLeast from '../../../../../jest.setup'
 import activity from '../../../../services/fixtures/activity_1.json'
-import { Activity } from '../../../../@types/activitiesAPI/types'
+import { Activity, ActivitySchedule } from '../../../../@types/activitiesAPI/types'
 
 jest.mock('../../../../services/activitiesService')
 
@@ -45,6 +45,34 @@ describe('Route Handlers - Create an activity schedule - Start date', () => {
       expect(res.render).toHaveBeenCalledWith('pages/activities/create-an-activity/start-date', {
         endDate: undefined,
       })
+    })
+
+    it('should render the expected view in edit mode', async () => {
+      when(activitiesService.getActivitySchedule)
+        .calledWith(atLeast(2))
+        .mockResolvedValueOnce({
+          id: 1,
+          activity: { id: 1 },
+          description: 'English',
+          internalLocation: { description: 'Education room 1' },
+          startDate: '2023-07-26',
+          allocations: [{ startDate: '2023-07-27' }],
+        } as unknown as ActivitySchedule)
+
+      req = {
+        session: {
+          createJourney: { endDate: simpleDateFromDate(new Date()), activityId: 1, scheduleId: 2 },
+        },
+        query: {
+          fromEditActivity: true,
+        },
+      } as unknown as Request
+
+      await handler.GET(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/activities/create-an-activity/start-date', {
+        endDate: formatDate(new Date(), 'yyyy-MM-dd'),
+      })
+      expect(req.session.createJourney.earliestAllocationStartDate).toEqual(new Date('2023-07-27'))
     })
   })
 

--- a/server/routes/activities/create-an-activity/handlers/startDate.ts
+++ b/server/routes/activities/create-an-activity/handlers/startDate.ts
@@ -40,8 +40,8 @@ export default class StartDateRoutes {
     const { user } = res.locals
     let allocations: Allocation[]
     if (req.query && req.query.fromEditActivity) {
-      const { activityId } = req.session.createJourney
-      const schedule = await this.activitiesService.getActivitySchedule(activityId, user)
+      const { scheduleId } = req.session.createJourney
+      const schedule = await this.activitiesService.getActivitySchedule(scheduleId, user)
       if (schedule.allocations.length > 0) {
         allocations = schedule.allocations.sort((a, b) => (a.startDate < b.startDate ? -1 : 1))
         req.session.createJourney.earliestAllocationStartDate = new Date(allocations[0].startDate)


### PR DESCRIPTION
When editing an activity start date from this page, getting 404. This was because behind the scenes it is looking up the activity schedule using the activity id.

![image](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/5a84ecbc-f3ed-46dc-a5d5-ad2df6b65cc1)

