### PR TITLE
SAA-1092 Loading Spinner for appointments

### DIFF
--- a/server/views/pages/appointments/create-and-edit/apply-to.njk
+++ b/server/views/pages/appointments/create-and-edit/apply-to.njk
@@ -30,7 +30,7 @@
 
             {{ addPrisonerList(session.editAppointmentJourney.addPrisoners) }}
 
-            <form method="POST">
+            <form method="POST" data-module="form-spinner" data-loading-text="Preparing your appointments" >
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {{ govukRadios({
                     name: "applyTo",


### PR DESCRIPTION
Form Spinner: Edit Manage Appointment has when updating require Loading spinner.

Before: While updating and sync with no spinner is loaded.

After: Spinner added until the update is completed.

![Screenshot 2024-01-18 at 16 34 52](https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/d492c15e-b71c-4fdd-a64d-0f06c435a3a5)
![Screenshot 2024-01-18 at 16 35 34](https://github.com/ministryofjustice/hmpps-activities-management/assets/139761909/5a13d437-b5d5-4959-a2a9-8f75686df5fa)
