### PR TITLE
SAA-1348 add custom dimensions to requests for app insights metrics

### DIFF
--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -1,5 +1,11 @@
-import { setup, defaultClient, TelemetryClient, DistributedTracingModes } from 'applicationinsights'
+import { Contracts, setup, defaultClient, TelemetryClient, DistributedTracingModes } from 'applicationinsights'
+import { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
 import applicationVersion from '../applicationVersion'
+
+export type ContextObject = {
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  [name: string]: any
+}
 
 function defaultName(): string {
   const {
@@ -26,7 +32,31 @@ export function buildAppInsightsClient(name = defaultName()): TelemetryClient {
   if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING && defaultClient) {
     defaultClient.context.tags['ai.cloud.role'] = name
     defaultClient.context.tags['ai.application.ver'] = version()
+    defaultClient.addTelemetryProcessor(addUserDataToRequests)
     return defaultClient
   }
   return null
+}
+
+/**
+ * Adds extra data in the requests logged for the service, to identify unique username and active caseload.
+ * @param envelope
+ * @param contextObjects
+ */
+export function addUserDataToRequests(envelope: EnvelopeTelemetry, contextObjects: ContextObject) {
+  const isRequest = envelope.data.baseType === Contracts.TelemetryTypeString.Request
+  if (isRequest) {
+    const { caseLoadId } = contextObjects?.['http.ServerRequest']?.res?.locals?.user?.activeCaseLoad || {}
+    const { username } = contextObjects?.['http.ServerRequest']?.res?.locals?.user || {}
+    if (username) {
+      const { properties } = envelope.data.baseData
+      // eslint-disable-next-line no-param-reassign
+      envelope.data.baseData.properties = {
+        username,
+        activeCaseLoadId: caseLoadId,
+        ...properties,
+      }
+    }
+  }
+  return true
 }


### PR DESCRIPTION
This PR adds username and their active caseload as custom dimensions for Requests.
It has been requested by the team who monitor the unique user counts for DPS v. NOMIS usage.

To test, our service should start to appear in this app insights query:

`requests
| mv-expand prison = split(customDimensions.activeCaseLoadId, ",") to typeof(string) 
| extend username = tostring(customDimensions.username)
| extend role_name = tostring(cloud_RoleName)
| where customDimensions.activeCaseLoadId <> ""
| where success == 'True'
//| where timestamp between(dateStart .. dateEnd)
| summarize totalRequests=count(), Distinct_Users=dcount(username) 
    by 
    format_datetime(timestamp, 'yyyy-MM'), 
    establishment = trim(@"[^\w]+",prison),
    role_name`

Where it does not currently appear.

Risk: LOW  - but needs to be verified in DEV.


