### PR TITLE
SAA-1423: Prevent double click on form submissions

### DIFF
--- a/server/views/pages/activities/create-an-activity/bank-holiday-option.njk
+++ b/server/views/pages/activities/create-an-activity/bank-holiday-option.njk
@@ -41,7 +41,8 @@
                 {% if session.req.params.mode == 'edit' %}
                     <div class="govuk-button-group">
                       {{ govukButton({
-                        text: "Update bank holiday scheduling"
+                        text: "Update bank holiday scheduling",
+                        preventDoubleClick: true
                       }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>

--- a/server/views/pages/activities/create-an-activity/capacity.njk
+++ b/server/views/pages/activities/create-an-activity/capacity.njk
@@ -41,7 +41,8 @@
                     }) }}
                     <div class="govuk-button-group">
                       {{ govukButton({
-                        text: "Update capacity"
+                        text: "Update capacity",
+                        preventDoubleClick: true
                       }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>

--- a/server/views/pages/activities/create-an-activity/category.njk
+++ b/server/views/pages/activities/create-an-activity/category.njk
@@ -44,7 +44,8 @@
                 {% if session.req.params.mode == 'edit' %}
                     <div class="govuk-button-group">
                         {{ govukButton({
-                            text: "Update activity category"
+                            text: "Update activity category",
+                            preventDoubleClick: true
                         }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>

--- a/server/views/pages/activities/create-an-activity/check-answers.njk
+++ b/server/views/pages/activities/create-an-activity/check-answers.njk
@@ -280,12 +280,13 @@
                 ]
             }) }}
 
-            <form method="POST">
+            <form method="POST" data-module="form-spinner" data-loading-text="Creating activity">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Create activity"
+                        text: "Create activity",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/activities/create-an-activity/check-education-level.njk
+++ b/server/views/pages/activities/create-an-activity/check-education-level.njk
@@ -56,7 +56,8 @@
                     }) }}
                 </div>
                 {{ govukButton({
-                    text: "Update education levels" if session.req.params.mode == 'edit' else "Confirm" 
+                    text: "Update education levels" if session.req.params.mode == 'edit' else "Confirm",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/activities/create-an-activity/check-pay.njk
+++ b/server/views/pages/activities/create-an-activity/check-pay.njk
@@ -99,7 +99,8 @@
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Confirm"
+                        text: "Confirm",
+                        preventDoubleClick: true
                     }) if flatPay | length > 0 or incentiveLevelPays | length > 0 }}
                     {{ govukButton({
                         text: "Add another pay rate",

--- a/server/views/pages/activities/create-an-activity/confirm-capacity.njk
+++ b/server/views/pages/activities/create-an-activity/confirm-capacity.njk
@@ -60,7 +60,8 @@
 
                 <div class="govuk-button-group">
                   {{ govukButton({
-                    text: "Confirm capacity change"
+                    text: "Confirm capacity change",
+                    preventDoubleClick: true
                   }) }}
                     <a class="govuk-link js-backlink" href="capacity">Cancel</a>
                 </div>

--- a/server/views/pages/activities/create-an-activity/days-and-times.njk
+++ b/server/views/pages/activities/create-an-activity/days-and-times.njk
@@ -99,9 +99,10 @@
                 }) }}
                 {% if session.req.params.mode == 'edit' %}
                     <div class="govuk-button-group">
-                      {{ govukButton({
-                        text: "Update days and times"
-                      }) }}
+                        {{ govukButton({
+                            text: "Update days and times",
+                            preventDoubleClick: true
+                        }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>
                 {% else %}

--- a/server/views/pages/activities/create-an-activity/end-date.njk
+++ b/server/views/pages/activities/create-an-activity/end-date.njk
@@ -36,9 +36,10 @@
                           text: "Anyone allocated to the activity who was due to be taken off after this date will now finish on this date."
                      }) }}
                     <div class="govuk-button-group">
-                      {{ govukButton({
-                        text: "Update end date"
-                      }) }}
+                        {{ govukButton({
+                            text: "Update end date",
+                            preventDoubleClick: true
+                        }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>
                 {% else %}

--- a/server/views/pages/activities/create-an-activity/location.njk
+++ b/server/views/pages/activities/create-an-activity/location.njk
@@ -76,9 +76,10 @@
                         iconFallbackText: "Warning"
                     }) }}
                     <div class="govuk-button-group">
-                      {{ govukButton({
-                        text: "Update activity location"
-                      }) }}
+                        {{ govukButton({
+                            text: "Update activity location",
+                            preventDoubleClick: true
+                        }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>
                 {% else %}

--- a/server/views/pages/activities/create-an-activity/name.njk
+++ b/server/views/pages/activities/create-an-activity/name.njk
@@ -39,9 +39,10 @@
                       text: "If you change the name of this activity, it will update all records. This includes any previous sessions of the activity on the unlock, movement and attendance lists."
                     }) }}
                     <div class="govuk-button-group">
-                      {{ govukButton({
-                        text: "Update activity name"
-                      }) }}
+                        {{ govukButton({
+                            text: "Update activity name",
+                            preventDoubleClick: true
+                        }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>
                 {% else %}

--- a/server/views/pages/activities/create-an-activity/organiser.njk
+++ b/server/views/pages/activities/create-an-activity/organiser.njk
@@ -38,9 +38,10 @@
 
                 {% if session.req.params.mode == 'edit' %}
                     <div class="govuk-button-group">
-                      {{ govukButton({
-                        text: "Update organiser"
-                      }) }}
+                        {{ govukButton({
+                            text: "Update organiser",
+                            preventDoubleClick: true
+                        }) }}
                         <a class="govuk-link js-backlink" href="/activities/view/{{ session.createJourney.activityId }}">Cancel</a>
                     </div>
                 {% else %}

--- a/server/views/pages/activities/create-an-activity/remove-pay.njk
+++ b/server/views/pages/activities/create-an-activity/remove-pay.njk
@@ -40,7 +40,8 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Confirm"
+                    text: "Confirm",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/activities/create-an-activity/risk-level.njk
+++ b/server/views/pages/activities/create-an-activity/risk-level.njk
@@ -69,7 +69,8 @@
 
                     <div class="govuk-button-group">
                         {{ govukButton({
-                            text: "Update risk assessment level"
+                            text: "Update risk assessment level",
+                            preventDoubleClick: true
                         }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>

--- a/server/views/pages/activities/create-an-activity/start-date.njk
+++ b/server/views/pages/activities/create-an-activity/start-date.njk
@@ -33,7 +33,8 @@
                 {% if session.req.params.mode == 'edit' %}
                     <div class="govuk-button-group">
                         {{ govukButton({
-                            text: "Update start date"
+                            text: "Update start date",
+                            preventDoubleClick: true
                         }) }}
                         <a class="govuk-link js-backlink" href="/">Cancel</a>
                     </div>

--- a/server/views/pages/activities/create-an-activity/tier.njk
+++ b/server/views/pages/activities/create-an-activity/tier.njk
@@ -42,7 +42,8 @@
                 {% if session.req.params.mode == 'edit' %}
                     <div class="govuk-button-group">
                       {{ govukButton({
-                        text: "Update tier"
+                        text: "Update tier",
+                        preventDoubleClick: true
                       }) }}
                         <a class="govuk-link js-backlink" href="/activities/view/{{ session.createJourney.activityId }}">Cancel</a>
                     </div>

--- a/server/views/pages/activities/manage-activities/activities-dashboard.njk
+++ b/server/views/pages/activities/manage-activities/activities-dashboard.njk
@@ -1,6 +1,5 @@
 {% extends "layout.njk" %}
 
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}

--- a/server/views/pages/activities/manage-activities/view-activity.njk
+++ b/server/views/pages/activities/manage-activities/view-activity.njk
@@ -1,7 +1,6 @@
 {% extends "layout.njk" %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}

--- a/server/views/pages/activities/manage-allocations/check-answers.njk
+++ b/server/views/pages/activities/manage-allocations/check-answers.njk
@@ -180,10 +180,13 @@
                 }) }}
             {% endif %}
 
-            <form method="POST">
+            <form method="POST" data-module="form-spinner" data-loading-text="Allocating prisoner">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 <div class="govuk-button-group">
-                    {{ govukButton({ text: "Confirm this allocation" if session.req.params.mode == 'create' else "Confirm and remove" }) }}
+                    {{ govukButton({ 
+                        text: "Confirm this allocation" if session.req.params.mode == 'create' else "Confirm and remove",
+                        preventDoubleClick: true
+                    }) }}
                     <a href="cancel" class="govuk-link govuk-link--no-visited-state">Cancel and return to the list of candidates</a>
                 </div>
             </form>

--- a/server/views/pages/activities/manage-allocations/confirm-exclusions.njk
+++ b/server/views/pages/activities/manage-allocations/confirm-exclusions.njk
@@ -66,7 +66,8 @@
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 <div class="govuk-button-group govuk-!-margin-top-6">
                     {{ govukButton({
-                        text: "Confirm"
+                        text: "Confirm",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/activities/manage-allocations/deallocation-reason.njk
+++ b/server/views/pages/activities/manage-allocations/deallocation-reason.njk
@@ -46,7 +46,10 @@
                 }) }}
 
                 <div class="govuk-button-group">
-                    {{ govukButton({ text: "Continue" }) }}
+                    {{ govukButton({ 
+                        text: "Continue",
+                        preventDoubleClick: true
+                    }) }}
                     {% if session.req.params.mode != 'edit' and not session.req.query.preserveHistory %}
                         <a class="govuk-link" href="cancel">Cancel</a>
                     {% endif %}

--- a/server/views/pages/activities/manage-allocations/pay-band.njk
+++ b/server/views/pages/activities/manage-allocations/pay-band.njk
@@ -44,7 +44,8 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Confirm pay"
+                        text: "Confirm pay",
+                        preventDoubleClick: true
                     }) }}
                     {% if session.req.params.mode != 'edit' and not session.req.query.preserveHistory %}
                         <a class="govuk-link" href="cancel">Cancel</a>

--- a/server/views/pages/activities/manage-allocations/remove-date-option.njk
+++ b/server/views/pages/activities/manage-allocations/remove-date-option.njk
@@ -43,9 +43,9 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Save and continue"
+                    text: "Save and continue",
+                    preventDoubleClick: true
                 }) }}
-
             </form>
         </div>
     </div>

--- a/server/views/pages/activities/manage-allocations/start-date.njk
+++ b/server/views/pages/activities/manage-allocations/start-date.njk
@@ -33,7 +33,8 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Continue"
+                        text: "Continue",
+                        preventDoubleClick: true
                     }) }}
                     {% if session.req.params.mode != 'edit' and not session.req.query.preserveHistory %}
                         <a class="govuk-link js-backlink" href="cancel">Cancel</a>

--- a/server/views/pages/activities/record-attendance/attendance-list.njk
+++ b/server/views/pages/activities/record-attendance/attendance-list.njk
@@ -5,7 +5,6 @@
 {% from "components/sticky-select.njk" import stickySelect %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}

--- a/server/views/pages/activities/record-attendance/cancel-session/confirm.njk
+++ b/server/views/pages/activities/record-attendance/cancel-session/confirm.njk
@@ -29,7 +29,8 @@
         }) }}
 
         {{ govukButton({
-          text: "Continue"
+          text: "Continue",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/pages/activities/record-attendance/edit-attendance.njk
+++ b/server/views/pages/activities/record-attendance/edit-attendance.njk
@@ -41,7 +41,8 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Continue"
+                    text: "Continue",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/activities/record-attendance/not-attended-reason.njk
+++ b/server/views/pages/activities/record-attendance/not-attended-reason.njk
@@ -214,7 +214,8 @@
                 {% endfor %}
 
                 {{ govukButton({
-                    text: "Confirm and record attendance"
+                    text: "Confirm and record attendance",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/activities/record-attendance/remove-pay.njk
+++ b/server/views/pages/activities/record-attendance/remove-pay.njk
@@ -33,9 +33,9 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Continue"
+                    text: "Continue",
+                    preventDoubleClick: true
                 }) }}
-
             </form>
         </div>
     </div>

--- a/server/views/pages/activities/record-attendance/reset-attendance.njk
+++ b/server/views/pages/activities/record-attendance/reset-attendance.njk
@@ -42,7 +42,8 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Continue"
+                    text: "Continue",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/activities/record-attendance/uncancel-session/confirm.njk
+++ b/server/views/pages/activities/record-attendance/uncancel-session/confirm.njk
@@ -28,7 +28,8 @@
         }) }}
 
         {{ govukButton({
-          text: "Continue"
+          text: "Continue",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/pages/activities/unlock-list/planned-events.njk
+++ b/server/views/pages/activities/unlock-list/planned-events.njk
@@ -1,5 +1,4 @@
 {% extends "layout.njk" %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}

--- a/server/views/pages/activities/waitlist-application/check-answers.njk
+++ b/server/views/pages/activities/waitlist-application/check-answers.njk
@@ -13,7 +13,7 @@
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-xl">Log an activity application</span>
 
-            <form method="POST">
+            <form method="POST" data-module="form-spinner" data-loading-text="Logging application">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 <h1 class='govuk-heading-xl'>Check and confirm application details</h1>
@@ -121,7 +121,8 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Continue"
+                        text: "Continue",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/activities/waitlist-application/edit-comment.njk
+++ b/server/views/pages/activities/waitlist-application/edit-comment.njk
@@ -42,7 +42,8 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Update application comment"
+                        text: "Update application comment",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/activities/waitlist-application/edit-request-date.njk
+++ b/server/views/pages/activities/waitlist-application/edit-request-date.njk
@@ -34,7 +34,8 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Update date of request"
+                        text: "Update date of request",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/activities/waitlist-application/edit-requester.njk
+++ b/server/views/pages/activities/waitlist-application/edit-requester.njk
@@ -122,7 +122,8 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Update requester details"
+                        text: "Update requester details",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/activities/waitlist-application/edit-status.njk
+++ b/server/views/pages/activities/waitlist-application/edit-status.njk
@@ -60,7 +60,8 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Update application status"
+                        text: "Update application status",
+                        preventDoubleClick: true
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/activities/waitlist-dashboard/dashboard.njk
+++ b/server/views/pages/activities/waitlist-dashboard/dashboard.njk
@@ -1,7 +1,6 @@
 {% extends "layout.njk" %}
 
 {% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "govuk/components/input/macro.njk" import govukInput %}

--- a/server/views/pages/appointments/appointment-series/details.njk
+++ b/server/views/pages/appointments/appointment-series/details.njk
@@ -1,7 +1,6 @@
 {% extends "layout.njk" %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 

--- a/server/views/pages/appointments/create-and-edit/apply-to.njk
+++ b/server/views/pages/appointments/create-and-edit/apply-to.njk
@@ -48,7 +48,8 @@
                 {% endif %}
 
                 {{ govukButton({
-                    text: getAppointmentEditApplyToCta(session.appointmentJourney, session.editAppointmentJourney)
+                    text: getAppointmentEditApplyToCta(session.appointmentJourney, session.editAppointmentJourney),
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/appointments/create-and-edit/appointment-set/date.njk
+++ b/server/views/pages/appointments/create-and-edit/appointment-set/date.njk
@@ -33,7 +33,8 @@
                     value: formResponses.startDate or ((session.editAppointmentJourney.startDate or session.appointmentJourney.startDate) | isoDateToDatePickerDate)
                 }) }}
                 {{ govukButton({
-                    text: "Confirm and save" if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT else "Continue"
+                    text: "Confirm and save" if session.appointmentJourney.mode == AppointmentJourneyMode.EDIT else "Continue",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/appointments/create-and-edit/confirm-edit.njk
+++ b/server/views/pages/appointments/create-and-edit/confirm-edit.njk
@@ -37,7 +37,8 @@
                 }) }}
 
                 {{ govukButton({
-                    text: getConfirmAppointmentEditCta(session.appointmentJourney, session.editAppointmentJourney)
+                    text: getConfirmAppointmentEditCta(session.appointmentJourney, session.editAppointmentJourney),
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/appointments/create-and-edit/extra-information.njk
+++ b/server/views/pages/appointments/create-and-edit/extra-information.njk
@@ -75,7 +75,8 @@
           </div>
         </div>
         {{ govukButton({
-          text: "Update extra information" if isCtaAcceptAndSave else "Continue"
+          text: "Update extra information" if isCtaAcceptAndSave else "Continue",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/pages/appointments/create-and-edit/host.njk
+++ b/server/views/pages/appointments/create-and-edit/host.njk
@@ -45,7 +45,8 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Update host" if isCtaAcceptAndSave else "Continue"
+                    text: "Update host" if isCtaAcceptAndSave else "Continue",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/appointments/create-and-edit/location.njk
+++ b/server/views/pages/appointments/create-and-edit/location.njk
@@ -48,7 +48,8 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Update location" if isCtaAcceptAndSave else "Continue"
+                    text: "Update location" if isCtaAcceptAndSave else "Continue",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/appointments/create-and-edit/schedule.njk
+++ b/server/views/pages/appointments/create-and-edit/schedule.njk
@@ -181,6 +181,7 @@
 
                     {{ govukButton({
                         text: getAppointmentEditApplyToCta(session.appointmentJourney, session.editAppointmentJourney) if isCtaAcceptAndSave else "Continue",
+                        preventDoubleClick: true,
                         attributes: { 'data-qa': 'top-cta' }
                     }) if prisonerSchedules.length > 10 }}
 
@@ -234,6 +235,7 @@
 
                     {{ govukButton({
                         attributes: { 'data-qa': 'bottom-cta' },
+                        preventDoubleClick: true,
                         text: getAppointmentEditApplyToCta(session.appointmentJourney, session.editAppointmentJourney) if isCtaAcceptAndSave else "Continue"
                     }) }}
                 </form>

--- a/server/views/pages/appointments/create-and-edit/tier.njk
+++ b/server/views/pages/appointments/create-and-edit/tier.njk
@@ -48,7 +48,8 @@
                 }) }}
 
                 {{ govukButton({
-                    text: "Update tier" if isCtaAcceptAndSave else "Continue"
+                    text: "Update tier" if isCtaAcceptAndSave else "Continue",
+                    preventDoubleClick: true
                 }) }}
             </form>
         </div>

--- a/server/views/pages/appointments/search/results.njk
+++ b/server/views/pages/appointments/search/results.njk
@@ -1,6 +1,5 @@
 {% extends "layout.njk" %}
 
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}


### PR DESCRIPTION
## Overview

Added `preventDoubleClick` to all form submit buttons which can result in either a create or edit request.

I've also added the form spinner to the create activity, create allocation and create waitlist check answers pages. It's unlikely to show on these pages since requests normally complete < 1 sec, but it further reduces the risk that a create request is submitted twice resulting in either a confusing error message to the user or a duplicate entities being created by accident.