### PR TITLE
SAA-1573: Scale printed unlock list to 75%

### DIFF
--- a/frontend/utilities/_unlock-list.scss
+++ b/frontend/utilities/_unlock-list.scss
@@ -1,4 +1,8 @@
 .unlock-list {
+  @media print {
+    zoom: 75%
+  }
+
   #unlock-list-table {
     margin-bottom: 10px;
   }


### PR DESCRIPTION
Scales the printed version of the unlock list to 75% to allow less pages to be needed