### PR TITLE
SAA-1483: Back link quick fixes

### DIFF
--- a/integration_tests/pages/recordAttendance/activitiesPage.ts
+++ b/integration_tests/pages/recordAttendance/activitiesPage.ts
@@ -13,5 +13,11 @@ export default class ActivitiesPage extends Page {
         return Cypress.$.makeArray($el)
       })
 
-  selectActivityWithName = (activityName: string) => this.activityRows().find(`a:contains(${activityName})`).click()
+  selectActivityWithName = (activityName: string) =>
+    this.activityRows()
+      .find(`a:contains(${activityName})`)
+      .then(e => {
+        const activityUrl = e.prop('href')
+        cy.visit(activityUrl)
+      })
 }

--- a/server/views/pages/activities/record-attendance/activities.njk
+++ b/server/views/pages/activities/record-attendance/activities.njk
@@ -170,7 +170,7 @@
                     },
                     html: '
                             <h2 class="govuk-heading-s govuk-!-margin-bottom-0">
-                                <a href="activities/' + activity.scheduledInstanceId + '/attendance-list" class="govuk-link govuk-link--no-visited-state">' + (activity.summary | escape) + '</a>
+                                <a href="activities/' + activity.scheduledInstanceId + '/attendance-list" class="govuk-link govuk-link--no-visited-state" target="_blank">' + (activity.summary | escape) + '<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
                             </h2>
                             <div>' + activityCancelledTag(activity.cancelled) + '</div>'
                 },

--- a/server/views/pages/appointments/appointment-series/details.njk
+++ b/server/views/pages/appointments/appointment-series/details.njk
@@ -8,7 +8,8 @@
 
 {% set pageTitle = appointmentSeries.appointmentName + ' series overview' %}
 {% set pageId = 'appointment-series-details-page' %}
-{% set jsBackLink = true %}
+{% set hardBackLinkText = 'Go to Appointments Dashboard' %}
+{% set hardBackLinkHref = '/appointments/search?startDate=' + appointmentSeries.appointments[0].startDate %}
 
 {% set appointmentTableRows = [] %}
 {% for appointment in appointmentSeries.appointments %}

--- a/server/views/pages/appointments/appointment/details.njk
+++ b/server/views/pages/appointments/appointment/details.njk
@@ -12,7 +12,8 @@
 
 {% set pageTitle = appointment.appointmentName + " - " + appointment.startDate | toDate | formatDate + " " + appointment.startTime + (" to " + appointment.endTime if appointment.endTime) %}
 {% set pageId = 'appointment-details-page' %}
-{% set jsBackLink = true %}
+{% set hardBackLinkText = 'Go to Appointments Dashboard' %}
+{% set hardBackLinkHref = '/appointments/search?startDate=' + appointments.startDate %}
 
 {% set appointmentLink = '/appointments/' + appointment.id  %}
 

--- a/server/views/pages/appointments/attendance/summaries.njk
+++ b/server/views/pages/appointments/attendance/summaries.njk
@@ -25,8 +25,8 @@
 {% endmacro %}
 
 {% macro summaryLink(summary) %}
-    <a href="/appointments/{{ summary.id }}/attendance" class="govuk-link--no-visited-state">
-        {{ summary.appointmentName }}
+    <a href="/appointments/{{ summary.id }}/attendance" class="govuk-link--no-visited-state" target="_blank">
+        {{ summary.appointmentName }}<span class="govuk-visually-hidden"> (opens in new tab)</span>
     </a>
 {% endmacro %}
 

--- a/server/views/partials/attendance/otherEvent.njk
+++ b/server/views/partials/attendance/otherEvent.njk
@@ -4,10 +4,14 @@
   <div class="govuk-body govuk-!-margin-0">
       <div class="govuk-!-font-weight-bold">
         {% if event.eventType == 'ACTIVITY' and event.eventSource =='SAA' %}
-            <a class="govuk-link" href="/activities/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list" class="govuk-link govuk-link--no-visited-state">{{ event.summary }}</a>
+            <a href="/activities/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list" 
+              class="govuk-link govuk-link--no-visited-state"
+              target="_blank">{{ event.summary }}<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
         {% endif %}
         {% if event.eventType == 'APPOINTMENT' and event.eventSource =='SAA' %}
-            <a class="govuk-link" href="/appointments/{{ event.appointmentId }}">{{ event.summary }}</a>
+            <a href="/appointments/{{ event.appointmentId }}"
+              class="govuk-link"
+              target="_blank">{{ event.summary }}<span class="govuk-visually-hidden"> (opens in new tab)</span></a>
             <div class='govuk-!-margin-top-1 govuk-!-margin-bottom-1'>{{ govukTag({ text: 'Appointment', classes: 'govuk-tag--small' }) }}</div>
         {% endif %}
         {% if event.cancelled %}

--- a/server/views/partials/showUnlockEvents.njk
+++ b/server/views/partials/showUnlockEvents.njk
@@ -8,13 +8,15 @@
                 <div class="govuk-!-font-weight-bold">
                     {% if event.eventType === 'ACTIVITY' and event.eventSource === 'SAA' %}
                         <a href="/activities/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list?preserveHistory=true"
-                        class="govuk-link govuk-link--no-visited-state">
-                            {{- event.summary | trim -}}
+                        class="govuk-link govuk-link--no-visited-state"
+                        target="_blank">
+                            {{- event.summary | trim -}}<span class="govuk-visually-hidden"> (opens in new tab)</span>
                         </a>
                     {% elseif event.eventType === 'APPOINTMENT' and event.eventSource === 'SAA'%}
                         <a href="/appointments/{{ event.appointmentId }}?preserveHistory=true"
-                        class="govuk-link govuk-link--no-visited-state">
-                            {{- event.summary | trim -}}
+                        class="govuk-link govuk-link--no-visited-state"
+                        target="_blank">
+                            {{- event.summary | trim -}}<span class="govuk-visually-hidden"> (opens in new tab)</span>
                         </a>
                         <div class='govuk-!-margin-top-1 govuk-!-margin-bottom-1'>{{ govukTag({ text: 'Appointment', classes: 'govuk-tag--small' }) }}</div>
                         {% if event.comments %}


### PR DESCRIPTION
## Overview

Some quick fixes for back links. Where we are unable to provide a workable backlink we open link in a new tab allowing user to close the tab and return to the previous screen.