### PR TITLE
SAA-1332: Fix for missing flat pay alias

### DIFF
--- a/server/views/pages/activities/create-an-activity/check-answers.njk
+++ b/server/views/pages/activities/create-an-activity/check-answers.njk
@@ -272,7 +272,7 @@
         <div class="govuk-!-margin-bottom-2">
             <div class="govuk-!-font-weight-bold">Flat rate pay</div>
             {% for flatRate in session.createJourney.flat %}
-                <div>{{ flatRate.bandAlias }}: {{ flatRate.rate | toMoney }}</div>
+                <div>{{ flatRate.prisonPayBand.alias }}: {{ flatRate.rate | toMoney }}</div>
             {% endfor %}
         </div>
     {% endif %}


### PR DESCRIPTION
## Overview

Small bug fix for missing flat pay alias on the check answers page.

### Screenshots

**Before**
<img width="941" alt="Screenshot at Oct 25 11-58-53" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/bf822749-2ebb-43c0-ba4f-d8990eb55b30">

**After**
<img width="911" alt="Screenshot at Oct 25 12-13-01" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/e13a163c-6551-4397-8787-8fe6e7d3c9e8">
