### PR TITLE
SAA-1181: Remove change link for past appointments

### DIFF
--- a/server/views/pages/appointments/appointment/details.njk
+++ b/server/views/pages/appointments/appointment/details.njk
@@ -122,7 +122,7 @@
                                     attributes: { 'data-qa': 'change-tier' }
                                 }
                             ]
-                        }
+                        } if appointment.isCancelled == false and appointment.isExpired == false
                     }, {
                         key: {
                             text: "Host"
@@ -139,7 +139,7 @@
                                     attributes: { 'data-qa': 'change-host' }
                                 }
                             ]
-                        }
+                        } if appointment.isCancelled == false and appointment.isExpired == false
                     } if appointment.organiser,
                     {
                         key: {


### PR DESCRIPTION
## Overview

Bug fix to remove change links for tier and host when appointment has been canceled or has expired