### PR TITLE
SAA-1489 Back session set to null in POST method

### DIFF
--- a/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.test.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.test.ts
@@ -22,7 +22,7 @@ describe('Not attended routes - select date', () => {
       redirect: jest.fn(),
     } as unknown as Response
 
-    req = {} as unknown as Request
+    req = { session: {} } as unknown as Request
     jest.resetAllMocks()
   })
 
@@ -37,6 +37,17 @@ describe('Not attended routes - select date', () => {
   })
 
   describe('POST', () => {
+    it('sets attendanceSummaryJourney to null', async () => {
+      req.session.attendanceSummaryJourney = {}
+      req.body = {
+        datePresetOption: 'today',
+      }
+
+      await handler.POST(req, res)
+
+      expect(req.session.attendanceSummaryJourney).toEqual(null)
+    })
+
     it("redirects to not attended list with today's date", async () => {
       const today = new Date()
 

--- a/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.ts
@@ -36,6 +36,7 @@ export default class SelectDateRoutes {
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
+    req.session.attendanceSummaryJourney = null
     const selectedDate = this.selectedDate(req.body)
     res.redirect(`attendance?date=${formatIsoDate(selectedDate)}&status=NotAttended&preserveHistory=true`)
   }


### PR DESCRIPTION
Issue: Activities - View people who are not attended yet 
Back button is not clearing the session and not loading the Categories and data correctly.

<img width="1159" alt="Screenshot 2024-01-16 at 15 37 16" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/0341ddca-974b-4441-8cbb-3215145fe8cb">

After: Session is set to null and categories are reloaded again.

<img width="1099" alt="Screenshot 2024-01-16 at 15 37 53" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/bbbced1a-5cbb-459a-a2ae-a40607d574fc">
