### PR TITLE
SAA-1566: Update base image to bookworm to fix CVE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
 
   node-version:
     type: string
-    default: 20.9-browsers
+    default: 20.11-browsers
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:20.9-bullseye-slim as base
+FROM node:20.11-bookworm-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available
@@ -27,9 +27,6 @@ FROM base as build
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available
-
-RUN apt-get update && \
-        apt-get install -y make python g++
 
 COPY package*.json ./
 RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit


### PR DESCRIPTION
SAA-1566: Update base image to bookworm to clear [CVE-2024-0567](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-activities-management/4037/workflows/9b1e0d0b-0ae1-4bf1-9726-01b5ec308c45/jobs/17175?invite=true#step-106-1312_147)