### PR TITLE
SAA-1517: Remove tier change link when activity has ended

### DIFF
--- a/server/views/pages/activities/manage-activities/view-activity.njk
+++ b/server/views/pages/activities/manage-activities/view-activity.njk
@@ -71,7 +71,7 @@
                                     text: "Change",
                                     visuallyHiddenText: "change tier"
                                 }
-                            ] if activity.category.code != 'SAA_NOT_IN_WORK'
+                            ] if not activityEnded and activity.category.code != 'SAA_NOT_IN_WORK'
                         }
                     },
                     {
@@ -89,7 +89,7 @@
                                     visuallyHiddenText: "change organiser"
                                 }
                             ]
-                        }
+                        } if not activityEnded 
                     } if organiser
                 ]
             }) }}


### PR DESCRIPTION
## Overview

Bug fix to remove activity tier and organiser change links when activity has ended.

### Screenshots

**Before**
<img width="1234" alt="Screenshot at Jan 25 14-32-13" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/12276303-aeaf-4c90-9afe-cd2de498aaa5">

**After**
<img width="1229" alt="Screenshot at Jan 25 14-32-46" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/125488090/66395951-7396-4052-a73f-c75b52cba8ac">
