### PR TITLE
SAA-1218 No attendees for review schedule

### DIFF
--- a/server/views/pages/appointments/create-and-edit/schedule.njk
+++ b/server/views/pages/appointments/create-and-edit/schedule.njk
@@ -26,9 +26,9 @@
                     <p class="govuk-body">You’ve removed the last attendee for this set of appointments.</p>
                     <p class="govuk-body">You need to add a new list of prison numbers to continue scheduling the set of back-to-backs.</p>
                 {% else %}
-                    <h1 class="govuk-heading-l">There are no attendees for this appointment</h1>
-                    <p class="govuk-body">You’ve removed the last attendee for this appointment.</p>
-                    <p class="govuk-body">You need to add someone to continue scheduling it.</p>
+                    <h1 class="govuk-heading-l">There are no attendees to add</h1>
+                    <p class="govuk-body">You’ve removed the last new attendee.</p>
+                    <p class="govuk-body">You can <a href="/appointments/{{ appointmentId }}" class="govuk-link--no-visited-state">return to the appointment details</a> or add someone else to continue updating.</p>
                 {% endif %}
 
                 {% set addPrisonersHref = ('prisoners/add/how-to-add-prisoners?preserveHistory=true' if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT) or

--- a/server/views/pages/appointments/create-and-edit/schedule.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/schedule.njk.test.ts
@@ -493,10 +493,10 @@ describe('Views - Appointments Management - Schedule', () => {
       $ = cheerio.load(compiledTemplate.render(viewContext))
 
       expect($('form').length).toBe(0)
-      expect($('h1').text().trim()).toEqual('There are no attendees for this appointment')
+      expect($('h1').text().trim()).toEqual('There are no attendees to add')
       const paragraphs = $('p')
-      expect(paragraphs.text()).toContain('You’ve removed the last attendee for this appointment.')
-      expect(paragraphs.text()).toContain('You need to add someone to continue scheduling it.')
+      expect(paragraphs.text()).toContain('You’ve removed the last new attendee.')
+      expect(paragraphs.text()).toContain('return to the appointment details')
       const cta = $('.govuk-button')
       expect(cta.text().trim()).toBe('Add someone to the list')
       expect(cta.attr('href')).toBe('how-to-add-prisoners?preserveHistory=true')


### PR DESCRIPTION
Issue: Manage Existing appointment when removed a prisioner appointment, page is directing has 2 versions of same page.

Resolution: When removed the pages has to be with same version.

Before the fix: 
![Screenshot 2023-10-30 at 09 42 08](https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/a53ce247-c519-443a-90f6-d4a5abe4dcc9)

After the fix:
![Screenshot 2023-10-30 at 09 42 44](https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/73eba1a8-5695-4694-83b3-7f96e730062c)
