### PR TITLE
SAA-1656 Retrospective appointments. Change the start time to be in the past

### DIFF
--- a/server/routes/appointments/create-and-edit/handlers/dateAndTime.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/dateAndTime.test.ts
@@ -118,7 +118,7 @@ describe('Route Handlers - Appointment Journey - Date and Time', () => {
   it('should populate return to with schedule', async () => {
     req.query = { preserveHistory: 'true' }
     req.body = {
-      startDate: formatDatePickerDate(tomorrow),
+      startDate: formatIsoDate(tomorrow),
       startTime: plainToInstance(SimpleTime, {
         hour: 11,
         minute: 30,

--- a/server/routes/appointments/create-and-edit/handlers/dateAndTime.ts
+++ b/server/routes/appointments/create-and-edit/handlers/dateAndTime.ts
@@ -42,13 +42,14 @@ export default class DateAndTimeRoutes {
   }
 
   CREATE = async (req: Request, res: Response): Promise<void> => {
-    if (req.query.preserveHistory) {
+    this.setTimeAndDate(req, 'appointmentJourney')
+    const retrospective = retrospectiveAppointment(req.session.appointmentJourney.startTime)
+
+    if (req.query.preserveHistory && !retrospective) {
       req.session.returnTo = 'schedule?preserveHistory=true'
     }
 
-    this.setTimeAndDate(req, 'appointmentJourney')
-
-    if (retrospectiveAppointment(req.session.appointmentJourney.startTime)) {
+    if (retrospective) {
       req.session.appointmentJourney.retrospective = YesNo.YES
       req.session.appointmentJourney.repeat = YesNo.NO
       res.redirectOrReturn(`check-answers`)


### PR DESCRIPTION
When the start date/time is changed on the confirm screen to be before the current time then skip the schedule clash screen