### PR TITLE
SAA-1173: Appointment tiers & hosts (create journey)

### DIFF
--- a/integration_tests/e2e/appointments/createGroupAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createGroupAppointment.cy.ts
@@ -25,6 +25,8 @@ import UploadPrisonerListPage from '../../pages/appointments/create-and-edit/upl
 import AppointmentDetailsPage from '../../pages/appointments/appointment/appointmentDetailsPage'
 import ExtraInformationPage from '../../pages/appointments/create-and-edit/extraInformationPage'
 import SchedulePage from '../../pages/appointments/create-and-edit/schedulePage'
+import TierPage from '../../pages/appointments/create-and-edit/tierPage'
+import HostPage from '../../pages/appointments/create-and-edit/hostPage'
 
 context('Create group appointment', () => {
   const tomorrow = addDays(new Date(), 1)
@@ -115,6 +117,14 @@ context('Create group appointment', () => {
     namePage.selectCategory('Chaplaincy')
     namePage.continue()
 
+    const tierPage = Page.verifyOnPage(TierPage)
+    tierPage.selectTier('Tier 2')
+    tierPage.continue()
+
+    const hostPage = Page.verifyOnPage(HostPage)
+    hostPage.selectHost('Prison staff')
+    hostPage.continue()
+
     const locationPage = Page.verifyOnPage(LocationPage)
     locationPage.selectLocation('Chapel')
     locationPage.continue()
@@ -140,6 +150,8 @@ context('Create group appointment', () => {
     checkAnswersPage.assertPrisonerInList('Gregs, Stephen', 'A8644DY')
     checkAnswersPage.assertPrisonerInList('Jacobson, Lee', 'A1351DZ')
     checkAnswersPage.assertCategory('Chaplaincy')
+    checkAnswersPage.assertTier('Tier 2')
+    checkAnswersPage.assertHost('Prison staff')
     checkAnswersPage.assertLocation('Chapel')
     checkAnswersPage.assertStartDate(tomorrow)
     checkAnswersPage.assertStartTime(14, 0)

--- a/integration_tests/e2e/appointments/createGroupRepeatAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createGroupRepeatAppointment.cy.ts
@@ -27,6 +27,8 @@ import AppointmentDetailsPage from '../../pages/appointments/appointment/appoint
 import { AppointmentFrequency } from '../../../server/@types/appointments'
 import ExtraInformationPage from '../../pages/appointments/create-and-edit/extraInformationPage'
 import SchedulePage from '../../pages/appointments/create-and-edit/schedulePage'
+import TierPage from '../../pages/appointments/create-and-edit/tierPage'
+import HostPage from '../../pages/appointments/create-and-edit/hostPage'
 
 context('Create group appointment', () => {
   const tomorrow = addDays(new Date(), 1)
@@ -123,6 +125,14 @@ context('Create group appointment', () => {
     namePage.selectCategory('Chaplaincy')
     namePage.continue()
 
+    const tierPage = Page.verifyOnPage(TierPage)
+    tierPage.selectTier('Tier 2')
+    tierPage.continue()
+
+    const hostPage = Page.verifyOnPage(HostPage)
+    hostPage.selectHost('Prison staff')
+    hostPage.continue()
+
     const locationPage = Page.verifyOnPage(LocationPage)
     locationPage.selectLocation('Chapel')
     locationPage.continue()
@@ -153,6 +163,8 @@ context('Create group appointment', () => {
     checkAnswersPage.assertPrisonerInList('Gregs, Stephen', 'A8644DY')
     checkAnswersPage.assertPrisonerInList('Jacobson, Lee', 'A1351DZ')
     checkAnswersPage.assertCategory('Chaplaincy')
+    checkAnswersPage.assertTier('Tier 2')
+    checkAnswersPage.assertHost('Prison staff')
     checkAnswersPage.assertLocation('Chapel')
     checkAnswersPage.assertStartDate(tomorrow)
     checkAnswersPage.assertStartTime(14, 0)

--- a/integration_tests/e2e/appointments/createIndividualAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createIndividualAppointment.cy.ts
@@ -22,6 +22,8 @@ import { formatDate } from '../../../server/utils/utils'
 import AppointmentDetailsPage from '../../pages/appointments/appointment/appointmentDetailsPage'
 import ExtraInformationPage from '../../pages/appointments/create-and-edit/extraInformationPage'
 import SchedulePage from '../../pages/appointments/create-and-edit/schedulePage'
+import TierPage from '../../pages/appointments/create-and-edit/tierPage'
+import HostPage from '../../pages/appointments/create-and-edit/hostPage'
 
 context('Create individual appointment', () => {
   const tomorrow = addDays(new Date(), 1)
@@ -72,6 +74,14 @@ context('Create individual appointment', () => {
     namePage.selectCategory('Chaplaincy')
     namePage.continue()
 
+    const tierPage = Page.verifyOnPage(TierPage)
+    tierPage.selectTier('Tier 2')
+    tierPage.continue()
+
+    const hostPage = Page.verifyOnPage(HostPage)
+    hostPage.selectHost('Prison staff')
+    hostPage.continue()
+
     const locationPage = Page.verifyOnPage(LocationPage)
     locationPage.selectLocation('Chapel')
     locationPage.continue()
@@ -96,6 +106,8 @@ context('Create individual appointment', () => {
     const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage)
     checkAnswersPage.assertPrisonerSummary('Stephen Gregs', 'A8644DY', '1-3')
     checkAnswersPage.assertCategory('Chaplaincy')
+    checkAnswersPage.assertTier('Tier 2')
+    checkAnswersPage.assertHost('Prison staff')
     checkAnswersPage.assertLocation('Chapel')
     checkAnswersPage.assertStartDate(tomorrow)
     checkAnswersPage.assertStartTime(14, 0)

--- a/integration_tests/e2e/appointments/createIndividualAppointmentBackLinks.cy.ts
+++ b/integration_tests/e2e/appointments/createIndividualAppointmentBackLinks.cy.ts
@@ -21,6 +21,8 @@ import ExtraInformationPage from '../../pages/appointments/create-and-edit/extra
 import RepeatFrequencyAndCountPage from '../../pages/appointments/create-and-edit/repeatFrequencyAndCountPage'
 import { formatDate } from '../../../server/utils/utils'
 import SchedulePage from '../../pages/appointments/create-and-edit/schedulePage'
+import TierPage from '../../pages/appointments/create-and-edit/tierPage'
+import HostPage from '../../pages/appointments/create-and-edit/hostPage'
 
 context('Create individual appointment - back links', () => {
   const tomorrow = addDays(new Date(), 1)
@@ -67,6 +69,14 @@ context('Create individual appointment - back links', () => {
     namePage.selectCategory('Chaplaincy')
     namePage.continue()
 
+    const tierPage = Page.verifyOnPage(TierPage)
+    tierPage.selectTier('Tier 2')
+    tierPage.continue()
+
+    const hostPage = Page.verifyOnPage(HostPage)
+    hostPage.selectHost('Prison staff')
+    hostPage.continue()
+
     const locationPage = Page.verifyOnPage(LocationPage)
     locationPage.selectLocation('Chapel')
     locationPage.continue()
@@ -105,6 +115,14 @@ context('Create individual appointment - back links', () => {
     locationPage.assertSelectedLocation('Chapel')
 
     locationPage.back()
+    Page.verifyOnPage(HostPage)
+    hostPage.assertHost('Prison staff')
+
+    hostPage.back()
+    Page.verifyOnPage(TierPage)
+    tierPage.assertTier('Tier 2')
+
+    tierPage.back()
     Page.verifyOnPage(NamePage)
     namePage.assertSelectedCategory('Chaplaincy')
 
@@ -115,6 +133,8 @@ context('Create individual appointment - back links', () => {
     // Continue to extra information page
     selectPrisonerPage.continue()
     namePage.continue()
+    tierPage.continue()
+    hostPage.continue()
     locationPage.continue()
     dateAndTimePage.continue()
     repeatPage.continue()
@@ -135,6 +155,16 @@ context('Create individual appointment - back links', () => {
     checkAnswersPage.changeName()
     Page.verifyOnPage(NamePage)
     namePage.back()
+    Page.verifyOnPage(CheckAnswersPage)
+
+    checkAnswersPage.changeTier()
+    Page.verifyOnPage(TierPage)
+    tierPage.back()
+    Page.verifyOnPage(CheckAnswersPage)
+
+    checkAnswersPage.changeHost()
+    Page.verifyOnPage(HostPage)
+    hostPage.back()
     Page.verifyOnPage(CheckAnswersPage)
 
     checkAnswersPage.changeLocation()

--- a/integration_tests/e2e/appointments/createIndividualAppointmentCheckAnswers.cy.ts
+++ b/integration_tests/e2e/appointments/createIndividualAppointmentCheckAnswers.cy.ts
@@ -23,6 +23,8 @@ import { formatDate } from '../../../server/utils/utils'
 import ExtraInformationPage from '../../pages/appointments/create-and-edit/extraInformationPage'
 import RepeatFrequencyAndCountPage from '../../pages/appointments/create-and-edit/repeatFrequencyAndCountPage'
 import SchedulePage from '../../pages/appointments/create-and-edit/schedulePage'
+import TierPage from '../../pages/appointments/create-and-edit/tierPage'
+import HostPage from '../../pages/appointments/create-and-edit/hostPage'
 
 context('Create individual appointment - check answers change links', () => {
   const tomorrow = addDays(new Date(), 1)
@@ -80,6 +82,14 @@ context('Create individual appointment - check answers change links', () => {
     const namePage = Page.verifyOnPage(NamePage)
     namePage.selectCategory('Chaplaincy')
     namePage.continue()
+
+    const tierPage = Page.verifyOnPage(TierPage)
+    tierPage.selectTier('Tier 2')
+    tierPage.continue()
+
+    const hostPage = Page.verifyOnPage(HostPage)
+    hostPage.selectHost('Prison staff')
+    hostPage.continue()
 
     const locationPage = Page.verifyOnPage(LocationPage)
     locationPage.selectLocation('Chapel')

--- a/integration_tests/e2e/appointments/createIndividualRepeatAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createIndividualRepeatAppointment.cy.ts
@@ -25,6 +25,8 @@ import AppointmentDetailsPage from '../../pages/appointments/appointment/appoint
 import AppointmentMovementSlipPage from '../../pages/appointments/appointment/appointmentMovementSlipPage'
 import ExtraInformationPage from '../../pages/appointments/create-and-edit/extraInformationPage'
 import SchedulePage from '../../pages/appointments/create-and-edit/schedulePage'
+import TierPage from '../../pages/appointments/create-and-edit/tierPage'
+import HostPage from '../../pages/appointments/create-and-edit/hostPage'
 
 context('Individual repeat appointment', () => {
   const tomorrow = addDays(new Date(), 1)
@@ -74,6 +76,14 @@ context('Individual repeat appointment', () => {
     const namePage = Page.verifyOnPage(NamePage)
     namePage.selectCategory('Chaplaincy')
     namePage.continue()
+
+    const tierPage = Page.verifyOnPage(TierPage)
+    tierPage.selectTier('Tier 2')
+    tierPage.continue()
+
+    const hostPage = Page.verifyOnPage(HostPage)
+    hostPage.selectHost('Prison staff')
+    hostPage.continue()
 
     const locationPage = Page.verifyOnPage(LocationPage)
     locationPage.selectLocation('Chapel')

--- a/integration_tests/pages/appointments/create-and-edit/checkAnswersPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/checkAnswersPage.ts
@@ -9,6 +9,11 @@ export default class CheckAnswersPage extends Page {
   assertAppointmentDetail = (header: string, value: string) =>
     this.assertSummaryListValue('appointment-details', header, value)
 
+  assertScheduleDetail = (header: string, value: string) =>
+    this.assertSummaryListValue('scheduling-information', header, value)
+
+  assertExtraDetail = (header: string, value: string) => this.assertSummaryListValue('extra-information', header, value)
+
   assertPrisonerSummary = (name: string, number: string, cellLocation: string) => {
     cy.get('[data-qa=prisoner-name]').contains(name)
     cy.get('[data-qa=prisoner-number]').contains(number)
@@ -26,27 +31,35 @@ export default class CheckAnswersPage extends Page {
 
   assertCategory = (category: string) => this.assertAppointmentDetail('Appointment name', category)
 
-  assertLocation = (location: string) => this.assertAppointmentDetail('Location', location)
+  assertTier = (tier: string) => this.assertAppointmentDetail('Tier', tier)
 
-  assertStartDate = (startDate: Date) => this.assertAppointmentDetail('Date', format(startDate, 'EEEE, d MMMM yyyy'))
+  assertHost = (host: string) => this.assertAppointmentDetail('Host', host)
+
+  assertLocation = (location: string) => this.assertScheduleDetail('Location', location)
+
+  assertStartDate = (startDate: Date) => this.assertScheduleDetail('Date', format(startDate, 'EEEE, d MMMM yyyy'))
 
   assertStartTime = (hour: number, minute: number) =>
-    this.assertAppointmentDetail('Start time', `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`)
+    this.assertScheduleDetail('Start time', `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`)
 
   assertEndTime = (hour: number, minute: number) =>
-    this.assertAppointmentDetail('End time', `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`)
+    this.assertScheduleDetail('End time', `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`)
 
-  assertRepeat = (option: string) => this.assertAppointmentDetail('Repeats', option)
+  assertRepeat = (option: string) => this.assertScheduleDetail('Repeats', option)
 
-  assertFrequency = (option: string) => this.assertAppointmentDetail('Frequency', option)
+  assertFrequency = (option: string) => this.assertScheduleDetail('Frequency', option)
 
-  assertNumberOfAppointments = (option: string) => this.assertAppointmentDetail('Number of appointments', option)
+  assertNumberOfAppointments = (option: string) => this.assertScheduleDetail('Number of appointments', option)
 
-  assertExtraInformation = (comment: string) => this.assertAppointmentDetail('Extra information', comment)
+  assertExtraInformation = (comment: string) => this.assertExtraDetail('Extra information', comment)
 
   changePrisoner = () => cy.get('[data-qa=change-prisoner]').click()
 
   changeName = () => cy.get('[data-qa=change-name]').click()
+
+  changeTier = () => cy.get('[data-qa=change-tier]').click()
+
+  changeHost = () => cy.get('[data-qa=change-host]').click()
 
   changeLocation = () => cy.get('[data-qa=change-location]').click()
 

--- a/integration_tests/pages/appointments/create-and-edit/hostPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/hostPage.ts
@@ -1,0 +1,11 @@
+import Page from '../../page'
+
+export default class HostPage extends Page {
+  constructor() {
+    super('appointment-host-page')
+  }
+
+  selectHost = (host: string) => this.getInputByLabel(host).click()
+
+  assertHost = (host: string) => cy.get(`[name='host']:checked`).next().should('contain.text', host)
+}

--- a/integration_tests/pages/appointments/create-and-edit/tierPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/tierPage.ts
@@ -1,0 +1,11 @@
+import Page from '../../page'
+
+export default class TierPage extends Page {
+  constructor() {
+    super('appointment-tier-page')
+  }
+
+  selectTier = (tier: string) => this.getInputByLabel(tier).click()
+
+  assertTier = (tier: string) => cy.get(`[name='tier']:checked`).next().should('contain.text', tier)
+}

--- a/server/@types/activitiesAPI/index.d.ts
+++ b/server/@types/activitiesAPI/index.d.ts
@@ -1125,6 +1125,8 @@ export interface components {
        * @example CHAP
        */
       categoryCode: string
+      tier?: components['schemas']['EventTier']
+      organiser?: components['schemas']['EventOrganiser']
       /**
        * @description
        *     Free text name further describing the appointment. Used as part of the appointment name with the
@@ -1360,6 +1362,8 @@ export interface components {
        * @example CHAP
        */
       categoryCode: string
+      tier?: components['schemas']['EventTier']
+      organiser?: components['schemas']['EventOrganiser']
       /**
        * @description
        *     Free text name further describing the appointment series. Used as part of the appointment name with the
@@ -1476,6 +1480,44 @@ export interface components {
        */
       numberOfAppointments: number
     }
+    /** @description An event organiser */
+    EventOrganiser: {
+      /**
+       * Format: int64
+       * @description The internally-generated ID for this event organiser
+       * @example 1
+       */
+      id: number
+      /**
+       * @description The code for this event organiser
+       * @example PRISON_STAFF
+       */
+      code: string
+      /**
+       * @description The detailed description for this event organiser
+       * @example Prison staff
+       */
+      description: string
+    }
+    /** @description An event tier */
+    EventTier: {
+      /**
+       * Format: int64
+       * @description The internally-generated ID for this event tier
+       * @example 1
+       */
+      id: number
+      /**
+       * @description The code for this event tier
+       * @example TIER_1
+       */
+      code: string
+      /**
+       * @description The detailed description for this event tier
+       * @example Work, education and maintenance
+       */
+      description: string
+    }
     /** @description The lists of prison numbers to mark as attended and non-attended */
     AppointmentAttendanceRequest: {
       /**
@@ -1541,10 +1583,10 @@ export interface components {
       unpaged?: boolean
     }
     PagedWaitingListApplication: {
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
       first?: boolean
       last?: boolean
       /** Format: int32 */
@@ -1553,9 +1595,9 @@ export interface components {
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     SortObject: {
@@ -1683,6 +1725,35 @@ export interface components {
        * @example 2023-09-10
        */
       endDate?: string
+      /** @description The days and times that the prisoner is excluded from this activity's schedule */
+      exclusions?: components['schemas']['Slot'][]
+    }
+    /**
+     * @description
+     *     Describes time slot and day (or days) the scheduled activity would run. At least one day must be specified.
+     *
+     *     e.g. 'AM, Monday, Wednesday and Friday' or 'PM Tuesday, Thursday, Sunday'
+     */
+    Slot: {
+      /**
+       * Format: int32
+       * @description The week of the schedule this slot relates to
+       * @example 1
+       */
+      weekNumber: number
+      /**
+       * @description The time slot of the activity schedule, morning afternoon or evening e.g. AM, PM or ED
+       * @example AM
+       */
+      timeSlot: string
+      monday: boolean
+      tuesday: boolean
+      wednesday: boolean
+      thursday: boolean
+      friday: boolean
+      saturday: boolean
+      sunday: boolean
+      daysOfWeek: ('MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY')[]
     }
     /** @description Describes a prisons scheduled events */
     PrisonerScheduledEvents: {
@@ -1998,6 +2069,8 @@ export interface components {
        */
       status: 'ACTIVE' | 'PENDING' | 'SUSPENDED' | 'AUTO_SUSPENDED' | 'ENDED'
       plannedDeallocation?: components['schemas']['PlannedDeallocation']
+      /** @description The days and times that the prisoner is excluded from this activity's schedule. All values must match a slot where the activity is scheduled to run, and due to sync to nomis, there can not not be exclusions defined on the same day and time slot over multiple weeks. */
+      exclusions?: components['schemas']['Slot'][]
       /** @description The name of the prisoner. Included only if includePrisonerSummary = true */
       prisonerName?: string
       /** @description The cell location of the prisoner. Included only if includePrisonerSummary = true */
@@ -2173,6 +2246,8 @@ export interface components {
        * @example true
        */
       suspendedFlag: boolean
+      /** @description The days and times that the prisoner is excluded from this activity's schedule. All values must match a slot where the activity is scheduled to run, and due to sync to nomis, there can not not be exclusions defined on the same day and time slot over multiple weeks. */
+      exclusions?: components['schemas']['Slot'][]
     }
     /** @description Response for a successful migration of one allocation to an activity */
     AllocationMigrateResponse: {
@@ -2637,6 +2712,7 @@ export interface components {
         | 'PRISONER_DECLINED_FROM_WAITING_LIST'
         | 'PRISONER_SUSPENDED_FROM_ACTIVITY'
         | 'PRISONER_UNSUSPENDED_FROM_ACTIVITY'
+        | 'PRISONER_MERGE'
       /**
        * Format: date-time
        * @description The date and time on or after which to search for events
@@ -2702,6 +2778,7 @@ export interface components {
         | 'PRISONER_DECLINED_FROM_WAITING_LIST'
         | 'PRISONER_SUSPENDED_FROM_ACTIVITY'
         | 'PRISONER_UNSUSPENDED_FROM_ACTIVITY'
+        | 'PRISONER_MERGE'
       /**
        * Format: date-time
        * @description The date and time at which this event occurred
@@ -3059,6 +3136,16 @@ export interface components {
        */
       categoryCode: string
       /**
+       * @description The tier code for this appointment
+       * @example TIER_1
+       */
+      tierCode: string
+      /**
+       * @description The organiser code for this appointment
+       * @example PRISON_STAFF
+       */
+      organiserCode?: string
+      /**
        * @description
        *     Free text name further describing the appointment series. Will be used to create the appointment name using the
        *     format "Custom name (Category description) if specified.
@@ -3117,6 +3204,8 @@ export interface components {
        * @example CHAP
        */
       categoryCode: string
+      tier?: components['schemas']['EventTier']
+      organiser?: components['schemas']['EventOrganiser']
       /**
        * @description
        *     Free text name further describing the appointment set. Used as part of the appointment name with the
@@ -3188,6 +3277,16 @@ export interface components {
        * @example CHAP
        */
       categoryCode: string
+      /**
+       * @description The tier code for this appointment
+       * @example TIER_1
+       */
+      tierCode: string
+      /**
+       * @description The organiser code for this appointment
+       * @example PRISON_STAFF
+       */
+      organiserCode?: string
       /**
        * @description
        *     Free text name further describing the appointment series. Will be used to create the appointment name using the
@@ -3470,33 +3569,6 @@ export interface components {
        * @example 10
        */
       pieceRateItems?: number
-    }
-    /**
-     * @description
-     *     Describes time slot and day (or days) the scheduled activity would run. At least one day must be specified.
-     *
-     *     e.g. 'AM, Monday, Wednesday and Friday' or 'PM Tuesday, Thursday, Sunday'
-     */
-    Slot: {
-      /**
-       * Format: int32
-       * @description The week of the schedule this slot relates to
-       * @example 1
-       */
-      weekNumber: number
-      /**
-       * @description The time slot of the activity schedule, morning afternoon or evening e.g. AM, PM or ED
-       * @example AM
-       */
-      timeSlot: string
-      monday: boolean
-      tuesday: boolean
-      wednesday: boolean
-      thursday: boolean
-      friday: boolean
-      saturday: boolean
-      sunday: boolean
-      daysOfWeek: ('MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY')[]
     }
     /** @description Describes a top-level activity */
     Activity: {
@@ -4179,44 +4251,6 @@ export interface components {
        */
       description: string
     }
-    /** @description An event organiser */
-    EventOrganiser: {
-      /**
-       * Format: int64
-       * @description The internally-generated ID for this event organiser
-       * @example 1
-       */
-      id: number
-      /**
-       * @description The code for this event organiser
-       * @example PRISON_STAFF
-       */
-      code: string
-      /**
-       * @description The detailed description for this event organiser
-       * @example Prison staff
-       */
-      description: string
-    }
-    /** @description An event tier */
-    EventTier: {
-      /**
-       * Format: int64
-       * @description The internally-generated ID for this event tier
-       * @example 1
-       */
-      id: number
-      /**
-       * @description The code for this event tier
-       * @example TIER_1
-       */
-      code: string
-      /**
-       * @description The detailed description for this event tier
-       * @example Work, education and maintenance
-       */
-      description: string
-    }
     /**
      * @description An internal NOMIS location for an activity to take place
      * @example 98877667
@@ -4337,6 +4371,16 @@ export interface components {
        */
       categoryCode?: string
       /**
+       * @description The tier code for this appointment
+       * @example TIER_1
+       */
+      tierCode?: string
+      /**
+       * @description The organiser code for this appointment
+       * @example PRISON_STAFF
+       */
+      organiserCode?: string
+      /**
        * Format: int64
        * @description
        *     The updated NOMIS internal location id within the specified prison. This must be supplied if inCell is false.
@@ -4447,6 +4491,8 @@ export interface components {
        * @description Where a prison uses pay bands to differentiate earnings, this is the pay band given to this prisoner
        */
       payBandId?: number
+      /** @description The days and times that the prisoner is excluded from this activity's schedule. All values must match a slot where the activity is scheduled to run, and due to sync to nomis, there can not not be exclusions defined on the same day and time slot over multiple weeks. */
+      exclusions?: components['schemas']['Slot'][]
     }
     /** @description The update request with the new activity details */
     ActivityUpdateRequest: {
@@ -5028,10 +5074,10 @@ export interface components {
       earliestReleaseDate: components['schemas']['EarliestReleaseDate']
     }
     PageActivityCandidate: {
-      /** Format: int32 */
-      totalPages?: number
       /** Format: int64 */
       totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
       first?: boolean
       last?: boolean
       /** Format: int32 */
@@ -5040,9 +5086,9 @@ export interface components {
       /** Format: int32 */
       number?: number
       sort?: components['schemas']['SortObject']
-      pageable?: components['schemas']['PageableObject']
       /** Format: int32 */
       numberOfElements?: number
+      pageable?: components['schemas']['PageableObject']
       empty?: boolean
     }
     /** @description Describes one instance of an activity schedule */
@@ -5778,8 +5824,9 @@ export interface components {
       notRecordedCount: number
       /**
        * @description
-       *     Summary of the prisoner or prisoners attending this appointment and their attendance record if any.
-       *     Attendees are at the appointment level to allow for per appointment attendee changes.
+       *     The prisoner or prisoners attending this appointment. Appointments of type INDIVIDUAL will have one
+       *     prisoner attending each appointment. Appointments of type GROUP can have more than one prisoner
+       *     attending each appointment
        */
       attendees: components['schemas']['AppointmentAttendeeSearchResult'][]
     }
@@ -5862,6 +5909,8 @@ export interface components {
        */
       attendees: components['schemas']['AppointmentAttendeeSummary'][]
       category: components['schemas']['AppointmentCategorySummary']
+      tier?: components['schemas']['EventTier']
+      organiser?: components['schemas']['EventOrganiser']
       /**
        * @description
        *     Free text name further describing the appointment. Used as part of the appointment name with the
@@ -6179,6 +6228,8 @@ export interface components {
        */
       appointmentName: string
       category: components['schemas']['AppointmentCategorySummary']
+      tier?: components['schemas']['EventTier']
+      organiser?: components['schemas']['EventOrganiser']
       /**
        * @description
        *     Free text name further describing the appointment series. Used as part of the appointment name with the
@@ -8355,12 +8406,15 @@ export interface operations {
    */
   getScheduledAttendeesByScheduledInstance: {
     parameters: {
+      header?: {
+        'Caseload-Id'?: string
+      }
       path: {
         instanceId: number
       }
     }
     responses: {
-      /** @description Scheduled instance found */
+      /** @description Scheduled attendees found */
       200: {
         content: {
           'application/json': components['schemas']['ScheduledAttendee'][]

--- a/server/routes/appointments/create-and-edit/appointmentJourney.ts
+++ b/server/routes/appointments/create-and-edit/appointmentJourney.ts
@@ -26,6 +26,8 @@ export type AppointmentJourney = {
     code: string
     description: string
   }
+  tierCode?: string
+  organiserCode?: string
   customName?: string
   location?: {
     id: number

--- a/server/routes/appointments/create-and-edit/createRoutes.ts
+++ b/server/routes/appointments/create-and-edit/createRoutes.ts
@@ -29,6 +29,8 @@ import AppointmentSetDateRoutes, { AppointmentSetDate } from './handlers/appoint
 import AppointmentSetTimesRoutes, { AppointmentTimes } from './handlers/appointment-set/appointmentSetTimes'
 import fetchAppointmentSet from '../../../middleware/appointments/fetchAppointmentSet'
 import ScheduleRoutes from './handlers/schedule'
+import TierRoutes, { TierForm } from './handlers/tier'
+import HostRoutes, { HostForm } from './handlers/host'
 
 export default function Create({ prisonService, activitiesService, metricsService }: Services): Router {
   const router = Router({ mergeParams: true })
@@ -43,6 +45,8 @@ export default function Create({ prisonService, activitiesService, metricsServic
   const selectPrisonerRoutes = new SelectPrisonerRoutes(prisonService)
   const uploadPrisonerListRoutes = new UploadPrisonerListRoutes(new PrisonerListCsvParser(), prisonService)
   const nameRoutes = new NameRoutes(activitiesService)
+  const tierRoutes = new TierRoutes()
+  const hostRoutes = new HostRoutes()
   const locationRoutes = new LocationRoutes(activitiesService, editAppointmentService)
   const dateAndTimeRoutes = new DateAndTimeRoutes()
   const repeatRoutes = new RepeatRoutes()
@@ -82,6 +86,10 @@ export default function Create({ prisonService, activitiesService, metricsServic
   )
   get('/name', nameRoutes.GET, true)
   post('/name', nameRoutes.POST, Name)
+  get('/tier', tierRoutes.GET, true)
+  post('/tier', tierRoutes.CREATE, TierForm)
+  get('/host', hostRoutes.GET, true)
+  post('/host', hostRoutes.CREATE, HostForm)
   get('/location', locationRoutes.GET, true)
   post('/location', locationRoutes.CREATE, Location)
   get('/date-and-time', dateAndTimeRoutes.GET, true)

--- a/server/routes/appointments/create-and-edit/handlers/checkAnswers.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/checkAnswers.test.ts
@@ -15,6 +15,8 @@ import { YesNo } from '../../../../@types/activities'
 import { AppointmentFrequency } from '../../../../@types/appointments'
 import { AppointmentType } from '../appointmentJourney'
 import { AppointmentSetJourney } from '../appointmentSetJourney'
+import { organiserDescriptions } from '../../../../enum/eventOrganisers'
+import { eventTierDescriptions } from '../../../../enum/eventTiers'
 
 jest.mock('../../../../services/activitiesService')
 
@@ -67,6 +69,8 @@ describe('Route Handlers - Create Appointment - Check answers', () => {
             minute: 0,
             date: '2023-04-23T13:00:00.000+0100',
           },
+          tierCode: 'TIER_2',
+          organiserCode: 'PRISON_STAFF',
           repeat: YesNo.NO,
         },
         appointmentSetJourney: {},
@@ -81,7 +85,10 @@ describe('Route Handlers - Create Appointment - Check answers', () => {
   describe('GET', () => {
     it('should render the check answers page with data from session', async () => {
       await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/check-answers')
+      expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/check-answers', {
+        tier: eventTierDescriptions.TIER_2,
+        organiser: organiserDescriptions.PRISON_STAFF,
+      })
     })
   })
 
@@ -100,6 +107,8 @@ describe('Route Handlers - Create Appointment - Check answers', () => {
         startTime: '09:30',
         endTime: '13:00',
         prisonerNumbers: ['A1234BC'],
+        tierCode: 'TIER_2',
+        organiserCode: 'PRISON_STAFF',
       } as AppointmentSeriesCreateRequest
 
       expectedResponse = {
@@ -221,6 +230,8 @@ describe('Route Handlers - Create Appointment - Check answers', () => {
             extraInformation: 'Extra information for B2345CD',
           } as AppointmentSetAppointment,
         ],
+        tierCode: 'TIER_2',
+        organiserCode: 'PRISON_STAFF',
       } as AppointmentSetCreateRequest
 
       expectedResponse = {

--- a/server/routes/appointments/create-and-edit/handlers/checkAnswers.ts
+++ b/server/routes/appointments/create-and-edit/handlers/checkAnswers.ts
@@ -5,13 +5,21 @@ import SimpleTime from '../../../../commonValidationTypes/simpleTime'
 import { AppointmentSeriesCreateRequest, AppointmentSetCreateRequest } from '../../../../@types/activitiesAPI/types'
 import { YesNo } from '../../../../@types/activities'
 import { AppointmentType } from '../appointmentJourney'
+import { eventTierDescriptions } from '../../../../enum/eventTiers'
+import { organiserDescriptions } from '../../../../enum/eventOrganisers'
 
 export default class CheckAnswersRoutes {
   constructor(private readonly activitiesService: ActivitiesService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
+    const { appointmentJourney } = req.session
+
     req.session.appointmentJourney.createJourneyComplete = true
-    res.render('pages/appointments/create-and-edit/check-answers')
+
+    res.render('pages/appointments/create-and-edit/check-answers', {
+      tier: eventTierDescriptions[appointmentJourney.tierCode],
+      organiser: organiserDescriptions[appointmentJourney.organiserCode],
+    })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
@@ -39,6 +47,8 @@ export default class CheckAnswersRoutes {
       prisonCode: user.activeCaseLoadId,
       prisonerNumbers: appointmentJourney.prisoners.map(p => p.number),
       categoryCode: appointmentJourney.category.code,
+      tierCode: appointmentJourney.tierCode,
+      organiserCode: appointmentJourney.organiserCode,
       customName: appointmentJourney.customName,
       internalLocationId: appointmentJourney.location.id,
       inCell: false,
@@ -65,6 +75,8 @@ export default class CheckAnswersRoutes {
     return {
       prisonCode: user.activeCaseLoadId,
       categoryCode: appointmentJourney.category.code,
+      tierCode: appointmentJourney.tierCode,
+      organiserCode: appointmentJourney.organiserCode,
       customName: appointmentJourney.customName,
       internalLocationId: appointmentJourney.location.id,
       inCell: false,

--- a/server/routes/appointments/create-and-edit/handlers/host.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/host.test.ts
@@ -1,0 +1,95 @@
+import { Request, Response } from 'express'
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import { associateErrorsWithProperty } from '../../../../utils/utils'
+import OrganiserRoutes, { HostForm } from './host'
+import Organiser, { organiserDescriptions } from '../../../../enum/eventOrganisers'
+
+describe('Route Handlers - Create Appointment - Host', () => {
+  const handler = new OrganiserRoutes()
+  let req: Request
+  let res: Response
+
+  const user = {
+    username: 'joebloggs',
+    activeCaseLoadId: 'MDI',
+  }
+
+  beforeEach(() => {
+    res = {
+      locals: {
+        user,
+      },
+      render: jest.fn(),
+      redirectOrReturn: jest.fn(),
+      redirectWithSuccess: jest.fn(),
+    } as unknown as Response
+
+    req = {
+      params: {},
+      session: {
+        appointmentJourney: {},
+      },
+    } as unknown as Request
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('GET', () => {
+    it('should render the expected view', async () => {
+      await handler.GET(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/host', {
+        organiserDescriptions,
+      })
+    })
+  })
+
+  describe('CREATE', () => {
+    it('should save selected organiser in session and redirect to location page', async () => {
+      req.body = {
+        host: Organiser.PRISONER,
+      }
+
+      await handler.CREATE(req, res)
+
+      expect(req.session.appointmentJourney.organiserCode).toEqual(Organiser.PRISONER)
+      expect(res.redirectOrReturn).toHaveBeenCalledWith('location')
+    })
+  })
+
+  describe('type validation', () => {
+    it('validation fails if a value is not entered', async () => {
+      const body = {}
+
+      const requestObject = plainToInstance(HostForm, body)
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+      expect(errors).toEqual(expect.arrayContaining([{ property: 'host', error: 'Select an appointment host' }]))
+    })
+
+    it('validation fails if a bad value is entered', async () => {
+      const body = {
+        host: 'invalid',
+      }
+
+      const requestObject = plainToInstance(HostForm, body)
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+      expect(errors).toEqual(expect.arrayContaining([{ property: 'host', error: 'Select an appointment host' }]))
+    })
+
+    it('passes validation', async () => {
+      const body = {
+        host: Organiser.EXTERNAL_PROVIDER,
+      }
+
+      const requestObject = plainToInstance(HostForm, body)
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+      expect(errors).toHaveLength(0)
+    })
+  })
+})

--- a/server/routes/appointments/create-and-edit/handlers/host.ts
+++ b/server/routes/appointments/create-and-edit/handlers/host.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express'
+import { Expose } from 'class-transformer'
+import { IsEnum } from 'class-validator'
+import Organiser, { organiserDescriptions } from '../../../../enum/eventOrganisers'
+
+export class HostForm {
+  @Expose()
+  @IsEnum(Organiser, { message: 'Select an appointment host' })
+  host: string
+}
+
+export default class HostRoutes {
+  GET = async (req: Request, res: Response): Promise<void> =>
+    res.render('pages/appointments/create-and-edit/host', { organiserDescriptions })
+
+  CREATE = async (req: Request, res: Response): Promise<void> => {
+    const { host }: HostForm = req.body
+
+    req.session.appointmentJourney.organiserCode = host
+
+    return res.redirectOrReturn('location')
+  }
+}

--- a/server/routes/appointments/create-and-edit/handlers/name.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/name.test.ts
@@ -119,7 +119,7 @@ describe('Route Handlers - Create Appointment - Name', () => {
   })
 
   describe('POST', () => {
-    it('should save selected category in session, use category description as appointment name and redirect to location page', async () => {
+    it('should save selected category in session, use category description as appointment name and redirect to tier page', async () => {
       req.body = {
         categoryCode: 'MEDO',
         description: '',
@@ -135,7 +135,7 @@ describe('Route Handlers - Create Appointment - Name', () => {
         description: 'Medical - Doctor',
       })
       expect(req.session.appointmentJourney.customName).toBeNull()
-      expect(res.redirectOrReturn).toHaveBeenCalledWith('location')
+      expect(res.redirectOrReturn).toHaveBeenCalledWith('tier')
     })
 
     it('should save selected category and custom name in session, use custom name and category description as appointment name and redirect to location page', async () => {
@@ -154,7 +154,7 @@ describe('Route Handlers - Create Appointment - Name', () => {
         description: 'Chaplaincy',
       })
       expect(req.session.appointmentJourney.customName).toEqual('Bible studies')
-      expect(res.redirectOrReturn).toHaveBeenCalledWith('location')
+      expect(res.redirectOrReturn).toHaveBeenCalledWith('tier')
     })
 
     it('should trim custom name', async () => {

--- a/server/routes/appointments/create-and-edit/handlers/name.ts
+++ b/server/routes/appointments/create-and-edit/handlers/name.ts
@@ -59,6 +59,6 @@ export default class NameRoutes {
       req.session.appointmentJourney.appointmentName = category.description
     }
 
-    return res.redirectOrReturn('location')
+    return res.redirectOrReturn('tier')
   }
 }

--- a/server/routes/appointments/create-and-edit/handlers/tier.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/tier.test.ts
@@ -1,0 +1,120 @@
+import { Request, Response } from 'express'
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import { associateErrorsWithProperty } from '../../../../utils/utils'
+import TierRoutes, { TierForm } from './tier'
+import EventTier, { eventTierDescriptions } from '../../../../enum/eventTiers'
+import Organiser from '../../../../enum/eventOrganisers'
+
+describe('Route Handlers - Create Appointment - Tier', () => {
+  const handler = new TierRoutes()
+  let req: Request
+  let res: Response
+
+  const user = {
+    username: 'joebloggs',
+    activeCaseLoadId: 'MDI',
+  }
+
+  beforeEach(() => {
+    res = {
+      locals: {
+        user,
+      },
+      render: jest.fn(),
+      redirect: jest.fn(),
+      redirectOrReturn: jest.fn(),
+      redirectWithSuccess: jest.fn(),
+    } as unknown as Response
+
+    req = {
+      params: {},
+      query: {},
+      session: {
+        appointmentJourney: {},
+      },
+    } as unknown as Request
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('GET', () => {
+    it('should render the expected view', async () => {
+      await handler.GET(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/tier', {
+        eventTierDescriptions,
+      })
+    })
+  })
+
+  describe('CREATE', () => {
+    it('should save selected tier in session and redirect to location page', async () => {
+      req.body = {
+        tier: EventTier.TIER_1,
+      }
+
+      await handler.CREATE(req, res)
+
+      expect(req.session.appointmentJourney.tierCode).toEqual(EventTier.TIER_1)
+      expect(res.redirectOrReturn).toHaveBeenCalledWith('location')
+    })
+
+    it('should save selected tier in session and redirect to host page if tier 2 selected', async () => {
+      req.body = {
+        tier: EventTier.TIER_2,
+      }
+
+      await handler.CREATE(req, res)
+
+      expect(req.session.appointmentJourney.tierCode).toEqual(EventTier.TIER_2)
+      expect(res.redirect).toHaveBeenCalledWith('host')
+    })
+
+    it('should remove organiser if tier 2 not selected', async () => {
+      req.body = {
+        tier: EventTier.TIER_1,
+      }
+      req.session.appointmentJourney.organiserCode = Organiser.PRISON_STAFF
+
+      await handler.CREATE(req, res)
+
+      expect(req.session.appointmentJourney.organiserCode).toBeNull()
+    })
+  })
+
+  describe('type validation', () => {
+    it('validation fails if a value is not entered', async () => {
+      const body = {}
+
+      const requestObject = plainToInstance(TierForm, body)
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+      expect(errors).toEqual(expect.arrayContaining([{ property: 'tier', error: 'Select an appointment tier' }]))
+    })
+
+    it('validation fails if a bad value is entered', async () => {
+      const body = {
+        tier: 'invalid',
+      }
+
+      const requestObject = plainToInstance(TierForm, body)
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+      expect(errors).toEqual(expect.arrayContaining([{ property: 'tier', error: 'Select an appointment tier' }]))
+    })
+
+    it('passes validation', async () => {
+      const body = {
+        tier: EventTier.TIER_1,
+      }
+
+      const requestObject = plainToInstance(TierForm, body)
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+      expect(errors).toHaveLength(0)
+    })
+  })
+})

--- a/server/routes/appointments/create-and-edit/handlers/tier.ts
+++ b/server/routes/appointments/create-and-edit/handlers/tier.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express'
+import { Expose } from 'class-transformer'
+import { IsEnum } from 'class-validator'
+import EventTier, { eventTierDescriptions } from '../../../../enum/eventTiers'
+
+export class TierForm {
+  @Expose()
+  @IsEnum(EventTier, { message: 'Select an appointment tier' })
+  tier: string
+}
+
+export default class TierRoutes {
+  GET = async (req: Request, res: Response): Promise<void> =>
+    res.render(`pages/appointments/create-and-edit/tier`, { eventTierDescriptions })
+
+  CREATE = async (req: Request, res: Response): Promise<void> => {
+    const { tier }: TierForm = req.body
+    const { preserveHistory } = req.query
+
+    req.session.appointmentJourney.tierCode = tier
+
+    if (EventTier.TIER_2 === tier) {
+      return res.redirect(`host${preserveHistory ? '?preserveHistory=true' : ''}`)
+    }
+    req.session.appointmentJourney.organiserCode = null
+
+    return res.redirectOrReturn('location')
+  }
+}

--- a/server/views/pages/appointments/create-and-edit/check-answers.njk
+++ b/server/views/pages/appointments/create-and-edit/check-answers.njk
@@ -11,11 +11,11 @@
 {% set pageTitle = appointmentJourneyTitle("Check and confirm set" if session.appointmentJourney.type == AppointmentType.SET else "Check and confirm appointment details", session.appointmentJourney) %}
 {% set pageId = 'appointment-check-answers-page' %}
 
-{% set summaryListRows = [] %}
+{% set appointmentDetailsRows = [] %}
 
 {% if session.appointmentJourney.type == AppointmentType.INDIVIDUAL %}
     {% set prisoner = session.appointmentJourney.prisoners[0] %}
-    {% set summaryListRows = (summaryListRows.push(
+    {% set appointmentDetailsRows = (appointmentDetailsRows.push(
         {
             key: {
                 text: "Attendee"
@@ -40,10 +40,10 @@
                 ]
             }
         }
-    ), summaryListRows) %}
+    ), appointmentDetailsRows) %}
 {% endif %}
 
-{% set summaryListRows = (summaryListRows.push(
+{% set appointmentDetailsRows = (appointmentDetailsRows.push(
     {
         key: {
             text: "Appointment name"
@@ -62,10 +62,47 @@
                 }
             ]
         }
-    }
-), summaryListRows) %}
+    }, {
+        key: {
+            text: "Tier"
+        },
+        value: {
+            text: tier
+        },
+        actions: {
+            items: [
+                {
+                    href: "tier?preserveHistory=true",
+                    text: "Change",
+                    visuallyHiddenText: "change appointment tier",
+                    classes: "govuk-link--no-visited-state",
+                    attributes: { 'data-qa': 'change-tier' }
+                }
+            ]
+        }
+    }, {
+        key: {
+            text: "Host"
+        },
+        value: {
+            text: organiser
+        },
+        actions: {
+            items: [
+                {
+                    href: "host?preserveHistory=true",
+                    text: "Change",
+                    visuallyHiddenText: "change appointment host",
+                    classes: "govuk-link--no-visited-state",
+                    attributes: { 'data-qa': 'change-host' }
+                }
+            ]
+        }
+    } if session.appointmentJourney.organiserCode
+), appointmentDetailsRows) %}
 
-{% set summaryListRows = (summaryListRows.push(
+{% set schedulingInformationRows = [] %}
+{% set schedulingInformationRows = (schedulingInformationRows.push(
     {
         key: {
             text: "Location"
@@ -162,9 +199,9 @@
             ]
         }
     } if session.appointmentJourney.repeat
-), summaryListRows) %}
+), schedulingInformationRows) %}
 {% if session.appointmentJourney.repeat == YesNo.YES %}
-  {% set summaryListRows = (summaryListRows.push({
+  {% set schedulingInformationRows = (schedulingInformationRows.push({
       key: {
           text: "Frequency"
       },
@@ -186,8 +223,8 @@
               }
           ]
       }
-  }), summaryListRows) %}
-  {% set summaryListRows = (summaryListRows.push({
+  }), schedulingInformationRows) %}
+  {% set schedulingInformationRows = (schedulingInformationRows.push({
       key: {
           text: "Number of appointments"
       },
@@ -205,10 +242,12 @@
               }
           ]
       }
-  }), summaryListRows) %}
+  }), schedulingInformationRows) %}
 {% endif %}
+
+{% set extraInfoRows = [] %}
 {% if session.appointmentJourney.type !== AppointmentType.SET %}
-    {% set summaryListRows = (summaryListRows.push(
+    {% set extraInfoRows = (extraInfoRows.push(
         {
             key: {
                 text: "Extra information"
@@ -228,10 +267,10 @@
                 ]
             }
         }
-    ), summaryListRows) %}
+    ), extraInfoRows) %}
 {% endif %}
 {% if session.appointmentJourney.type == AppointmentType.SET %}
-    {% set summaryListRows = (summaryListRows.push(
+    {% set schedulingInformationRows = (schedulingInformationRows.push(
         {
             key: {
                 text: "Appointments created"
@@ -240,22 +279,36 @@
                 text: session.appointmentSetJourney.appointments | length
             }
         }
-    ), summaryListRows) %}
+    ), schedulingInformationRows) %}
 {% endif %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">Check and confirm the appointment details</h1>
-            <h2 class="govuk-heading-m">Appointment details</h2>
 
             <form method="POST" data-module="form-spinner" data-loading-text="Preparing your appointments">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
+                <h2 class="govuk-heading-m">Appointment details</h2>
                 {{ govukSummaryList({
-                    rows: summaryListRows,
+                    rows: appointmentDetailsRows,
                     attributes: { 'data-qa': 'appointment-details' }
                 }) }}
+
+                <h2 class="govuk-heading-m">Scheduling information</h2>
+                {{ govukSummaryList({
+                    rows: schedulingInformationRows,
+                    attributes: { 'data-qa': 'scheduling-information' }
+                }) }}
+
+                {% if extraInfoRows | length %}
+                    <h2 class="govuk-heading-m">Extra information</h2>
+                    {{ govukSummaryList({
+                        rows: extraInfoRows,
+                        attributes: { 'data-qa': 'extra-information' }
+                    }) }}
+                {% endif %}
 
                 {{ prisonersList() if session.appointmentJourney.type == AppointmentType.GROUP }}
 

--- a/server/views/pages/appointments/create-and-edit/check-answers.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/check-answers.njk.test.ts
@@ -12,6 +12,8 @@ import {
 } from '../../../../routes/appointments/create-and-edit/appointmentJourney'
 import { AppointmentFrequency } from '../../../../@types/appointments'
 import { formatIsoDate } from '../../../../utils/datePickerUtils'
+import EventTier, { eventTierDescriptions } from '../../../../enum/eventTiers'
+import EventOrganiser, { organiserDescriptions } from '../../../../enum/eventOrganisers'
 
 let $: CheerioAPI
 const view = fs.readFileSync('server/views/pages/appointments/create-and-edit/check-answers.njk')
@@ -21,13 +23,18 @@ const getAppointmentDetailsValueElement = (heading: string) =>
     .parent()
     .find('.govuk-summary-list__value')
 
+const getSchedulingInformationValueElement = (heading: string) =>
+  $(`[data-qa=scheduling-information] > .govuk-summary-list__row > .govuk-summary-list__key:contains("${heading}")`)
+    .parent()
+    .find('.govuk-summary-list__value')
+
 const getPrisonerDetailsValueElement = (heading: string) =>
   $(`[data-qa=prisoner-details] > .govuk-summary-list__row > .govuk-summary-list__key:contains("${heading}")`)
     .parent()
     .find('.govuk-summary-list__value')
 
-const getFrequencyValueElement = () => getAppointmentDetailsValueElement('Frequency')
-const getNumberOfAppointmentsValueElement = () => getAppointmentDetailsValueElement('Number of appointments')
+const getFrequencyValueElement = () => getSchedulingInformationValueElement('Frequency')
+const getNumberOfAppointmentsValueElement = () => getSchedulingInformationValueElement('Number of appointments')
 const getIndividualPrisonerValueElement = (qaAttr: string) =>
   getAppointmentDetailsValueElement('Attendee').find(`[data-qa="${qaAttr}"]`)
 const getPrisonerListValueElement = (qaAttr: string, index: number) =>
@@ -44,6 +51,8 @@ describe('Views - Create Appointment - Check Answers', () => {
   beforeEach(() => {
     compiledTemplate = nunjucks.compile(view.toString(), njkEnv)
     viewContext = {
+      tier: eventTierDescriptions[EventTier.TIER_2],
+      organiser: organiserDescriptions[EventOrganiser.EXTERNAL_PROVIDER],
       session: {
         appointmentJourney: {
           mode: AppointmentJourneyMode.CREATE,
@@ -64,6 +73,8 @@ describe('Views - Create Appointment - Check Answers', () => {
             hour: 10,
             minute: 0,
           },
+          tierCode: EventTier.TIER_2,
+          organiserCode: EventOrganiser.EXTERNAL_PROVIDER,
         } as AppointmentJourney,
       },
     }
@@ -77,6 +88,13 @@ describe('Views - Create Appointment - Check Answers', () => {
     $ = cheerio.load(compiledTemplate.render(viewContext))
 
     expect(getAppointmentDetailsValueElement('Appointment name').text().trim()).toBe('Bible studies (Chaplaincy)')
+  })
+
+  it('should display appointment tier & organiser information', () => {
+    $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect(getAppointmentDetailsValueElement('Tier').text().trim()).toBe('Tier 2')
+    expect(getAppointmentDetailsValueElement('Host').text().trim()).toBe('An external provider')
   })
 
   it('should not display repeat frequency or number of appointments when repeat = NO', () => {

--- a/server/views/pages/appointments/create-and-edit/host.njk
+++ b/server/views/pages/appointments/create-and-edit/host.njk
@@ -1,0 +1,54 @@
+{% extends "layout.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
+{% from "pages/appointments/partials/appointment-type-caption.njk" import appointmentTypeCaption %}
+{% from "partials/activities/activity-journey-caption.njk" import activityJourneyCaption %}
+
+{% if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT %}
+    {% set pageTitle = appointmentJourneyTitle("Change appointment host", session.appointmentJourney) %}
+    {% set pageHeading = "Enter the new appointment tier" %}
+{% else %}
+    {% set pageTitle = appointmentJourneyTitle("Appointment host", session.appointmentJourney) %}
+    {% set pageHeading = "What is the appointment host?" %}
+{% endif %}
+
+{% set pageId = 'host-page' %}
+{% set jsBackLink = true %}
+
+{% set organiserOptions = [] %}
+{% for organiserKey, organiserText in organiserDescriptions %}
+    {% set organiserOptions = (organiserOptions.push({
+        value: organiserKey,
+        text: organiserText,
+        checked: formResponses.organiser == organiserKey or session.appointmentJourney.organiserCode == organiserKey
+    }), organiserOptions) %}
+{% endfor %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                {{ appointmentTypeCaption(session) }}
+                {{ govukRadios({
+                    fieldset: {
+                        legend: {
+                            text: "Who hosts this appointment?",
+                            isPageHeading: true,
+                            classes: "govuk-fieldset__legend--l"
+                        }
+                    },
+                    name: "host",
+                    errorMessage: validationErrors | findError('host'),
+                    items: organiserOptions
+                }) }}
+
+                {{ govukButton({
+                    text: "Continue"
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/pages/appointments/create-and-edit/host.njk
+++ b/server/views/pages/appointments/create-and-edit/host.njk
@@ -8,13 +8,11 @@
 
 {% if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT %}
     {% set pageTitle = appointmentJourneyTitle("Change appointment host", session.appointmentJourney) %}
-    {% set pageHeading = "Enter the new appointment tier" %}
 {% else %}
     {% set pageTitle = appointmentJourneyTitle("Appointment host", session.appointmentJourney) %}
-    {% set pageHeading = "What is the appointment host?" %}
 {% endif %}
 
-{% set pageId = 'host-page' %}
+{% set pageId = 'appointment-host-page' %}
 {% set jsBackLink = true %}
 
 {% set organiserOptions = [] %}
@@ -35,11 +33,12 @@
                 {{ govukRadios({
                     fieldset: {
                         legend: {
-                            text: "Who hosts this appointment?",
+                            text: "Who hosts these appointments?" if session.appointmentJourney.type == AppointmentType.SET else "Who hosts this appointment?",
                             isPageHeading: true,
                             classes: "govuk-fieldset__legend--l"
                         }
                     },
+                    id: "host",
                     name: "host",
                     errorMessage: validationErrors | findError('host'),
                     items: organiserOptions

--- a/server/views/pages/appointments/create-and-edit/tier.njk
+++ b/server/views/pages/appointments/create-and-edit/tier.njk
@@ -8,13 +8,11 @@
 
 {% if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT %}
     {% set pageTitle = appointmentJourneyTitle("Change appointment tier", session.appointmentJourney) %}
-    {% set pageHeading = "Enter the new appointment tier" %}
 {% else %}
     {% set pageTitle = appointmentJourneyTitle("Appointment tier", session.appointmentJourney) %}
-    {% set pageHeading = "What is the appointment tier?" %}
 {% endif %}
 
-{% set pageId = 'appointment-tier' %}
+{% set pageId = 'appointment-tier-page' %}
 {% set jsBackLink = true %}
 
 {% set activityTierOptions = [] %}
@@ -35,14 +33,15 @@
                 {{ govukRadios({
                     fieldset: {
                         legend: {
-                            text: "Which tier is the appointment in?" if session.req.params.mode == 'edit' else "Select a tier for the new appointment",
+                            text: "Which tier are the appointments in?" if session.appointmentJourney.type == AppointmentType.SET else "Which tier is the appointment in?",
                             isPageHeading: true,
                             classes: "govuk-fieldset__legend--l"
                         }
                     },
                     hint: {
-                        text: 'Recording whether the appointment is tier 1 (core curriculum, for example literacy), tier 2 (extra-curricular, for example library) or routine activities (for example showers or exercise) helps ensure there is a balanced regime.'
+                        text: 'Recording whether the appointments are tier 1 (core curriculum, for example a health clinic or induction assessment), tier 2 (extra-curricular, for example an Alcohol Awareness Day event or Storybook Mums and Dads) or not purposeful (also called foundational) helps ensure there is a balanced regime.'
                     },
+                    id: "tier",
                     name: "tier",
                     errorMessage: validationErrors | findError('tier'),
                     items: activityTierOptions

--- a/server/views/pages/appointments/create-and-edit/tier.njk
+++ b/server/views/pages/appointments/create-and-edit/tier.njk
@@ -1,0 +1,57 @@
+{% extends "layout.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
+{% from "pages/appointments/partials/appointment-type-caption.njk" import appointmentTypeCaption %}
+{% from "partials/activities/activity-journey-caption.njk" import activityJourneyCaption %}
+
+{% if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT %}
+    {% set pageTitle = appointmentJourneyTitle("Change appointment tier", session.appointmentJourney) %}
+    {% set pageHeading = "Enter the new appointment tier" %}
+{% else %}
+    {% set pageTitle = appointmentJourneyTitle("Appointment tier", session.appointmentJourney) %}
+    {% set pageHeading = "What is the appointment tier?" %}
+{% endif %}
+
+{% set pageId = 'appointment-tier' %}
+{% set jsBackLink = true %}
+
+{% set activityTierOptions = [] %}
+{% for tierKey, tierText in eventTierDescriptions %}
+    {% set activityTierOptions = (activityTierOptions.push({
+        value: tierKey,
+        text: tierText,
+        checked: formResponses.tier == tierKey or session.appointmentJourney.tierCode == tierKey
+    }), activityTierOptions) %}
+{% endfor %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form method="POST">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                {{ appointmentTypeCaption(session) }}
+                {{ govukRadios({
+                    fieldset: {
+                        legend: {
+                            text: "Which tier is the appointment in?" if session.req.params.mode == 'edit' else "Select a tier for the new appointment",
+                            isPageHeading: true,
+                            classes: "govuk-fieldset__legend--l"
+                        }
+                    },
+                    hint: {
+                        text: 'Recording whether the appointment is tier 1 (core curriculum, for example literacy), tier 2 (extra-curricular, for example library) or routine activities (for example showers or exercise) helps ensure there is a balanced regime.'
+                    },
+                    name: "tier",
+                    errorMessage: validationErrors | findError('tier'),
+                    items: activityTierOptions
+                }) }}
+
+                {{ govukButton({
+                    text: "Continue"
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Overview

Adds tiers and organisers to appointment journeys (group and bulk). Edit appointment and updates to appointment details page to come in next PR.

### Screenshots

<img width="1244" alt="Screenshot at Nov 16 18-21-09" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/60f30c79-06ed-49cc-b55d-c5c2b7f17916">

<img width="1247" alt="Screenshot at Nov 16 17-37-21" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/b910d7bf-b234-471e-a1bd-edfba20bc6e1">

<img width="1256" alt="Screenshot at Nov 16 17-39-11" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/2bbcb255-7cbb-4c30-b655-a0e991aee12d">
