### PR TITLE
SAA-1314 Single Attendee information added

### DIFF
--- a/server/@types/activitiesAPI/index.d.ts
+++ b/server/@types/activitiesAPI/index.d.ts
@@ -5734,6 +5734,12 @@ export interface components {
        * @example 3
        */
       notRecordedCount: number
+      /**
+       * @description
+       *     Summary of the prisoner or prisoners attending this appointment and their attendance record if any.
+       *     Attendees are at the appointment level to allow for per appointment attendee changes.
+       */
+      attendees: components['schemas']['AppointmentAttendeeSearchResult'][]
     }
     /**
      * @description

--- a/server/routes/appointments/attendance/handlers/summaries.test.ts
+++ b/server/routes/appointments/attendance/handlers/summaries.test.ts
@@ -6,13 +6,16 @@ import ActivitiesService from '../../../../services/activitiesService'
 import { AppointmentAttendanceSummary } from '../../../../@types/activitiesAPI/types'
 import DateOption from '../../../../enum/dateOption'
 import { parseIsoDate } from '../../../../utils/datePickerUtils'
+import PrisonService from '../../../../services/prisonService'
+import { Prisoner } from '../../../../@types/prisonerOffenderSearchImport/types'
 
 jest.mock('../../../../services/activitiesService')
 
 const activitiesService = new ActivitiesService(null) as jest.Mocked<ActivitiesService>
+const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
 
 describe('Route Handlers - Appointment Attendance Summaries', () => {
-  const handler = new SummariesRoutes(activitiesService)
+  const handler = new SummariesRoutes(activitiesService, prisonService)
   let req: Request
   let res: Response
 
@@ -59,6 +62,7 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
       }
 
       const summaries = [] as AppointmentAttendanceSummary[]
+      const prisonersDetails = {} as Prisoner
 
       when(activitiesService.getAppointmentAttendanceSummaries)
         .calledWith(prisonCode, today, res.locals.user)
@@ -79,6 +83,7 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
           notAttendedPercentage: 0,
           notRecordedPercentage: 0,
         },
+        prisonersDetails,
       })
     })
 
@@ -87,6 +92,7 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
       req.query = {
         dateOption,
       }
+      const prisonersDetails = {} as Prisoner
 
       const summaries = [
         {
@@ -94,18 +100,21 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
           attendedCount: 0,
           nonAttendedCount: 0,
           notRecordedCount: 1,
+          attendees: [],
         },
         {
           attendeeCount: 3,
           attendedCount: 2,
           nonAttendedCount: 1,
           notRecordedCount: 0,
+          attendees: [],
         },
         {
           attendeeCount: 6,
           attendedCount: 3,
           nonAttendedCount: 2,
           notRecordedCount: 1,
+          attendees: [],
         },
       ] as AppointmentAttendanceSummary[]
 
@@ -128,6 +137,7 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
           notAttendedPercentage: 30,
           notRecordedPercentage: 20,
         },
+        prisonersDetails,
       })
     })
 
@@ -137,6 +147,7 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
         dateOption,
         date: '2023-10-16',
       }
+      const prisonersDetails = {} as Prisoner
 
       const summaries = [
         {
@@ -144,6 +155,7 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
           attendedCount: 0,
           nonAttendedCount: 0,
           notRecordedCount: 1,
+          attendees: [],
         },
         {
           isCancelled: true,
@@ -151,12 +163,14 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
           attendedCount: 2,
           nonAttendedCount: 1,
           notRecordedCount: 0,
+          attendees: [],
         },
         {
           attendeeCount: 6,
           attendedCount: 3,
           nonAttendedCount: 2,
           notRecordedCount: 1,
+          attendees: [],
         },
       ] as AppointmentAttendanceSummary[]
 
@@ -175,12 +189,14 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
             attendedCount: 0,
             nonAttendedCount: 0,
             notRecordedCount: 1,
+            attendees: [],
           },
           {
             attendeeCount: 6,
             attendedCount: 3,
             nonAttendedCount: 2,
             notRecordedCount: 1,
+            attendees: [],
           },
         ] as AppointmentAttendanceSummary[],
         attendanceSummary: {
@@ -192,6 +208,7 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
           notAttendedPercentage: 29,
           notRecordedPercentage: 29,
         },
+        prisonersDetails,
       })
     })
   })

--- a/server/routes/appointments/attendance/handlers/summaries.test.ts
+++ b/server/routes/appointments/attendance/handlers/summaries.test.ts
@@ -8,8 +8,10 @@ import DateOption from '../../../../enum/dateOption'
 import { parseIsoDate } from '../../../../utils/datePickerUtils'
 import PrisonService from '../../../../services/prisonService'
 import { Prisoner } from '../../../../@types/prisonerOffenderSearchImport/types'
+import atLeast from '../../../../../jest.setup'
 
 jest.mock('../../../../services/activitiesService')
+jest.mock('../../../../services/prisonService')
 
 const activitiesService = new ActivitiesService(null) as jest.Mocked<ActivitiesService>
 const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
@@ -209,6 +211,104 @@ describe('Route Handlers - Appointment Attendance Summaries', () => {
           notRecordedPercentage: 29,
         },
         prisonersDetails,
+      })
+    })
+
+    it('should provide prisoner details for 1 attendee', async () => {
+      const dateOption = DateOption.OTHER
+      req.query = {
+        dateOption,
+        date: '2023-10-17',
+      }
+
+      const summaries = [
+        {
+          attendeeCount: 1,
+          attendedCount: 0,
+          nonAttendedCount: 0,
+          notRecordedCount: 1,
+          attendees: [
+            {
+              prisonerNumber: 'A0013DZ',
+            },
+          ],
+        },
+        {
+          attendeeCount: 3,
+          attendedCount: 2,
+          nonAttendedCount: 1,
+          notRecordedCount: 0,
+          attendees: [],
+        },
+      ] as AppointmentAttendanceSummary[]
+
+      // Mock the response of activitiesService.getAppointmentAttendanceSummaries
+      when(activitiesService.getAppointmentAttendanceSummaries)
+        .calledWith(prisonCode, parseIsoDate('2023-10-17'), res.locals.user)
+        .mockResolvedValue(summaries)
+
+      // Mock the response of prisonService.searchInmatesByPrisonerNumbers
+      when(prisonService.searchInmatesByPrisonerNumbers)
+        .calledWith(atLeast(['A0013DZ']))
+        .mockResolvedValue([
+          {
+            prisonerNumber: 'A0013DZ',
+            firstName: 'RODNEY',
+            lastName: 'REINDEER',
+            cellLocation: 'MDI-4-2-009',
+          },
+        ] as Prisoner[])
+
+      // Call the GET method
+      await handler.GET(req, res)
+
+      // Define the expected summaries without cancelled appointments
+      const expectedSummaries = [
+        {
+          attendeeCount: 1,
+          attendedCount: 0,
+          nonAttendedCount: 0,
+          notRecordedCount: 1,
+          attendees: [
+            {
+              prisonerNumber: 'A0013DZ',
+            },
+          ],
+        },
+        {
+          attendeeCount: 3,
+          attendedCount: 2,
+          nonAttendedCount: 1,
+          notRecordedCount: 0,
+          attendees: [],
+        },
+      ] as AppointmentAttendanceSummary[]
+
+      // Define the expected prisoners details
+      const expectedPrisonersDetails = {
+        A0013DZ: {
+          prisonerNumber: 'A0013DZ',
+          firstName: 'RODNEY',
+          lastName: 'REINDEER',
+          cellLocation: 'MDI-4-2-009',
+        },
+      }
+
+      // Assert that res.render was called with the expected data
+      expect(res.render).toHaveBeenCalledWith('pages/appointments/attendance/summaries', {
+        dateOption,
+        date: parseIsoDate('2023-10-17'),
+        summaries: expectedSummaries,
+        attendanceSummary: {
+          attended: 2,
+          attendedPercentage: 50,
+          attendeeCount: 4,
+          notAttended: 1,
+          notAttendedPercentage: 25,
+          notRecorded: 1,
+          notRecordedPercentage: 25,
+        },
+        prisonersDetails: expectedPrisonersDetails,
       })
     })
   })

--- a/server/routes/appointments/attendance/handlers/summaries.ts
+++ b/server/routes/appointments/attendance/handlers/summaries.ts
@@ -23,10 +23,10 @@ export default class SummariesRoutes {
     ).filter(s => !s.isCancelled)
 
     // Get prisoner details for appointments with a single attendee
-    const prisonerNumbers = summaries.flatMap(r => (r.attendees.length === 1 ? r.attendees[0].prisonerNumber : []))
+    const prisonerNumber = summaries.flatMap(r => (r.attendees.length === 1 ? r.attendees[0].prisonerNumber : []))
     let prisonersDetails = {}
-    if (prisonerNumbers.length > 0) {
-      prisonersDetails = (await this.prisonService.searchInmatesByPrisonerNumbers(uniq(prisonerNumbers), user)).reduce(
+    if (prisonerNumber.length > 0) {
+      prisonersDetails = (await this.prisonService.searchInmatesByPrisonerNumbers(uniq(prisonerNumber), user)).reduce(
         (prisonerMap, prisoner) => ({
           ...prisonerMap,
           [prisoner.prisonerNumber]: prisoner,

--- a/server/routes/appointments/attendance/handlers/summaries.ts
+++ b/server/routes/appointments/attendance/handlers/summaries.ts
@@ -1,11 +1,13 @@
 import { Request, Response } from 'express'
+import { uniq } from 'lodash'
 import DateOption from '../../../../enum/dateOption'
 import ActivitiesService from '../../../../services/activitiesService'
+import PrisonService from '../../../../services/prisonService'
 import { dateFromDateOption } from '../../../../utils/datePickerUtils'
 import { AppointmentAttendanceSummary } from '../../../../@types/activitiesAPI/types'
 
 export default class SummariesRoutes {
-  constructor(private readonly activitiesService: ActivitiesService) {}
+  constructor(private readonly activitiesService: ActivitiesService, private readonly prisonService: PrisonService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
     const { user } = res.locals
@@ -20,11 +22,25 @@ export default class SummariesRoutes {
       await this.activitiesService.getAppointmentAttendanceSummaries(user.activeCaseLoadId, dateOptionDate, user)
     ).filter(s => !s.isCancelled)
 
+    // Get prisoner details for appointments with a single attendee
+    const prisonerNumbers = summaries.flatMap(r => (r.attendees.length === 1 ? r.attendees[0].prisonerNumber : []))
+    let prisonersDetails = {}
+    if (prisonerNumbers.length > 0) {
+      prisonersDetails = (await this.prisonService.searchInmatesByPrisonerNumbers(uniq(prisonerNumbers), user)).reduce(
+        (prisonerMap, prisoner) => ({
+          ...prisonerMap,
+          [prisoner.prisonerNumber]: prisoner,
+        }),
+        {},
+      )
+    }
+
     return res.render('pages/appointments/attendance/summaries', {
       dateOption,
       date: dateOptionDate,
       summaries,
       attendanceSummary: this.getAttendanceSummary(summaries),
+      prisonersDetails,
     })
   }
 

--- a/server/routes/appointments/attendance/index.ts
+++ b/server/routes/appointments/attendance/index.ts
@@ -5,7 +5,7 @@ import validationMiddleware from '../../../middleware/validationMiddleware'
 import SelectDateRoutes, { SelectDate } from './handlers/selectDate'
 import SummariesRoutes from './handlers/summaries'
 
-export default function Index({ activitiesService }: Services): Router {
+export default function Index({ activitiesService, prisonService }: Services): Router {
   const router = Router({ mergeParams: true })
 
   const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
@@ -13,7 +13,7 @@ export default function Index({ activitiesService }: Services): Router {
     router.post(path, validationMiddleware(type), asyncMiddleware(handler))
 
   const selectDateRoutes = new SelectDateRoutes()
-  const summariesRoutes = new SummariesRoutes(activitiesService)
+  const summariesRoutes = new SummariesRoutes(activitiesService, prisonService)
 
   get('/select-date', selectDateRoutes.GET)
   post('/select-date', selectDateRoutes.POST, SelectDate)

--- a/server/views/pages/appointments/attendance/summaries.njk
+++ b/server/views/pages/appointments/attendance/summaries.njk
@@ -2,11 +2,27 @@
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "partials/showProfileLink.njk" import showProfileLink %}
 
 {% set pageTitle = "Appointment attendance summaries" %}
 {% set pageId = 'appointment-attendance-summaries-page' %}
 {% set hardBackLinkText = "Choose a different date" %}
 {% set hardBackLinkHref = "select-date" %}
+
+{% macro attendees(attendees) %}
+    {% if attendees | length == 1 %}
+        {% set prisonerDetails = prisonersDetails[attendees[0].prisonerNumber] %}
+        {{ showProfileLink({
+            name: prisonerDetails | firstNameLastName,
+            prisonerNumber: prisonerDetails.prisonerNumber or attendees[0].prisonerNumber,
+            cellLocation: prisonerDetails.cellLocation or "UNKNOWN",
+            link: true,
+            classes: 'hmpps-inline-block'
+        }) }}
+    {% else %}
+        {{ attendees.length }}
+    {% endif %}
+{% endmacro %}
 
 {% macro summaryLink(summary) %}
     <a href="/appointments/{{ summary.id }}/attendance" class="govuk-link--no-visited-state">
@@ -30,9 +46,10 @@
             text: summary.startTime + (" to " + summary.endTime if summary.endTime),
             attributes: { 'data-qa': 'appointment-attendance-summary-' + loop.index + '-time' }
         }, {
-            text: summary.attendeeCount,
+            text: attendees(summary.attendees, prisonersDetails),
             attributes: { 'data-qa': 'appointment-attendance-summary-' + loop.index + '-attendee-count' }
-        }, {
+        },
+         {
             text: summary.attendedCount,
             attributes: { 'data-qa': 'appointment-attendance-summary-' + loop.index + '-attended-count' }
         }, {

--- a/server/views/pages/appointments/attendance/summaries.njk
+++ b/server/views/pages/appointments/attendance/summaries.njk
@@ -47,7 +47,9 @@
             attributes: { 'data-qa': 'appointment-attendance-summary-' + loop.index + '-time' }
         }, {
             text: attendees(summary.attendees, prisonersDetails),
-            attributes: { 'data-qa': 'appointment-attendance-summary-' + loop.index + '-attendee-count' }
+            attributes: { 'data-qa': 'appointment-attendance-summary-' + loop.index + '-attendee-count',
+                "data-sort-value": summary.attendees
+            }
         },
          {
             text: summary.attendedCount,


### PR DESCRIPTION
Change:
Record Maintanance Page to display single prision information.

Before Changes:
<img width="1281" alt="Screenshot 2023-11-08 at 14 44 07" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/bf9b909b-1b4a-4549-a6c2-7d941dfbc2f3">

Appointment Canteen, has only 1 Attendee but it shows a number. 

After Changes:

![Screenshot 2023-11-08 at 15 20 12](https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/c205043d-8820-4470-b25f-683477548b14)

Appointment Canteen, Shows the Prisoner details. 
