### PR TITLE
SAA-1429: Unlock list displays wing name rather than location key

### DIFF
--- a/server/routes/activities/unlock-list/handlers/plannedEvents.test.ts
+++ b/server/routes/activities/unlock-list/handlers/plannedEvents.test.ts
@@ -62,12 +62,10 @@ describe('Unlock list routes - planned events', () => {
       req = {
         query: {
           date: '2022-01-01',
-          slot: 'am',
-          location: 'A',
         },
         session: {
           unlockListJourney: {
-            location: 'A',
+            locationKey: 'A',
             timeSlot: 'am',
             // No filters supplied in session
           },
@@ -106,8 +104,15 @@ describe('Unlock list routes - planned events', () => {
 
       expect(res.render).toHaveBeenCalledWith('pages/activities/unlock-list/planned-events', {
         date: '2022-01-01',
-        location: 'A',
-        subLocations: ['A', 'B', 'C'],
+        location: {
+          name: 'A-Wing',
+          key: 'A',
+          children: [
+            { name: 'A-Wing', key: 'A', children: [] },
+            { name: 'B-Wing', key: 'B', children: [] },
+            { name: 'C-Wing', key: 'C', children: [] },
+          ],
+        },
         timeSlot: 'am',
         unlockListItems,
         movementCounts: {
@@ -121,12 +126,10 @@ describe('Unlock list routes - planned events', () => {
       req = {
         query: {
           date: '2022-01-01',
-          slot: 'am',
-          location: 'A',
         },
         session: {
           unlockListJourney: {
-            location: 'A',
+            locationKey: 'A',
             timeSlot: 'am',
             stayingOrLeavingFilter: 'Leaving',
             activityFilter: 'With',
@@ -167,8 +170,15 @@ describe('Unlock list routes - planned events', () => {
 
       expect(res.render).toHaveBeenCalledWith('pages/activities/unlock-list/planned-events', {
         date: '2022-01-01',
-        location: 'A',
-        subLocations: ['A', 'B', 'C'],
+        location: {
+          name: 'A-Wing',
+          key: 'A',
+          children: [
+            { name: 'A-Wing', key: 'A', children: [] },
+            { name: 'B-Wing', key: 'B', children: [] },
+            { name: 'C-Wing', key: 'C', children: [] },
+          ],
+        },
         timeSlot: 'am',
         unlockListItems,
         movementCounts: {

--- a/server/routes/activities/unlock-list/handlers/selectDateAndLocation.test.ts
+++ b/server/routes/activities/unlock-list/handlers/selectDateAndLocation.test.ts
@@ -72,7 +72,7 @@ describe('Unlock list routes - select date and location', () => {
       req.body = {
         datePresetOption: 'today',
         activitySlot: 'am',
-        location: 'here',
+        locationKey: 'here',
       }
       const todaysDate = format(new Date(), 'yyyy-MM-dd')
 
@@ -80,14 +80,14 @@ describe('Unlock list routes - select date and location', () => {
 
       expect(res.redirect).toHaveBeenCalledWith(`planned-events?date=${todaysDate}`)
       expect(req.session.unlockListJourney.timeSlot).toEqual('am')
-      expect(req.session.unlockListJourney.location).toEqual('here')
+      expect(req.session.unlockListJourney.locationKey).toEqual('here')
     })
 
     it("redirect with the expected query params for when tomorrow's date is selected", async () => {
       req.body = {
         datePresetOption: 'tomorrow',
         activitySlot: 'am',
-        location: 'here',
+        locationKey: 'here',
       }
       const tomorrowsDate = format(addDays(new Date(), 1), 'yyyy-MM-dd')
 
@@ -95,7 +95,7 @@ describe('Unlock list routes - select date and location', () => {
 
       expect(res.redirect).toHaveBeenCalledWith(`planned-events?date=${tomorrowsDate}`)
       expect(req.session.unlockListJourney.timeSlot).toEqual('am')
-      expect(req.session.unlockListJourney.location).toEqual('here')
+      expect(req.session.unlockListJourney.locationKey).toEqual('here')
     })
 
     it('redirects with the expected query params for when a custom date is selected', async () => {
@@ -103,14 +103,14 @@ describe('Unlock list routes - select date and location', () => {
         datePresetOption: 'other',
         date: new Date('2022-12-01'),
         activitySlot: 'am',
-        location: 'here',
+        locationKey: 'here',
       }
 
       await handler.POST(req, res)
 
       expect(res.redirect).toHaveBeenCalledWith(`planned-events?date=2022-12-01`)
       expect(req.session.unlockListJourney.timeSlot).toEqual('am')
-      expect(req.session.unlockListJourney.location).toEqual('here')
+      expect(req.session.unlockListJourney.locationKey).toEqual('here')
     })
   })
 
@@ -124,7 +124,7 @@ describe('Unlock list routes - select date and location', () => {
       expect(errors).toEqual([
         { property: 'datePresetOption', error: 'Select a date' },
         { property: 'activitySlot', error: 'Select a time' },
-        { property: 'location', error: 'Select a location' },
+        { property: 'locationKey', error: 'Select a location' },
       ])
     })
 
@@ -140,7 +140,7 @@ describe('Unlock list routes - select date and location', () => {
       expect(errors).toEqual([
         { property: 'datePresetOption', error: 'Select a date' },
         { property: 'activitySlot', error: 'Select a time' },
-        { property: 'location', error: 'Select a location' },
+        { property: 'locationKey', error: 'Select a location' },
       ])
     })
 
@@ -149,7 +149,7 @@ describe('Unlock list routes - select date and location', () => {
         datePresetOption: 'other',
         date: {},
         activitySlot: 'am',
-        location: 'some location',
+        locationKey: 'some location',
       }
 
       const requestObject = plainToInstance(DateAndLocation, body)
@@ -163,7 +163,7 @@ describe('Unlock list routes - select date and location', () => {
         datePresetOption: 'other',
         date: '2022/2/31',
         activitySlot: 'am',
-        location: 'here',
+        locationKey: 'here',
       }
 
       const requestObject = plainToInstance(DateAndLocation, body)
@@ -178,7 +178,7 @@ describe('Unlock list routes - select date and location', () => {
         datePresetOption: 'other',
         date: formatDatePickerDate(dateIn59Days),
         activitySlot: 'am',
-        location: 'here',
+        locationKey: 'here',
       }
 
       const requestObject = plainToInstance(DateAndLocation, body)
@@ -193,7 +193,7 @@ describe('Unlock list routes - select date and location', () => {
         datePresetOption: 'other',
         date: formatDatePickerDate(dateIn60Days),
         activitySlot: 'am',
-        location: 'here',
+        locationKey: 'here',
       }
 
       const requestObject = plainToInstance(DateAndLocation, body)
@@ -208,7 +208,7 @@ describe('Unlock list routes - select date and location', () => {
         datePresetOption: 'other',
         date: formatDatePickerDate(dateIn61Days),
         activitySlot: 'am',
-        location: 'some location',
+        locationKey: 'some location',
       }
 
       const requestObject = plainToInstance(DateAndLocation, body)

--- a/server/routes/activities/unlock-list/handlers/selectDateAndLocation.ts
+++ b/server/routes/activities/unlock-list/handlers/selectDateAndLocation.ts
@@ -39,7 +39,7 @@ export class DateAndLocation {
 
   @Expose()
   @IsNotEmpty({ message: 'Select a location' })
-  location: string
+  locationKey: string
 }
 
 export default class SelectDateAndLocationRoutes {
@@ -54,11 +54,11 @@ export default class SelectDateAndLocationRoutes {
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
-    const { activitySlot, location, datePresetOption, date } = req.body
+    const { activitySlot, locationKey, datePresetOption, date } = req.body
 
     req.session.unlockListJourney = {
       timeSlot: activitySlot,
-      location,
+      locationKey,
     }
 
     const selectedDate = this.getDateValue(datePresetOption, date)

--- a/server/routes/activities/unlock-list/journey.ts
+++ b/server/routes/activities/unlock-list/journey.ts
@@ -1,6 +1,6 @@
 export type UnlockListJourney = {
   timeSlot?: string
-  location?: string
+  locationKey?: string
   subLocationFilters?: string[]
   activityFilter?: string
   stayingOrLeavingFilter?: string

--- a/server/views/pages/activities/unlock-list/planned-events.njk
+++ b/server/views/pages/activities/unlock-list/planned-events.njk
@@ -21,7 +21,7 @@
             <tr class="govuk-table__row"><td>
                 <div class="govuk-grid-row govuk-!-margin-bottom-1">
                     <div class="govuk-grid-column-two-thirds govuk-!-print-grid-column-one-half govuk-!-margin-bottom-1">
-                        <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ location }} - Unlock list</h1>
+                        <h1 class="govuk-heading-l govuk-!-margin-bottom-0">{{ location.name }} - Unlock list</h1>
                         <div class="govuk-caption-l govuk-!-margin-top-0 govuk-!-margin-bottom-0">{{ timeSlot | upper }} session</div>
                         <div class="govuk-caption-l">{{ date |formatDate('cccc d LLLL y') }}</div>
                         <div class="govuk-!-margin-top-2">
@@ -47,13 +47,13 @@
         </thead>
         <tbody class="govuk-table__body"><tr class="govuk-table__row"><td>
             {% set filterOptionsHtml %}
-                {% if subLocations | length %}
+                {% if location.children | length %}
                     {% set locationFilters = [] %}
-                    {% for location in subLocations %}
+                    {% for subLocation in location.children %}
                         {% set locationFilters = (locationFilters.push({
-                            value: location,
-                            text: location,
-                            checked: location in session.unlockListJourney.subLocationFilters
+                            value: subLocation.key,
+                            text: subLocation.name,
+                            checked: subLocation.key in session.unlockListJourney.subLocationFilters
                         }), locationFilters) %}
                     {% endfor %}
 

--- a/server/views/pages/activities/unlock-list/select-date-and-location.njk
+++ b/server/views/pages/activities/unlock-list/select-date-and-location.njk
@@ -105,15 +105,15 @@
                 {% endfor %}
 
                 {{ govukRadios({
-                    idPrefix: "location",
-                    name: "location",
+                    idPrefix: "locationKey",
+                    name: "locationKey",
                     fieldset: {
                         legend: {
                             text: "Locations",
                             classes: "govuk-fieldset__legend--m"
                         }
                     },
-                    errorMessage: validationErrors | findError('location'),
+                    errorMessage: validationErrors | findError('locationKey'),
                     items: items
                 }) }}
 


### PR DESCRIPTION
The location name will now be used for display purposes, while the location key is used for location ID purposes