### PR TITLE
SAA-1593 fix content, add adjudication hearings

### DIFF
--- a/server/routes/activities/record-attendance/handlers/attendanceList.test.ts
+++ b/server/routes/activities/record-attendance/handlers/attendanceList.test.ts
@@ -89,12 +89,22 @@ describe('Route Handlers - Attendance List', () => {
     prisonerNumber: 'ABC123',
   }
 
+  const adjudicationsEvent = {
+    eventId: 5,
+    eventType: 'ADJUDICATION_HEARING',
+    eventSource: 'NOMIS',
+    summary: 'Adujication Hearing',
+    startTime: '10:30',
+    endTime: '11:00',
+    prisonerNumber: 'ABC123',
+  }
+
   const scheduledEvents = {
     activities: [event1],
     appointments: [event2],
     courtHearings: [event3],
     visits: [event4],
-    adjudications: [],
+    adjudications: [adjudicationsEvent],
   } as PrisonerScheduledEvents
 
   const instance = {
@@ -170,7 +180,7 @@ describe('Route Handlers - Attendance List', () => {
           alerts: [{ alertCode: 'HA' }],
         },
         attendance: { prisonerNumber: 'ABC123', status: 'WAITING' },
-        otherEvents: [event4],
+        otherEvents: [event4, adjudicationsEvent],
       },
       {
         prisoner: prisoners[1],

--- a/server/routes/activities/record-attendance/handlers/attendanceList.test.ts
+++ b/server/routes/activities/record-attendance/handlers/attendanceList.test.ts
@@ -94,6 +94,7 @@ describe('Route Handlers - Attendance List', () => {
     appointments: [event2],
     courtHearings: [event3],
     visits: [event4],
+    adjudications: [],
   } as PrisonerScheduledEvents
 
   const instance = {
@@ -316,6 +317,7 @@ describe('Route Handlers - Attendance List', () => {
           appointments: [],
           courtHearings: [],
           visits: [],
+          adjudications: [],
         } as PrisonerScheduledEvents)
 
       when(prisonService.searchInmatesByPrisonerNumbers)

--- a/server/routes/activities/record-attendance/handlers/attendanceList.ts
+++ b/server/routes/activities/record-attendance/handlers/attendanceList.ts
@@ -55,6 +55,7 @@ export default class AttendanceListRoutes {
         ...otherEvents.appointments,
         ...otherEvents.courtHearings,
         ...otherEvents.visits,
+        ...otherEvents.adjudications,
       ]
 
       attendance = attendees.map(att => {

--- a/server/routes/activities/record-attendance/handlers/attendanceList.ts
+++ b/server/routes/activities/record-attendance/handlers/attendanceList.ts
@@ -133,6 +133,7 @@ export default class AttendanceListRoutes {
         ...response.appointments,
         ...response.courtHearings,
         ...response.visits,
+        ...response.adjudications,
       ])
       .then(events => events.filter(e => !e.cancelled))
       .then(events => events.filter(e => e.scheduledInstanceId !== +instanceId))

--- a/server/views/pages/activities/record-attendance/not-attended-reason.njk
+++ b/server/views/pages/activities/record-attendance/not-attended-reason.njk
@@ -224,7 +224,7 @@
 {% macro renderOtherEvents(otherEvents) %}
     {% for event in otherEvents %}
         <div class="govuk-body govuk-!-margin-0">
-            {{ event.startTime }}{{ "to " + event.endTime if event.endTime }}:
+            {{ event.startTime }}{{ " to " + event.endTime if event.endTime }}:
             {% if event.eventType == 'ACTIVITY' and event.eventSource =='SAA' %}
                 <a href="/activities/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list">{{ event.summary }}</a>
             {% elseif event.eventType == 'APPOINTMENT' and event.eventSource =='SAA' %}


### PR DESCRIPTION
1. content needs a space around {time} to {time}. 
2.  Adjudication hearings should have been included, but they were added to the api after the UI was written, and as the UI also flattens the objects, it needs to be explicitly included