### PR TITLE
SAA-1571: Add earliestReleaseDate to the waitlist dashboard

### DIFF
--- a/server/routes/activities/waitlist-dashboard/handlers/dashboard.test.ts
+++ b/server/routes/activities/waitlist-dashboard/handlers/dashboard.test.ts
@@ -41,6 +41,14 @@ describe('Route Handlers - Waitlist application - Edit Status', () => {
     activityId: 1,
     scheduleId: 2,
     requestedBy: 'OMU_STAFF',
+    earliestReleaseDate: {
+      releaseDate: '2025-02-13',
+      isIndeterminateSentence: false,
+      isTariffDate: false,
+      isRemand: true,
+      isImmigrationDetainee: false,
+      isConvictedUnsentenced: false,
+    },
   } as WaitingListApplication
 
   const waitingListSearchResults = {

--- a/server/views/pages/activities/waitlist-dashboard/dashboard.njk
+++ b/server/views/pages/activities/waitlist-dashboard/dashboard.njk
@@ -11,6 +11,7 @@
 {% from 'components/hmppsDatePicker.njk' import hmppsDatePicker %}
 {% from "partials/showProfileLink.njk" import showProfileLink %}
 {% from "partials/activities/waitlist-status-badge.njk" import waitlistStatusBadge %}
+{% from "partials/earliestReleaseDate.njk" import earliestReleaseDate %}
 {% from "partials/splitLine.njk" import splitLine %}
 {% from "partials/statusBasedCellLocation.njk" import statusBasedCellLocation %}
 
@@ -156,7 +157,7 @@
                                     html: splitLine(application.requestedDate, application.requestedBy)
                                 },
                                 {
-                                    text: application.prisoner.releaseDate | formatDate('d MMMM yyyy')
+                                    html: earliestReleaseDate(application.earliestReleaseDate)
                                 },
                                 {
                                     html: waitlistStatusBadge(application.status)


### PR DESCRIPTION
Add earliestReleaseDate to the waitlist dashboard to replace the prisoner release date.

![screencapture-localhost-3000-activities-waitlist-dashboard-2024-03-05-16_36_35](https://github.com/ministryofjustice/hmpps-activities-management/assets/159147179/cffeb123-7fde-4ec5-a7ba-11876b8373da)
