### PR TITLE
SAA-1218 appointmentId passed to njk for the url

### DIFF
--- a/server/routes/appointments/create-and-edit/handlers/schedule.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/schedule.test.ts
@@ -100,6 +100,7 @@ describe('Route Handlers - Create Appointment - Schedule', () => {
       expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/schedule', {
         isCtaAcceptAndSave: false,
         prisonerSchedules: [],
+        appointmentId: req.params.appointmentId,
       })
     })
 

--- a/server/routes/appointments/create-and-edit/handlers/schedule.ts
+++ b/server/routes/appointments/create-and-edit/handlers/schedule.ts
@@ -67,6 +67,7 @@ export default class ScheduleRoutes {
     res.render('pages/appointments/create-and-edit/schedule', {
       preserveHistory,
       prisonerSchedules,
+      appointmentId,
       isCtaAcceptAndSave:
         req.session.appointmentJourney.mode === AppointmentJourneyMode.EDIT &&
         !isApplyToQuestionRequired(req.session.editAppointmentJourney),


### PR DESCRIPTION
**Issue:** : Page link not pointing to appointment details, instead point to main page. appointmentId is not passed.  

**Resolved** adjudicationId passed from ts file to njk render.

<img width="1274" alt="Screenshot 2023-11-01 at 11 21 33" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/898c2103-258d-4c8f-899b-0c94c70957bb">
