### PR TITLE
SAA-1612: Fix validation - error summary links to specific field

### DIFF
--- a/server/routes/appointments/create-and-edit/handlers/dateAndTime.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/dateAndTime.test.ts
@@ -250,9 +250,7 @@ describe('Route Handlers - Appointment Journey - Date and Time', () => {
         expect.arrayContaining([
           { error: 'Enter a date for the appointment', property: 'startDate' },
           { error: 'Select a start time for the appointment', property: 'startTime' },
-          { error: 'Select a valid start time for the appointment', property: 'startTime' },
           { error: 'Select an end time for the appointment', property: 'endTime' },
-          { error: 'Select a valid end time for the appointment', property: 'endTime' },
         ]),
       )
     })

--- a/server/routes/appointments/create-and-edit/handlers/dateAndTime.ts
+++ b/server/routes/appointments/create-and-edit/handlers/dateAndTime.ts
@@ -3,7 +3,6 @@ import { Expose, Transform, Type } from 'class-transformer'
 import { IsNotEmpty, ValidateNested } from 'class-validator'
 import { startOfToday } from 'date-fns'
 import SimpleTime from '../../../../commonValidationTypes/simpleTime'
-import IsValidTime from '../../../../validators/isValidTime'
 import TimeIsAfter from '../../../../validators/timeIsAfter'
 import TimeAndDateIsAfterNow from '../../../../validators/timeAndDateIsAfterNow'
 import { hasAnyAppointmentPropertyChanged } from '../../../../utils/editAppointmentUtils'
@@ -24,7 +23,6 @@ export class DateAndTime {
   @ValidateNested()
   @TimeAndDateIsAfterNow('startDate', { message: 'Select a start time that is in the future' })
   @IsNotEmpty({ message: 'Select a start time for the appointment' })
-  @IsValidTime({ message: 'Select a valid start time for the appointment' })
   startTime: SimpleTime
 
   @Expose()
@@ -32,7 +30,6 @@ export class DateAndTime {
   @ValidateNested()
   @TimeIsAfter('startTime', { message: 'Select an end time after the start time' })
   @IsNotEmpty({ message: 'Select an end time for the appointment' })
-  @IsValidTime({ message: 'Select a valid end time for the appointment' })
   endTime: SimpleTime
 }
 


### PR DESCRIPTION
As far as I can tell, on this page the @IsValidTime declaration was blocking the @IsNotEmpty declaration - it was never triggering as @IsValidTime was superceding it, regardless of what order they were put in. Paired with the fact that because the time is selected from a dropdown rather than manual typing, I don't think there could actually be an invalid time entered in there.
Removing the @IsValidTime check solves the accessibility issue, as the error is then caught by the @IsNotEmpty validation and includes the exact ID of the field that's empty