### PR TITLE
SAA-1536 we should only use the filtered activities endpoint when retrieving activities to avoid pulling back too much (unused instances) data.

### DIFF
--- a/integration_tests/e2e/allocateToActivity.cy.ts
+++ b/integration_tests/e2e/allocateToActivity.cy.ts
@@ -45,7 +45,7 @@ context('Allocate to activity', () => {
     cy.stubEndpoint('GET', '/schedules/2/candidates(.)*', getCandidates)
     cy.stubEndpoint('GET', '/prisoner/A5015DY', getInmateDetails)
     cy.stubEndpoint('GET', '/incentive-reviews/prisoner/A5015DY', getPrisonerIepSummary)
-    cy.stubEndpoint('GET', '/activities/2', getActivity)
+    cy.stubEndpoint('GET', '/activities/2/filtered', getActivity)
     cy.stubEndpoint('GET', '/allocations/deallocation-reasons', getDeallocationReasons)
     cy.stubEndpoint('GET', '/prison/MDI/prison-pay-bands', getMdiPrisonPayBands)
     cy.stubEndpoint('POST', '/schedules/2/allocations')

--- a/integration_tests/e2e/deallocateFromActivity.cy.ts
+++ b/integration_tests/e2e/deallocateFromActivity.cy.ts
@@ -33,7 +33,7 @@ context('Deallocation from activity', () => {
     cy.stubEndpoint('POST', '/prisons/MDI/prisoner-allocations', prisonerAllocations)
     cy.stubEndpoint('GET', '/schedules/2/waiting-list-applications', JSON.parse('[]'))
     cy.stubEndpoint('GET', '/schedules/2/candidates(.)*', getCandidates)
-    cy.stubEndpoint('GET', '/activities/2', getActivity)
+    cy.stubEndpoint('GET', '/activities/2/filtered', getActivity)
     cy.stubEndpoint('GET', '/allocations/deallocation-reasons', getDeallocationReasons)
     cy.stubEndpoint('GET', '/prison/MDI/prison-pay-bands', getMdiPrisonPayBands)
     cy.stubEndpoint('POST', '/prisoner-search/prisoner-numbers', getInmateDetails)

--- a/server/data/activitiesApiClient.test.ts
+++ b/server/data/activitiesApiClient.test.ts
@@ -59,7 +59,7 @@ describe('activitiesApiClient', () => {
     it('should return data from api', async () => {
       const response = { data: 'data' }
       fakeActivitiesApi
-        .get('/activities/1')
+        .get('/activities/1/filtered')
         .matchHeader('authorization', `Bearer token`)
         .matchHeader('Caseload-Id', 'MDI')
         .reply(200, response)

--- a/server/data/activitiesApiClient.ts
+++ b/server/data/activitiesApiClient.ts
@@ -70,7 +70,7 @@ export default class ActivitiesApiClient extends AbstractHmppsRestClient {
 
   getActivity(activityId: number, user: ServiceUser): Promise<Activity> {
     return this.get({
-      path: `/activities/${activityId}`,
+      path: `/activities/${activityId}/filtered`,
       authToken: user.token,
       headers: CASELOAD_HEADER(user.activeCaseLoadId),
     })


### PR DESCRIPTION
This changes the API client to only use the filtered Activities endpoint due to the large volume of instances and attendances that are building up over time.

This is using the default API period of one month's recent instances.