### PR TITLE
SAA-1296: Bug fixes

### DIFF
--- a/server/middleware/activities/initialiseEditJourney.test.ts
+++ b/server/middleware/activities/initialiseEditJourney.test.ts
@@ -1,0 +1,162 @@
+import { Request, Response } from 'express'
+import { when } from 'jest-when'
+import initialiseEditJourney from './initialiseEditJourney'
+import ActivitiesService from '../../services/activitiesService'
+import { ServiceUser } from '../../@types/express'
+import { Activity } from '../../@types/activitiesAPI/types'
+import { mapActivityModelSlotsToJourney } from '../../utils/utils'
+import atLeast from '../../../jest.setup'
+
+jest.mock('../../services/activitiesService')
+
+const activitiesService = new ActivitiesService(null) as jest.Mocked<ActivitiesService>
+const middleware = initialiseEditJourney(activitiesService)
+
+describe('initialiseEditJourney', () => {
+  const user = {
+    username: 'joebloggs',
+  } as ServiceUser
+
+  const req = {
+    session: {
+      createJourney: {},
+    },
+    params: {
+      mode: 'edit',
+      activityId: '1',
+    },
+  } as unknown as Request
+
+  const res = {
+    locals: {
+      user,
+    },
+  } as unknown as Response
+
+  const next = jest.fn()
+
+  const allocation1 = {
+    id: 1,
+    startDate: '2022-02-01',
+  }
+
+  const allocation2 = {
+    id: 2,
+    startDate: '2022-02-02',
+  }
+
+  const schedule = {
+    id: 1,
+    scheduleWeeks: 1,
+    slots: [
+      {
+        id: 1,
+        weekNumber: 1,
+        startTime: '9:00',
+        endTime: '11:30',
+        daysOfWeek: ['Mon', 'Tue'],
+        mondayFlag: true,
+        tuesdayFlag: true,
+        wednesdayFlag: false,
+        thursdayFlag: false,
+        fridayFlag: false,
+        saturdayFlag: false,
+        sundayFlag: false,
+      },
+    ],
+    runsOnBankHoliday: false,
+    capacity: 10,
+    internalLocation: {
+      id: 14438,
+      code: 'AWING',
+      description: 'A-Wing',
+    },
+    allocations: [allocation1, allocation2],
+  }
+
+  const activity = {
+    id: 1,
+    category: {
+      id: 1,
+      code: 'LEISURE_SOCIAL',
+    },
+    inCell: false,
+    onWing: false,
+    offWing: false,
+    riskLevel: 'high',
+    summary: 'activity summary',
+    startDate: '2022-01-01',
+    endDate: '2023-12-01',
+    minimumIncentiveLevel: 'Basic',
+    pay: [
+      {
+        id: 123456,
+        incentiveNomisCode: 'BAS',
+        incentiveLevel: 'Basic',
+        rate: 150,
+      },
+    ],
+    minimumEducationLevel: [
+      {
+        id: 123456,
+        educationLevelCode: 'Basic',
+        studyAreaCode: 'ENGLA',
+      },
+    ],
+    schedules: [schedule],
+  } as unknown as Activity
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should set up session object', async () => {
+    when(activitiesService.getActivity).calledWith(atLeast(1, user)).defaultResolvedValue(activity)
+
+    await middleware(req, res, next)
+
+    expect(req.session.createJourney).toEqual({
+      activityId: activity.id,
+      scheduleId: schedule.id,
+      category: activity.category,
+      name: activity.summary,
+      inCell: activity.inCell,
+      onWing: activity.onWing,
+      offWing: activity.offWing,
+      riskLevel: activity.riskLevel,
+      startDate: activity.startDate,
+      endDate: activity.endDate,
+      minimumIncentiveLevel: activity.minimumIncentiveLevel,
+      scheduleWeeks: schedule.scheduleWeeks,
+      slots: mapActivityModelSlotsToJourney(schedule.slots),
+      runsOnBankHoliday: schedule.runsOnBankHoliday,
+      currentCapacity: schedule.capacity,
+      capacity: schedule.capacity,
+      allocations: [allocation1, allocation2],
+      pay: activity.pay,
+      educationLevels: activity.minimumEducationLevel,
+      location: {
+        id: schedule.internalLocation.id,
+        name: schedule.internalLocation.description,
+      },
+      latestAllocationStartDate: allocation2.startDate,
+      earliestAllocationStartDate: allocation1.startDate,
+    })
+
+    expect(next).toBeCalledTimes(1)
+  })
+
+  it('it should skip initalisation if session object already set', async () => {
+    req.session.createJourney = { activityId: 1 }
+
+    await middleware(req, res, next)
+
+    expect(activitiesService.getActivity).toBeCalledTimes(0)
+
+    expect(req.session.createJourney).toEqual({
+      activityId: 1,
+    })
+
+    expect(next).toBeCalledTimes(1)
+  })
+})

--- a/server/middleware/activities/initialiseEditJourney.ts
+++ b/server/middleware/activities/initialiseEditJourney.ts
@@ -10,7 +10,9 @@ export default (activitiesService: ActivitiesService): RequestHandler => {
 
     const activity = await activitiesService.getActivity(+activityId, res.locals.user)
     const schedule = activity.schedules[0]
-    const allocations = activity.schedules.flatMap(s => s.allocations.filter(a => a.status !== 'ENDED'))
+    const allocations = activity.schedules
+      .flatMap(s => s.allocations.filter(a => a.status !== 'ENDED'))
+      .sort((a, b) => (a.startDate < b.startDate ? -1 : 1))
 
     req.session.createJourney = {
       activityId: activity.id,
@@ -39,6 +41,11 @@ export default (activitiesService: ActivitiesService): RequestHandler => {
         id: schedule.internalLocation.id,
         name: schedule.internalLocation.description,
       }
+    }
+
+    if (allocations.length > 0) {
+      req.session.createJourney.latestAllocationStartDate = allocations[allocations.length - 1].startDate
+      req.session.createJourney.earliestAllocationStartDate = allocations[0].startDate
     }
 
     return next()

--- a/server/routes/activities/create-an-activity/handlers/endDate.ts
+++ b/server/routes/activities/create-an-activity/handlers/endDate.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import { Expose, Transform } from 'class-transformer'
 import { IsDate, ValidateIf } from 'class-validator'
+import { startOfToday } from 'date-fns'
 import { ActivityUpdateRequest } from '../../../../@types/activitiesAPI/types'
 import ActivitiesService from '../../../../services/activitiesService'
 import {
@@ -19,6 +20,7 @@ export class EndDate {
   @Transform(({ obj }) => parseDatePickerDate(obj.endDateString))
   @ValidateIf(o => o.endDateString !== '')
   @IsDate({ message: 'Enter a valid end date' })
+  @DateValidator(thisDate => thisDate > startOfToday(), { message: 'Activity end date must be in the future' })
   @DateValidator(
     (date, { createJourney }) => {
       const allocationDate = createJourney?.latestAllocationStartDate
@@ -55,7 +57,7 @@ export default class EndDateRoutes {
       const activity = { endDate, removeEndDate: !endDate } as ActivityUpdateRequest
       await this.activitiesService.updateActivity(user.activeCaseLoadId, activityId, activity)
 
-      const successMessage = `We've updated the end date for, ${name}`
+      const successMessage = `We've updated the end date for ${name}`
       res.redirectWithSuccess(`/activities/view/${activityId}`, 'Activity updated', successMessage)
     } else res.redirectOrReturn('schedule-frequency')
   }

--- a/server/views/pages/activities/create-an-activity/end-date.njk
+++ b/server/views/pages/activities/create-an-activity/end-date.njk
@@ -29,7 +29,7 @@
                         text: 'Enter the date, for example ' + exampleDatePickerDate() + ', or click on the calendar to select'
                     },
                     errorMessage: validationErrors | findError('endDate'),
-                    value: formResponses.endDate or session.createJourney.endDate | isoDateToDatePickerDate
+                    value: formResponses.endDateString or session.createJourney.endDate | isoDateToDatePickerDate
                 }) }}
                 {% if session.req.params.mode == 'edit' %}
                     {{ govukInsetText({


### PR DESCRIPTION
## Overview

This adds extra activity end date validation to ensure end date is always set to a date in the future (also needs API validation).

I've also added support for the `latestAllocationStartDate` and `earliestAllocationStartDate` journey properties to the initialise `initialiseEditJourney` middleware. I added this originally, but I think it may have been removed when resolving merge conflicts.