### PR TITLE
SAA-1115 change error message for required field deallocation reason.

### DIFF
--- a/server/routes/activities/manage-allocations/handlers/deallocationReason.test.ts
+++ b/server/routes/activities/manage-allocations/handlers/deallocationReason.test.ts
@@ -1,8 +1,11 @@
 import { Request, Response } from 'express'
 import { when } from 'jest-when'
-import DeallocationReasonRoutes from './deallocationReason'
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import DeallocationReasonRoutes, { DeallocationReason } from './deallocationReason'
 import ActivitiesService from '../../../../services/activitiesService'
 import { formatIsoDate } from '../../../../utils/datePickerUtils'
+import { associateErrorsWithProperty } from '../../../../utils/utils'
 
 jest.mock('../../../../services/activitiesService')
 
@@ -83,6 +86,19 @@ describe('Route Handlers - Deallocation reason', () => {
       expect(req.session.allocateJourney.deallocationReason).toEqual('HEALTH')
       expect(req.session.allocateJourney.deallocationCaseNote).toBeNull()
       expect(res.redirect).toHaveBeenCalledWith('check-answers')
+    })
+  })
+
+  describe('validation', () => {
+    it('should fail validation if no deallocation reason is provided', async () => {
+      const body = {}
+
+      const requestObject = plainToInstance(DeallocationReason, body)
+      const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+      expect(errors).toEqual([
+        { property: 'deallocationReason', error: "Select why you're taking this person off the activity" },
+      ])
     })
   })
 })

--- a/server/routes/activities/manage-allocations/handlers/deallocationReason.ts
+++ b/server/routes/activities/manage-allocations/handlers/deallocationReason.ts
@@ -5,7 +5,7 @@ import ActivitiesService from '../../../../services/activitiesService'
 
 export class DeallocationReason {
   @Expose()
-  @IsNotEmpty({ message: 'Select a reason for deallocation' })
+  @IsNotEmpty({ message: "Select why you're taking this person off the activity" })
   deallocationReason: string
 }
 


### PR DESCRIPTION
Simple error message change for the deallaction reason.  Ticket mentioned the end date message needing correcting also but this looked correct already.

Before:

![before](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/47f12155-b41d-49d6-bbb9-89c0cca45431)

After:

![after](https://github.com/ministryofjustice/hmpps-activities-management/assets/60104344/017f6ae5-72e2-44e3-9da1-cb9f7889309c)
