### PR TITLE
SAA-1614: Fix missing in cell location in appointments dashboard search results

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -82,7 +82,7 @@ module.exports = grunt => {
           {
             expand: true,
             cwd: 'server/views',
-            src: ['./**/*'],
+            src: ['./**/*.njk'],
             dest: 'dist/server/views/',
           },
         ],

--- a/integration_tests/e2e/appointments/manageAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/manageAppointment.cy.ts
@@ -1,0 +1,54 @@
+import { addDays } from 'date-fns'
+import Page from '../../pages/page'
+import IndexPage from '../../pages'
+import AppointmentsManagementPage from '../../pages/appointments/appointmentsManagementPage'
+import getCategories from '../../fixtures/activitiesApi/getAppointmentCategories.json'
+import getAppointmentLocations from '../../fixtures/prisonApi/getMdiAppointmentLocations.json'
+import SearchSelectDatePage from '../../pages/appointments/appointment/searchSelectDatePage'
+import SearchResultsPage from '../../pages/appointments/appointment/appointmentsSearchResultsPage'
+import getAppointmentSearchResults from '../../fixtures/activitiesApi/getAppointmentSearchResults.json'
+import postPrisonerNumbers from '../../fixtures/prisonerSearchApi/postPrisonerNumbers-A1350DZ-A8644DY.json'
+
+context('Manage appointment', () => {
+  const tomorrow = addDays(new Date(), 1)
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+    cy.stubEndpoint('GET', '/appointment-categories', getCategories)
+    cy.stubEndpoint('GET', '/appointment-locations/MDI', getAppointmentLocations)
+    cy.stubEndpoint('POST', '/appointments/MDI/search', getAppointmentSearchResults)
+    cy.stubEndpoint('POST', '/prisoner-search/prisoner-numbers', postPrisonerNumbers)
+  })
+
+  it('Should be able to view appointments', () => {
+    const indexPage = Page.verifyOnPage(IndexPage)
+    indexPage.appointmentsManagementCard().should('contain.text', 'Appointments scheduling and attendance')
+    indexPage
+      .appointmentsManagementCard()
+      .should(
+        'contain.text',
+        'Create, manage and edit appointments. Print movement slips. Record appointment attendance.',
+      )
+    indexPage.appointmentsManagementCard().click()
+
+    const searchAppointmentsPage = Page.verifyOnPage(AppointmentsManagementPage)
+    searchAppointmentsPage.searchAppointmentsCard().should('contain.text', 'Manage existing appointments')
+    searchAppointmentsPage
+      .searchAppointmentsCard()
+      .should(
+        'contain.text',
+        'Edit the details of an appointment, including cancelling, adding and removing people, and printing movement slips.',
+      )
+    searchAppointmentsPage.searchAppointmentsCard().click()
+
+    const searchSelectDatePage = Page.verifyOnPage(SearchSelectDatePage)
+    searchSelectDatePage.selectDatePickerDate(tomorrow)
+    searchSelectDatePage.continue()
+
+    const searchResultsDatePage = Page.verifyOnPage(SearchResultsPage)
+    searchResultsDatePage.assertResultsLocation(0, getAppointmentSearchResults[0].internalLocation.description)
+    searchResultsDatePage.assertResultsLocation(1, 'In cell')
+  })
+})

--- a/integration_tests/fixtures/activitiesApi/getAppointmentSearchResults.json
+++ b/integration_tests/fixtures/activitiesApi/getAppointmentSearchResults.json
@@ -1,0 +1,48 @@
+[
+  {
+    "appointmentSeriesId": 1,
+    "appointmentId": 1,
+    "appointmentType": "INDIVIDUAL",
+    "attendees": [
+      {
+        "prisonerNumber": "A1350DZ"
+      }
+    ],
+    "appointmentName": "Chaplaincy",
+    "category": {
+      "code": "CHAP",
+      "description": "Chaplaincy"
+    },
+    "internalLocation": {
+      "description": "Test Location 1"
+    },
+    "startDate": "2023-05-26",
+    "startTime": "09:30",
+    "endTime": "11:00",
+    "isRepeat": false,
+    "sequenceNumber": 1,
+    "maxSequenceNumber": 1
+  },
+  {
+    "appointmentSeriesId": 1,
+    "appointmentId": 2,
+    "appointmentType": "INDIVIDUAL",
+    "attendees": [
+      {
+        "prisonerNumber": "A8644DY"
+      }
+    ],
+    "appointmentName": "Chaplaincy",
+    "category": {
+      "code": "CHAP",
+      "description": "Chaplaincy"
+    },
+    "inCell": true,
+    "startDate": "2023-05-26",
+    "startTime": "09:30",
+    "endTime": "11:00",
+    "isRepeat": false,
+    "sequenceNumber": 1,
+    "maxSequenceNumber": 1
+  }
+]

--- a/integration_tests/pages/appointments/appointment/appointmentsSearchResultsPage.ts
+++ b/integration_tests/pages/appointments/appointment/appointmentsSearchResultsPage.ts
@@ -1,0 +1,11 @@
+import Page from '../../page'
+
+export default class SearchResultsPage extends Page {
+  constructor() {
+    super('appointments-search-results-page')
+  }
+
+  assertResultsLocation = (row: number, expected: string) => {
+    cy.get('table[data-qa=search-results]').find(`td[data-qa=result-location-${row}]`).contains(expected)
+  }
+}

--- a/integration_tests/pages/appointments/appointment/searchSelectDatePage.ts
+++ b/integration_tests/pages/appointments/appointment/searchSelectDatePage.ts
@@ -1,0 +1,7 @@
+import Page from '../../page'
+
+export default class SearchSelectDatePage extends Page {
+  constructor() {
+    super('appointments-search-select-date-page')
+  }
+}

--- a/integration_tests/pages/appointments/appointmentsManagementPage.ts
+++ b/integration_tests/pages/appointments/appointmentsManagementPage.ts
@@ -6,4 +6,6 @@ export default class AppointmentsManagementPage extends Page {
   }
 
   createGroupAppointmentCard = (): Cypress.Chainable => cy.get('[data-qa=create-group-appointment-card]')
+
+  searchAppointmentsCard = (): Cypress.Chainable => cy.get('[data-qa=search-appointments-card]')
 }

--- a/server/views/pages/appointments/search/results.njk
+++ b/server/views/pages/appointments/search/results.njk
@@ -8,6 +8,7 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from 'components/hmppsDatePicker.njk' import hmppsDatePicker %}
+{% from "partials/appointments/location-text.njk" import locationText %}
 {% from "partials/showProfileLink.njk" import showProfileLink %}
 
 {% set pageTitle = "Appointments Management - Appointment Search Results" %}
@@ -56,7 +57,7 @@
             text: result.appointmentName,
             attributes: { 'data-qa': 'result-appointment-name-' + index }
         }, {
-            text: result.internalLocation.description,
+            text: locationText(result),
             attributes: { 'data-qa': 'result-location-' + index }
         }, {
             html: attendees(result.attendees, prisonersDetails),

--- a/server/views/pages/appointments/search/results.njk.test.ts
+++ b/server/views/pages/appointments/search/results.njk.test.ts
@@ -103,9 +103,7 @@ describe('Views - Appointments Management - Appointment Search Results', () => {
             code: 'TEST2',
             description: 'Test Category 2',
           },
-          internalLocation: {
-            description: 'Test Location 2',
-          },
+          inCell: true,
           startDate: '2022-12-01',
           startTime: '13:00',
           endTime: '14:30',
@@ -174,7 +172,7 @@ describe('Views - Appointments Management - Appointment Search Results', () => {
 
     expect($('[data-qa=result-time-1]').text().trim()).toEqual('13:00 to 14:30')
     expect($('[data-qa=result-appointment-name-1]').text().trim()).toEqual('Test appointment name 2 (Test Category 2)')
-    expect($('[data-qa=result-location-1]').text().trim()).toEqual('Test Location 2')
+    expect($('[data-qa=result-location-1]').text().trim()).toEqual('In cell')
     expect($('[data-qa=result-prisoner-count-1]').text().trim()).toEqual('3')
     expect($('[data-qa=result-sequence-number-1]').text().trim()).toEqual('2 of 6')
     expect($('[data-qa=view-and-edit-result-1] > a').text()).toContain('View')

--- a/server/views/pages/appointments/search/select-date.njk
+++ b/server/views/pages/appointments/search/select-date.njk
@@ -4,7 +4,7 @@
 {% from 'components/hmppsDatePicker.njk' import hmppsDatePicker %}
 
 {% set pageTitle = "Choose date of appointments" %}
-{% set pageId = 'create-schedule-start-date-page' %}
+{% set pageId = 'appointments-search-select-date-page' %}
 {% set hardBackLinkText = "Back to all appointment tasks" %}
 {% set hardBackLinkHref = "/appointments" %}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",
-    "sourceMap": true,
+    "sourceMap": false,
     "suppressImplicitAnyIndexErrors": true,
     "skipLibCheck": true,
     "noEmit": false,


### PR DESCRIPTION
- Show in cell location in appointment search results table
- Configure `grunt` to only copy `.njk` files
- Configure `tsc` to exclude source maps

**NB: I'll double check the `grunt` and `tsc` changes once deployed to `dev`**

<img width="990" alt="image" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/1684766/59bfb4c6-f147-4717-beb5-32b0bd8ce294">
