### PR TITLE
SAA-1350: Allow form submissions to prison estate domains

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -26,6 +26,7 @@ export default function setUpWebSecurity(): Router {
   const styleSrc = ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`]
   const imgSrc = ["'self'", 'data:']
   const fontSrc = ["'self'"]
+  const formAction = ["'self' *.prison.service.justice.gov.uk"]
 
   scriptSrc.push(config.apis.frontendComponents.url)
   styleSrc.push(config.apis.frontendComponents.url)
@@ -42,6 +43,7 @@ export default function setUpWebSecurity(): Router {
           styleSrc,
           imgSrc,
           fontSrc,
+          formAction,
         },
       },
       referrerPolicy: { policy: 'same-origin' },


### PR DESCRIPTION
- Frontend components API has delivered a new prisoner search form to the top of every page of our service
- Content security policy currently disallows the form to be posted, as the `form-action` is to another domain
- We should now allow form submissions to any domain matching the regex