### PR TITLE
SAA-1118: Update validation error messages

### DIFF
--- a/server/routes/activities/manage-allocations/handlers/removeDateOption.test.ts
+++ b/server/routes/activities/manage-allocations/handlers/removeDateOption.test.ts
@@ -106,7 +106,7 @@ describe('Route Handlers - Allocation - Remove Date option', () => {
       const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
 
       expect(errors).toEqual([
-        { property: 'endDateOption', error: 'Choose whether you want to change or remove the end date.' },
+        { property: 'endDateOption', error: 'Select if you want to change the allocation end date or remove it' },
       ])
     })
   })

--- a/server/routes/activities/manage-allocations/handlers/removeDateOption.ts
+++ b/server/routes/activities/manage-allocations/handlers/removeDateOption.ts
@@ -10,7 +10,7 @@ enum Options {
 
 export class RemoveDateOption {
   @Expose()
-  @IsIn(Object.values(Options), { message: 'Choose whether you want to change or remove the end date.' })
+  @IsIn(Object.values(Options), { message: 'Select if you want to change the allocation end date or remove it' })
   endDateOption: string
 }
 

--- a/server/routes/activities/manage-allocations/handlers/startDate.test.ts
+++ b/server/routes/activities/manage-allocations/handlers/startDate.test.ts
@@ -133,7 +133,7 @@ describe('Route Handlers - Edit allocation - Start date', () => {
       })
       const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
 
-      expect(errors).toEqual([{ property: 'startDate', error: "Enter a date after today's date" }])
+      expect(errors).toEqual([{ property: 'startDate', error: 'Enter a date in the future' }])
     })
 
     it('validation fails if start date is before activity start date', async () => {

--- a/server/routes/activities/manage-allocations/handlers/startDate.ts
+++ b/server/routes/activities/manage-allocations/handlers/startDate.ts
@@ -16,7 +16,7 @@ import IsValidDate from '../../../../validators/isValidDate'
 export class StartDate {
   @Expose()
   @Transform(({ value }) => parseDatePickerDate(value))
-  @DateValidator(date => date > startOfToday(), { message: "Enter a date after today's date" })
+  @DateValidator(date => date > startOfToday(), { message: 'Enter a date in the future' })
   @DateValidator((date, { allocateJourney }) => date >= parseIsoDate(allocateJourney.activity.startDate), {
     message: (args: ValidationArguments) => {
       const { allocateJourney } = args.object as { allocateJourney: AllocateToActivityJourney }


### PR DESCRIPTION
Updated error messaging for validation in edit allocation journey for:

**Remove allocation validation**

<img width="799" alt="Screenshot 2024-01-18 at 17 08 15" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/29005413/b38e15ea-5966-4816-8aa4-8ead61838541"> 

**Start date allocation validation**

<img width="836" alt="Screenshot 2024-01-18 at 17 09 43" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/29005413/e07c7002-1f02-459c-947d-03f161de19e7">

