### PR TITLE
SAA-1120 very small content change to error message when saying if want to add an end date or not when allocating a prisoner.

### DIFF
--- a/server/routes/activities/manage-allocations/handlers/endDateOption.test.ts
+++ b/server/routes/activities/manage-allocations/handlers/endDateOption.test.ts
@@ -80,7 +80,7 @@ describe('Route Handlers - Allocation - End Date option', () => {
       const requestObject = plainToInstance(EndDateOption, body)
       const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
 
-      expect(errors).toEqual([{ property: 'endDateOption', error: 'Choose whether you want to set the end date.' }])
+      expect(errors).toEqual([{ property: 'endDateOption', error: 'Select if you want to enter an end date or not' }])
     })
   })
 })

--- a/server/routes/activities/manage-allocations/handlers/endDateOption.ts
+++ b/server/routes/activities/manage-allocations/handlers/endDateOption.ts
@@ -4,7 +4,7 @@ import { IsNotEmpty } from 'class-validator'
 
 export class EndDateOption {
   @Expose()
-  @IsNotEmpty({ message: 'Choose whether you want to set the end date.' })
+  @IsNotEmpty({ message: 'Select if you want to enter an end date or not' })
   endDateOption: string
 }
 

--- a/server/routes/activities/record-attendance/handlers/removePay.test.ts
+++ b/server/routes/activities/record-attendance/handlers/removePay.test.ts
@@ -127,7 +127,7 @@ describe('Route Handlers - Remove Pay', () => {
         .calledWith(1, res.locals.user)
         .mockResolvedValue({
           id: 1,
-          date: format(new Date(), 'yyyy-MM-dd'),
+          date: '2024-01-12',
           startTime: '10:00',
           endTime: '11:00',
           activitySchedule: {


### PR DESCRIPTION
Bring error message inline with the content doc:

before:

![before](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/06ca16a1-fe69-4b7f-a1ef-ea7b01b999e4)

after:

![after](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/f37ac0c5-2a2b-49f9-b2a4-3eb384d58820)
