### PR TITLE
INC-1296: Removed referenced to deprecated INC endpoint

### DIFF
--- a/server/@types/incentivesApi/index.d.ts
+++ b/server/@types/incentivesApi/index.d.ts
@@ -177,14 +177,6 @@ export interface paths {
     /** Returns a specified IEP Review */
     get: operations['getReviewById']
   }
-  '/iep/levels/{prisonId}': {
-    /**
-     * Lists active incentive levels in this prison
-     * @deprecated
-     * @description Not all globally active incentive levels will necessarily be included
-     */
-    get: operations['getPrisonIncentiveLevels_1']
-  }
 }
 
 export type webhooks = Record<string, never>
@@ -661,36 +653,6 @@ export interface components {
        * @example 23
        */
       daysSinceReview: number
-    }
-    LegacyPrisonIncentiveLevel: {
-      /**
-       * @description Code for this incentive level level
-       * @example STD
-       */
-      iepLevel: string
-      /**
-       * @description The name of this incentive level
-       * @example Standard
-       */
-      iepDescription: string
-      /**
-       * Format: int32
-       * @description Order in which to sort and display incentive levels
-       * @example 1
-       */
-      sequence: number
-      /**
-       * @description Indicates that this incentive level is the default for new admissions
-       * @default false
-       * @example false
-       */
-      default: boolean
-      /**
-       * @description Indicates that this incentive level is enabled in this prison
-       * @default true
-       * @example true
-       */
-      active: boolean
     }
   }
   responses: never
@@ -1778,48 +1740,6 @@ export interface operations {
       }
       /** @description Incorrect permissions to use this endpoint */
       403: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-    }
-  }
-  /**
-   * Lists active incentive levels in this prison
-   * @deprecated
-   * @description Not all globally active incentive levels will necessarily be included
-   */
-  getPrisonIncentiveLevels_1: {
-    parameters: {
-      path: {
-        /**
-         * @description Prison id
-         * @example MDI
-         */
-        prisonId: string
-      }
-    }
-    responses: {
-      /** @description Active prison incentive levels returned */
-      200: {
-        content: {
-          'application/json': components['schemas']['LegacyPrisonIncentiveLevel'][]
-        }
-      }
-      /** @description Unauthorized to access this endpoint */
-      401: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Incorrect permissions to use this endpoint */
-      403: {
-        content: {
-          'application/json': components['schemas']['ErrorResponse']
-        }
-      }
-      /** @description Prison incentive level not found */
-      404: {
         content: {
           'application/json': components['schemas']['ErrorResponse']
         }


### PR DESCRIPTION
The `GET /iep/levels/{prisonId}` endpoint has been deprecated for awhile and [no clients seems to use it according to AppInsights](https://portal.azure.com#@747381f4-e81f-4a43-bf68-ced6a1e14edf/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2Fa5ddf257-3b21-4ba9-a28c-ab30f751b383%2FresourceGroups%2Fnomisapi-prod-rg%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2Fnomisapi-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA1XNOw6DMBAE0J5TrKgT%252BwSUUboUUZQWIXsEC8a2vMY0HJ5PESnVaqQ3sxYR3sIbhlQbrQMSKHepR6amoZq9gc9cIPcushrmGEUJUmEDNS6Sz9uHopap%252FvV9N4PkWMmych5aI1Q%252FHx%252FSjKgdCpzoU8cURph8%252BRsZFxbbvoPD68pipy%252BScPCV1rSR5eObP%252Fg%252F3AGe4URUwgAAAA%253D%253D/timespan/P7D)

This PR removes the types definitions related to that endpoint.

I don't think the service actually uses it but let me know if I'm going to accidentally break something with this change.