### PR TITLE
SAA-1490: Fixed event tag styling on COC page

### DIFF
--- a/server/views/pages/activities/change-of-circumstances/view-events.njk
+++ b/server/views/pages/activities/change-of-circumstances/view-events.njk
@@ -106,54 +106,14 @@
 {% endblock %}
 
 {% macro renderEventTypeTag(event) %}
-    {% if 'non-association' in event.eventType %}
-        {{
-            govukTag({
-                text: "NON-ASSOCIATION",
-                classes: "govuk-tag--orange"
-            })
-        }}
-    {% elseif 'iep-review' in event.eventType %}
-        {{
-            govukTag({
-                text: "IEP STATUS",
-                classes: "govuk-tag--green"
-            })
-        }}
-    {% elseif 'activities-changed' in event.eventType %}
-        {{
-        govukTag({
-            text: "RELEASE",
-            classes: "govuk-tag--green"
-        })
-        }}
-    {% elseif 'appointments-changed' in event.eventType %}
-        {{
-        govukTag({
-            text: "RELEASE",
-            classes: "govuk-tag--green"
-        })
-        }}
-    {% elseif 'prisoner.released' in event.eventType %}
-        {{
-        govukTag({
-            text: "RELEASE",
-            classes: "govuk-tag--green"
-        })
-        }}
-    {% elseif '' in event.eventType %}
-        {{
-            govukTag({
-                text: "CELL-MOVE",
-                classes: "govuk-tag--blue"
-            })
-        }}
-    {% else %}
-        {{
-            govukTag({
-                text: "UNKNOWN-EVENT",
-                classes: "govuk-tag--red"
-            })
-        }}
-    {% endif %}
+    {% set options = 
+        ({ text: "Non-association", classes: "govuk-tag--orange" } if 'non-association' in event.eventType) or
+        ({ text: "IEP status", classes: "govuk-tag--green" } if 'iep-review' in event.eventType) or
+        ({ text: "Release", classes: "govuk-tag--green" } if 'activities-changed' in event.eventType or 'appointments-changed' in event.eventType or 'prisoner.released' in event.eventType) or
+        ({ text: "Cell-move", classes: "govuk-tag--blue" } if '' in event.eventType) or
+        { text: "Unknown-event", classes: "govuk-tag--red"} %}
+
+    {% set options = options | setAttribute('classes', options.classes + " govuk-!-font-size-16") %}
+
+    {{ govukTag(options) }}
 {% endmacro %}


### PR DESCRIPTION
## Overview

Fixes styling of event tags on COC page

### Screenshots

**Before**
<img width="1244" alt="Screenshot at Jan 16 13-55-00" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/1f13232a-ad58-4e56-9235-c09d60cb9e28">

**After**
<img width="1231" alt="Screenshot at Jan 16 13-54-52" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/1dc5d66c-1b4b-4aed-910f-dc9c1e05310e">
