### PR TITLE
SAA-1297: add multiple people to appointments

### DIFF
--- a/integration_tests/e2e/appointments/createAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createAppointment.cy.ts
@@ -94,7 +94,7 @@ context('Create group appointment', () => {
       .should('contain.text', 'Set up a one-off or repeating appointment for one or more people.')
     appointmentsManagementPage.createGroupAppointmentCard().click()
 
-    let howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
+    const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
     howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
     howToAddPrisonersPage.continue()
 
@@ -109,11 +109,6 @@ context('Create group appointment', () => {
     reviewPrisonersPage.assertPrisonerInList('Gregs, Stephen')
     reviewPrisonersPage.assertPrisonerInList('Winchurch, David')
     reviewPrisonersPage.addAnotherPrisoner()
-    reviewPrisonersPage.continue()
-
-    howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Search for them one by one')
-    howToAddPrisonersPage.continue()
 
     let selectPrisonerPage = Page.verifyOnPage(SelectPrisonerPage)
     selectPrisonerPage.enterPrisonerNumber('lee')

--- a/integration_tests/e2e/appointments/createAppointmentCheckAnswers.cy.ts
+++ b/integration_tests/e2e/appointments/createAppointmentCheckAnswers.cy.ts
@@ -147,10 +147,6 @@ context('Create group appointment - check answers change links', () => {
     reviewPrisonersPage.assertPrisonerInList('Gregs, Stephen')
     reviewPrisonersPage.addAnotherPrisoner()
 
-    Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Search for them one by one')
-    howToAddPrisonersPage.continue()
-
     Page.verifyOnPage(SelectPrisonerPage)
     selectPrisonerPage.enterPrisonerNumber('A1350DZ')
     selectPrisonerPage.searchButton().click()

--- a/integration_tests/e2e/appointments/createRepeatAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createRepeatAppointment.cy.ts
@@ -103,7 +103,7 @@ context('Create group appointment', () => {
       .should('contain.text', 'Set up a one-off or repeating appointment for one or more people.')
     appointmentsManagementPage.createGroupAppointmentCard().click()
 
-    let howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
+    const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
     howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
     howToAddPrisonersPage.continue()
 
@@ -118,10 +118,6 @@ context('Create group appointment', () => {
     reviewPrisonersPage.assertPrisonerInList('Gregs, Stephen')
     reviewPrisonersPage.assertPrisonerInList('Winchurch, David')
     reviewPrisonersPage.addAnotherPrisoner()
-
-    howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Search for them one by one')
-    howToAddPrisonersPage.continue()
 
     let selectPrisonerPage = Page.verifyOnPage(SelectPrisonerPage)
     selectPrisonerPage.enterPrisonerNumber('lee')

--- a/integration_tests/e2e/appointments/createRetrospectiveAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createRetrospectiveAppointment.cy.ts
@@ -90,7 +90,7 @@ context('Create a retrospective appointment', () => {
       .should('contain.text', 'Set up a one-off or repeating appointment for one or more people.')
     appointmentsManagementPage.createGroupAppointmentCard().click()
 
-    let howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
+    const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
     howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
     howToAddPrisonersPage.continue()
 
@@ -105,11 +105,6 @@ context('Create a retrospective appointment', () => {
     reviewPrisonersPage.assertPrisonerInList('Gregs, Stephen')
     reviewPrisonersPage.assertPrisonerInList('Winchurch, David')
     reviewPrisonersPage.addAnotherPrisoner()
-    reviewPrisonersPage.continue()
-
-    howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Search for them one by one')
-    howToAddPrisonersPage.continue()
 
     let selectPrisonerPage = Page.verifyOnPage(SelectPrisonerPage)
     selectPrisonerPage.enterPrisonerNumber('lee')

--- a/server/views/pages/appointments/create-and-edit/review-prisoners.njk
+++ b/server/views/pages/appointments/create-and-edit/review-prisoners.njk
@@ -113,7 +113,7 @@
                     {{ govukButton({
                         text: "Add another person",
                         classes: "govuk-button--secondary",
-                        href: "how-to-add-prisoners" + ('?preserveHistory=true' if preserveHistory else ''),
+                        href: "select-prisoner" + ('?preserveHistory=true' if preserveHistory else ''),
                         attributes: { 'data-qa': 'add-prisoner-secondary' }
                     }) }}
                 </div>

--- a/server/views/pages/appointments/create-and-edit/review-prisoners.njk
+++ b/server/views/pages/appointments/create-and-edit/review-prisoners.njk
@@ -111,10 +111,20 @@
             {% if session.appointmentJourney.type != AppointmentType.SET %}
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Add another person",
+                        text: "Add another person individually",
+                        id: "add-prisoner-individual",
                         classes: "govuk-button--secondary",
                         href: "select-prisoner" + ('?preserveHistory=true' if preserveHistory else ''),
                         attributes: { 'data-qa': 'add-prisoner-secondary' }
+                    }) }}
+                </div>
+                <div class="govuk-button-group">
+                    {{ govukButton({
+                        text: "Add people using a CSV file",
+                        id: "add-prisoners-csv",
+                        classes: "govuk-button--secondary",
+                        href: "upload-prisoner-list" + ('?preserveHistory=true' if preserveHistory else ''),
+                        attributes: { 'data-qa': 'add-prisoner-multiple' }
                     }) }}
                 </div>
             {% endif %}
@@ -123,7 +133,8 @@
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Continue"
+                        text: "Continue",
+                        id: "continue-button"
                     }) }}
                 </div>
             </form>

--- a/server/views/pages/appointments/create-and-edit/review-prisoners.njk.test.ts
+++ b/server/views/pages/appointments/create-and-edit/review-prisoners.njk.test.ts
@@ -1,0 +1,49 @@
+import * as cheerio from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import fs from 'fs'
+import { registerNunjucks } from '../../../../nunjucks/nunjucksSetup'
+import {
+  AppointmentJourney,
+  AppointmentJourneyMode,
+  AppointmentType,
+} from '../../../../routes/appointments/create-and-edit/appointmentJourney'
+import { EditAppointmentJourney } from '../../../../routes/appointments/create-and-edit/editAppointmentJourney'
+
+const view = fs.readFileSync('server/views/pages/appointments/create-and-edit/review-prisoners.njk')
+
+describe('Views - Appointments Management - Review Prisoners', () => {
+  let compiledTemplate: Template
+  let viewContext = {
+    session: {
+      appointmentJourney: {} as unknown as AppointmentJourney,
+      editAppointmentJourney: {} as unknown as EditAppointmentJourney,
+    },
+  }
+
+  const njkEnv = registerNunjucks()
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(view.toString(), njkEnv)
+    viewContext = {
+      session: {
+        appointmentJourney: {
+          mode: AppointmentJourneyMode.CREATE,
+          type: AppointmentType.INDIVIDUAL,
+        } as AppointmentJourney,
+        editAppointmentJourney: {} as EditAppointmentJourney,
+      },
+    }
+  })
+
+  it('should display both select individual, select using csv and continue buttons', () => {
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#add-prisoner-individual').text().trim()).toEqual('Add another person individually')
+    expect($('#add-prisoner-individual').attr('href')).toEqual('select-prisoner')
+
+    expect($('#add-prisoners-csv').text().trim()).toEqual('Add people using a CSV file')
+    expect($('#add-prisoners-csv').attr('href')).toEqual('upload-prisoner-list')
+
+    expect($('#continue-button').text().trim()).toEqual('Continue')
+  })
+})


### PR DESCRIPTION
Change to screen logic when adding people. Add an extra button to return directly to the select prisoner screen when adding an individual prisoner

Review

<img width="1405" alt="Screenshot 2024-05-01 at 14 34 34" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/159147179/d5b1a67a-75cb-40cc-9fa0-58b30e0ea3dd">


Add individual button

<img width="1405" alt="Screenshot 2024-05-01 at 14 34 50" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/159147179/d52fb663-b7d2-4cd7-801e-f144bb787414">

Add CSV button

<img width="1405" alt="Screenshot 2024-05-01 at 14 35 10" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/159147179/00291f1e-9b9f-4057-bf10-4b3305ea82dc">

