### PR TITLE
SAA-1655: Remove any unavailable attendees

### DIFF
--- a/server/routes/appointments/create-and-edit/createRoutes.ts
+++ b/server/routes/appointments/create-and-edit/createRoutes.ts
@@ -32,6 +32,7 @@ import ScheduleRoutes from './handlers/schedule'
 import TierRoutes, { TierForm } from './handlers/tier'
 import HostRoutes, { HostForm } from './handlers/host'
 import CopySeries, { HowToCopySeriesForm } from './handlers/copySeries'
+import NoAttendees from './handlers/noAttendees'
 import ReviewPrisonersAlertsRoutes from './handlers/reviewPrisonersAlerts'
 import PrisonerAlertsService from '../../../services/prisonerAlertsService'
 import fetchAppointmentSeries from '../../../middleware/appointments/fetchAppointmentSeries'
@@ -72,6 +73,7 @@ export default function Create({ prisonService, activitiesService, metricsServic
   const scheduleRoutes = new ScheduleRoutes(activitiesService, editAppointmentService, metricsService)
   const reviewPrisonerAlerts = new ReviewPrisonersAlertsRoutes(prisonerAlertsService)
   const copySeriesRoutes = new CopySeries()
+  const noAttendeesRoutes = new NoAttendees()
 
   get('/start-group', startJourneyRoutes.GROUP)
   get('/start-set', startJourneyRoutes.SET)
@@ -158,6 +160,8 @@ export default function Create({ prisonService, activitiesService, metricsServic
 
     get('/copy-series', copySeriesRoutes.GET, true)
     post('/copy-series', copySeriesRoutes.POST, HowToCopySeriesForm)
+    get('/no-attendees', noAttendeesRoutes.GET, true)
+    post('/no-attendees', noAttendeesRoutes.POST)
   }
 
   return router

--- a/server/routes/appointments/create-and-edit/createRoutes.ts
+++ b/server/routes/appointments/create-and-edit/createRoutes.ts
@@ -36,6 +36,7 @@ import ReviewPrisonersAlertsRoutes from './handlers/reviewPrisonersAlerts'
 import PrisonerAlertsService from '../../../services/prisonerAlertsService'
 import fetchAppointmentSeries from '../../../middleware/appointments/fetchAppointmentSeries'
 import config from '../../../config'
+import AppointeeAttendeeService from '../../../services/appointeeAttendeeService'
 
 export default function Create({ prisonService, activitiesService, metricsService }: Services): Router {
   const router = Router({ mergeParams: true })
@@ -47,7 +48,8 @@ export default function Create({ prisonService, activitiesService, metricsServic
 
   const editAppointmentService = new EditAppointmentService(activitiesService, metricsService)
   const prisonerAlertsService = new PrisonerAlertsService(prisonService)
-  const startJourneyRoutes = new StartJourneyRoutes(prisonService, metricsService)
+  const appointeeAttendeeService = new AppointeeAttendeeService(prisonService)
+  const startJourneyRoutes = new StartJourneyRoutes(prisonService, metricsService, appointeeAttendeeService)
   const selectPrisonerRoutes = new SelectPrisonerRoutes(prisonService)
   const uploadPrisonerListRoutes = new UploadPrisonerListRoutes(new PrisonerListCsvParser(), prisonService)
   const nameRoutes = new NameRoutes(activitiesService)

--- a/server/routes/appointments/create-and-edit/editRoutes.ts
+++ b/server/routes/appointments/create-and-edit/editRoutes.ts
@@ -24,6 +24,7 @@ import TierRoutes, { TierForm } from './handlers/tier'
 import HostRoutes, { HostForm } from './handlers/host'
 import ReviewPrisonersAlertsRoutes from './handlers/reviewPrisonersAlerts'
 import PrisonerAlertsService from '../../../services/prisonerAlertsService'
+import AppointeeAttendeeService from '../../../services/appointeeAttendeeService'
 
 export default function Edit({ prisonService, activitiesService, metricsService }: Services): Router {
   const router = Router({ mergeParams: true })
@@ -34,7 +35,8 @@ export default function Edit({ prisonService, activitiesService, metricsService 
     router.post(path, validationMiddleware(type), asyncMiddleware(handler))
 
   const editAppointmentService = new EditAppointmentService(activitiesService, metricsService)
-  const startJourneyRoutes = new StartJourneyRoutes(prisonService, metricsService)
+  const appointeeAttendeeService = new AppointeeAttendeeService(prisonService)
+  const startJourneyRoutes = new StartJourneyRoutes(prisonService, metricsService, appointeeAttendeeService)
   const prisonerAlertsService = new PrisonerAlertsService(prisonService)
   const tierRoutes = new TierRoutes(editAppointmentService)
   const hostRoutes = new HostRoutes(editAppointmentService)

--- a/server/routes/appointments/create-and-edit/handlers/copySeries.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/copySeries.test.ts
@@ -14,7 +14,6 @@ describe('Route Handlers - Duplicate Appointment - Copy Appointment Series', () 
     res = {
       render: jest.fn(),
       redirect: jest.fn(),
-      redirectOrReturn: jest.fn(),
     } as unknown as Response
 
     req = {

--- a/server/routes/appointments/create-and-edit/handlers/howToAddPrisoners.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/howToAddPrisoners.test.ts
@@ -18,7 +18,9 @@ describe('Route Handlers - Create Appointment - How to add prisoners', () => {
 
     req = {
       session: {
-        appointmentJourney: {},
+        appointmentJourney: {
+          appointmentName: 'Craftwork',
+        },
       },
       query: {},
     } as unknown as Request
@@ -29,6 +31,7 @@ describe('Route Handlers - Create Appointment - How to add prisoners', () => {
       await handler.GET(req, res)
       expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/how-to-add-prisoners', {
         HowToAddOptions,
+        appointmentJourney: req.session.appointmentJourney,
       })
     })
 
@@ -38,6 +41,7 @@ describe('Route Handlers - Create Appointment - How to add prisoners', () => {
       expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/how-to-add-prisoners', {
         preserveHistory: 'true',
         HowToAddOptions,
+        appointmentJourney: req.session.appointmentJourney,
       })
     })
   })

--- a/server/routes/appointments/create-and-edit/handlers/howToAddPrisoners.ts
+++ b/server/routes/appointments/create-and-edit/handlers/howToAddPrisoners.ts
@@ -15,10 +15,12 @@ export class HowToAddPrisonersForm {
 export default class HowToAddPrisonerRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
     const { preserveHistory } = req.query
+    const { appointmentJourney } = req.session
 
     res.render('pages/appointments/create-and-edit/how-to-add-prisoners', {
       preserveHistory,
       HowToAddOptions,
+      appointmentJourney,
     })
   }
 

--- a/server/routes/appointments/create-and-edit/handlers/noAttendees.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/noAttendees.test.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express'
+import NoAttendees from './noAttendees'
+
+describe('Route Handlers - Duplicate Appointment - No Attendees', () => {
+  const handler = new NoAttendees()
+  let req: Request
+  let res: Response
+
+  beforeEach(() => {
+    res = {
+      render: jest.fn(),
+      redirect: jest.fn(),
+    } as unknown as Response
+
+    req = {
+      session: {
+        appointmentJourney: {},
+      },
+    } as unknown as Request
+  })
+
+  describe('GET', () => {
+    it('should render correct view', async () => {
+      await handler.GET(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/appointments/create-and-edit/no-attendees', {
+        appointmentJourney: req.session.appointmentJourney,
+      })
+    })
+  })
+
+  describe('POST', () => {
+    it('should redirect to how to add prisoners page when user click continue', async () => {
+      await handler.POST(req, res)
+
+      expect(res.redirect).toBeCalledWith('how-to-add-prisoners')
+    })
+  })
+})

--- a/server/routes/appointments/create-and-edit/handlers/noAttendees.ts
+++ b/server/routes/appointments/create-and-edit/handlers/noAttendees.ts
@@ -1,0 +1,15 @@
+import { Request, Response } from 'express'
+
+export default class NoAttendeesRoutes {
+  GET = async (req: Request, res: Response): Promise<void> => {
+    const { appointmentJourney } = req.session
+
+    res.render('pages/appointments/create-and-edit/no-attendees', {
+      appointmentJourney,
+    })
+  }
+
+  POST = async (req: Request, res: Response): Promise<void> => {
+    res.redirect('how-to-add-prisoners')
+  }
+}

--- a/server/routes/appointments/create-and-edit/handlers/startJourney.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/startJourney.test.ts
@@ -9,19 +9,23 @@ import { YesNo } from '../../../../@types/activities'
 import PrisonService from '../../../../services/prisonService'
 import { Prisoner } from '../../../../@types/prisonerOffenderSearchImport/types'
 import MetricsService from '../../../../services/metricsService'
+import AppointeeAttendeeService from '../../../../services/appointeeAttendeeService'
 import MetricsEvent from '../../../../data/metricsEvent'
 import { MetricsEventType } from '../../../../@types/metricsEvents'
 import EventTier, { eventTierDescriptions } from '../../../../enum/eventTiers'
 import EventOrganiser, { organiserDescriptions } from '../../../../enum/eventOrganisers'
+import atLeast from '../../../../../jest.setup'
 
 jest.mock('../../../../services/prisonService')
 jest.mock('../../../../services/metricsService')
+jest.mock('../../../../services/appointeeAttendeeService')
 
 const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
 const metricsService = new MetricsService(null) as jest.Mocked<MetricsService>
+const appointeeAttendeeService = new AppointeeAttendeeService(null) as jest.Mocked<AppointeeAttendeeService>
 
 describe('Route Handlers - Create Appointment - Start', () => {
-  const handler = new StartJourneyRoutes(prisonService, metricsService)
+  const handler = new StartJourneyRoutes(prisonService, metricsService, appointeeAttendeeService)
   let req: Request
   let res: Response
   const journeyId = uuidv4()
@@ -40,6 +44,7 @@ describe('Route Handlers - Create Appointment - Start', () => {
       },
     ],
   } as unknown as AppointmentSeriesDetails
+
   const appointment = {
     id: 12,
     appointmentSeries: { id: 2, schedule: { frequency: 'WEEKLY', numberOfAppointments: 3 } },
@@ -171,6 +176,10 @@ describe('Route Handlers - Create Appointment - Start', () => {
     it('should set mode, original appointment id and redirect', async () => {
       req.appointment = appointment
 
+      when(appointeeAttendeeService.findUnavailableAttendees)
+        .calledWith(atLeast(['A1234BC', 'B2345CD'], res.locals.user))
+        .mockResolvedValueOnce([])
+
       await handler.COPY(req, res)
 
       expect(req.session.appointmentJourney).toEqual(expectedJourney(AppointmentJourneyMode.COPY, appointment.id))
@@ -189,6 +198,62 @@ describe('Route Handlers - Create Appointment - Start', () => {
       // )
 
       expect(res.redirect).toHaveBeenCalledWith('../review-prisoners')
+    })
+
+    it('should remove any prisoners who are unavailable', async () => {
+      req.appointment = appointment
+
+      when(appointeeAttendeeService.findUnavailableAttendees)
+        .calledWith(atLeast(['A1234BC', 'B2345CD'], res.locals.user))
+        .mockResolvedValueOnce(['A1234BC'])
+
+      await handler.COPY(req, res)
+
+      expect(req.session.appointmentJourney.prisoners.map(p => p.number)).toEqual(['B2345CD'])
+
+      expect(req.session.appointmentSetJourney).toBeUndefined()
+
+      expect(Date.now() - req.session.journeyMetrics.journeyStartTime).toBeLessThanOrEqual(1000)
+      expect(req.session.journeyMetrics.source).toBeUndefined()
+
+      // TODO
+      // expect(metricsService.trackEvent).toBeCalledWith(
+      //   new MetricsEvent(MetricsEventType.EDIT_APPOINTMENT_JOURNEY_STARTED, res.locals.user)
+      //     .addProperty('journeyId', journeyId)
+      //     .addProperty('appointmentId', appointment.id)
+      //     .addProperty('property', 'location')
+      //     .addProperty('isApplyToQuestionRequired', 'true'),
+      // )
+
+      expect(res.redirect).toHaveBeenCalledWith('../review-prisoners')
+    })
+
+    it('should render how to add prisoners page if no attendees remain', async () => {
+      req.appointment = appointment
+
+      when(appointeeAttendeeService.findUnavailableAttendees)
+        .calledWith(atLeast(['A1234BC', 'B2345CD'], res.locals.user))
+        .mockResolvedValueOnce(['A1234BC', 'B2345CD'])
+
+      await handler.COPY(req, res)
+
+      expect(req.session.appointmentJourney.prisoners).toHaveLength(0)
+
+      expect(req.session.appointmentSetJourney).toBeUndefined()
+
+      expect(Date.now() - req.session.journeyMetrics.journeyStartTime).toBeLessThanOrEqual(1000)
+      expect(req.session.journeyMetrics.source).toBeUndefined()
+
+      // TODO
+      // expect(metricsService.trackEvent).toBeCalledWith(
+      //   new MetricsEvent(MetricsEventType.EDIT_APPOINTMENT_JOURNEY_STARTED, res.locals.user)
+      //     .addProperty('journeyId', journeyId)
+      //     .addProperty('appointmentId', appointment.id)
+      //     .addProperty('property', 'location')
+      //     .addProperty('isApplyToQuestionRequired', 'true'),
+      // )
+
+      expect(res.redirect).toHaveBeenCalledWith('../how-to-add-prisoners')
     })
   })
 

--- a/server/routes/appointments/create-and-edit/handlers/startJourney.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/startJourney.test.ts
@@ -228,7 +228,7 @@ describe('Route Handlers - Create Appointment - Start', () => {
       expect(res.redirect).toHaveBeenCalledWith('../review-prisoners')
     })
 
-    it('should render how to add prisoners page if no attendees remain', async () => {
+    it('should render no attendees view if no attendees remain', async () => {
       req.appointment = appointment
 
       when(appointeeAttendeeService.findUnavailableAttendees)
@@ -253,7 +253,7 @@ describe('Route Handlers - Create Appointment - Start', () => {
       //     .addProperty('isApplyToQuestionRequired', 'true'),
       // )
 
-      expect(res.redirect).toHaveBeenCalledWith('../how-to-add-prisoners')
+      expect(res.redirect).toHaveBeenCalledWith('../no-attendees')
     })
   })
 

--- a/server/routes/appointments/create-and-edit/handlers/startJourney.ts
+++ b/server/routes/appointments/create-and-edit/handlers/startJourney.ts
@@ -72,7 +72,7 @@ export default class StartJourneyRoutes {
     // this.metricsService.trackEvent(MetricsEvent.CREATE_APPOINTMENT_JOURNEY_STARTED(req, res.locals.user))
 
     if (appointmentJourney.prisoners.length === 0) {
-      return res.redirect('../how-to-add-prisoners')
+      return res.redirect('../no-attendees')
     }
 
     return res.redirect('../review-prisoners')

--- a/server/services/appointeeAttendeeService.test.ts
+++ b/server/services/appointeeAttendeeService.test.ts
@@ -1,0 +1,202 @@
+import { when } from 'jest-when'
+import { addDays, subDays } from 'date-fns'
+import { ServiceUser } from '../@types/express'
+import PrisonService from './prisonService'
+import atLeast from '../../jest.setup'
+import { Prisoner } from '../@types/prisonerOffenderSearchImport/types'
+import { formatIsoDate } from '../utils/datePickerUtils'
+import AppointeeAttendeeService from './appointeeAttendeeService'
+
+jest.mock('./prisonService')
+
+const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+
+describe('Appointee Attendee Service', () => {
+  const appointeeAttendeeService = new AppointeeAttendeeService(prisonService)
+  const today = new Date()
+  const yesterday = subDays(today, 1)
+  const tomorrow = addDays(today, 1)
+
+  const user = {
+    activeCaseLoadId: 'MDI',
+  } as ServiceUser
+
+  const newPrisoner = (
+    prisonerNumber: string,
+    status: string,
+    lastMovementTypeCode: string,
+    confirmedReleaseDate: Date,
+  ): Prisoner => ({
+    dateOfBirth: '',
+    ethnicity: '',
+    firstName: '',
+    gender: '',
+    lastName: '',
+    prisonId: 'MDI',
+    maritalStatus: '',
+    mostSeriousOffence: '',
+    nationality: '',
+    religion: '',
+    restrictedPatient: false,
+    status,
+    youthOffender: false,
+    prisonerNumber,
+    lastMovementTypeCode,
+    confirmedReleaseDate: formatIsoDate(confirmedReleaseDate),
+  })
+
+  let prisoners: Prisoner[]
+  let prisonerA: Prisoner
+  let prisonerB: Prisoner
+
+  beforeEach(() => {
+    prisonerA = newPrisoner('AAAAAAA', 'INACTIVE OUT', 'REL', yesterday)
+    prisonerB = newPrisoner('BBBBBBB', 'INACTIVE OUT', 'CRT', yesterday)
+    prisoners = [prisonerA, prisonerB]
+  })
+
+  describe('Status is INACTIVE OUT', () => {
+    const nonReleaseMovementCodes = ['ADM', 'CRT', null, undefined]
+
+    afterEach(() => {
+      jest.resetAllMocks()
+
+      prisonService.searchInmatesByPrisonerNumbers.mockClear()
+    })
+
+    it("Should return attendee who's release date is today and last movement type was permanently released", async () => {
+      prisonerA.confirmedReleaseDate = formatIsoDate(today)
+
+      when(prisonService.searchInmatesByPrisonerNumbers)
+        .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+        .mockResolvedValueOnce(prisoners)
+
+      const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(['AAAAAAA', 'BBBBBBB'], user)
+
+      expect(unavailableAttendees).toEqual(['AAAAAAA'])
+    })
+
+    it("Should return attendee who's release date was yesterday and last movement type was permanently released", async () => {
+      prisonerA.confirmedReleaseDate = formatIsoDate(yesterday)
+
+      when(prisonService.searchInmatesByPrisonerNumbers)
+        .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+        .mockResolvedValueOnce(prisoners)
+
+      const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(['AAAAAAA', 'BBBBBBB'], user)
+
+      expect(unavailableAttendees).toEqual(['AAAAAAA'])
+    })
+
+    it("Should not return attendee who's release date is tomorrow and last movement type was permanently released", async () => {
+      prisonerA.confirmedReleaseDate = formatIsoDate(tomorrow)
+
+      when(prisonService.searchInmatesByPrisonerNumbers)
+        .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+        .mockResolvedValueOnce(prisoners)
+
+      const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(['AAAAAAA', 'BBBBBBB'], user)
+
+      expect(unavailableAttendees).toHaveLength(0)
+    })
+
+    it.each(nonReleaseMovementCodes)(
+      "Should not return attendee who's release date is yesterday and last movement type was %s",
+      async lastMovementTypeCode => {
+        prisonerA.lastMovementTypeCode = lastMovementTypeCode
+        prisonerA.confirmedReleaseDate = formatIsoDate(yesterday)
+
+        when(prisonService.searchInmatesByPrisonerNumbers)
+          .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+          .mockResolvedValueOnce(prisoners)
+
+        const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(
+          ['AAAAAAA', 'BBBBBBB'],
+          user,
+        )
+
+        expect(unavailableAttendees).toHaveLength(0)
+      },
+    )
+  })
+
+  describe('Status is ACTIVE IN', () => {
+    beforeEach(() => {
+      prisonerA.status = 'ACTIVE IN'
+      prisonerB.status = 'ACTIVE IN'
+    })
+
+    describe('is in expected prison', () => {
+      it("Should not return attendee who's release date is today and last movement type was permanently released", async () => {
+        prisonerA.lastMovementTypeCode = 'REL'
+        prisonerA.confirmedReleaseDate = formatIsoDate(today)
+
+        when(prisonService.searchInmatesByPrisonerNumbers)
+          .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+          .mockResolvedValueOnce(prisoners)
+
+        const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(
+          ['AAAAAAA', 'BBBBBBB'],
+          user,
+        )
+
+        expect(unavailableAttendees).toHaveLength(0)
+      })
+
+      it("Should not return attendee who's release date was yesterday and last movement type was permanently released", async () => {
+        prisonerA.lastMovementTypeCode = 'REL'
+        prisonerA.confirmedReleaseDate = formatIsoDate(yesterday)
+
+        when(prisonService.searchInmatesByPrisonerNumbers)
+          .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+          .mockResolvedValueOnce(prisoners)
+
+        const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(
+          ['AAAAAAA', 'BBBBBBB'],
+          user,
+        )
+
+        expect(unavailableAttendees).toHaveLength(0)
+      })
+    })
+
+    describe('In/out status is OUT', () => {
+      const wrongPrisonCodes = ['RSI', null, undefined]
+
+      beforeEach(() => {
+        prisonerA.inOutStatus = 'OUT'
+      })
+
+      it('Should not return attendee where active case load id is MDI and prison id MDI', async () => {
+        when(prisonService.searchInmatesByPrisonerNumbers)
+          .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+          .mockResolvedValueOnce(prisoners)
+
+        const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(
+          ['AAAAAAA', 'BBBBBBB'],
+          user,
+        )
+
+        expect(unavailableAttendees).toHaveLength(0)
+      })
+
+      it.each(wrongPrisonCodes)(
+        'Should return attendee active case load id is MDI but prison id is %s',
+        async wrongPrisonCode => {
+          prisonerA.prisonId = wrongPrisonCode
+
+          when(prisonService.searchInmatesByPrisonerNumbers)
+            .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+            .mockResolvedValueOnce(prisoners)
+
+          const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(
+            ['AAAAAAA', 'BBBBBBB'],
+            user,
+          )
+
+          expect(unavailableAttendees).toEqual(['AAAAAAA'])
+        },
+      )
+    })
+  })
+})

--- a/server/services/appointeeAttendeeService.ts
+++ b/server/services/appointeeAttendeeService.ts
@@ -1,0 +1,26 @@
+import { Prisoner } from '../@types/prisonerOffenderSearchImport/types'
+import PrisonService from './prisonService'
+import { toDateString } from '../utils/utils'
+import { ServiceUser } from '../@types/express'
+
+export default class AppointeeAttendeeService {
+  constructor(private readonly prisonService: PrisonService) {}
+
+  async findUnavailableAttendees(attendeePrisonerNumbers: string[], user: ServiceUser): Promise<string[]> {
+    const now = toDateString(new Date())
+
+    const prisoners = await this.prisonService.searchInmatesByPrisonerNumbers(attendeePrisonerNumbers, user)
+
+    const isPermanentlyReleased = (prisoner: Prisoner) =>
+      prisoner.status === 'INACTIVE OUT' &&
+      prisoner.confirmedReleaseDate <= now &&
+      prisoner.lastMovementTypeCode === 'REL'
+
+    const notInExpectedPrison = (prisoner: Prisoner) =>
+      prisoner.inOutStatus === 'OUT' && prisoner.prisonId !== user.activeCaseLoadId
+
+    return prisoners
+      .filter(prisoner => isPermanentlyReleased(prisoner) || notInExpectedPrison(prisoner))
+      .map(prisoner => prisoner.prisonerNumber)
+  }
+}

--- a/server/views/pages/appointments/create-and-edit/copy-series.njk
+++ b/server/views/pages/appointments/create-and-edit/copy-series.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "pages/appointments/partials/appointment-type-caption.njk" import appointmentTypeCaption %}
 {% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
 
 {% set pageTitle = appointmentJourneyTitle("copy appointment series", session.appointmentJourney) %}
@@ -15,7 +14,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-l" data-qa="caption">Manage appointments</span>
-            <h1 class="govuk-heading-l">Copying an appointment that's part of a series</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
             <p class="govuk-body-l">{{ appointmentJourney.appointmentName }} is part of a series of {{ appointmentJourney.numberOfAppointments }} appointments.</p>
 
             <form method="POST" action="copy-series">

--- a/server/views/pages/appointments/create-and-edit/how-to-add-prisoners.njk
+++ b/server/views/pages/appointments/create-and-edit/how-to-add-prisoners.njk
@@ -48,9 +48,13 @@
                     ]
                 }) }}
 
-                {{ govukButton({
-                    text: "Continue"
-                }) }}
+                <div class='govuk-button-group'>
+                    {{ govukButton({ text: "Continue" }) }}
+
+                    {% if appointmentJourney.mode == AppointmentJourneyMode.COPY %}
+                        <a class="govuk-link govuk-link--no-visited-state" href="/appointments/{{ appointmentJourney.originalAppointmentId }}">Cancel and return to appointment</a>
+                    {% endif %}
+                </div>
             </form>
         </div>
     </div>

--- a/server/views/pages/appointments/create-and-edit/no-attendees.njk
+++ b/server/views/pages/appointments/create-and-edit/no-attendees.njk
@@ -1,0 +1,30 @@
+{% extends "layout.njk" %}
+
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "pages/appointments/partials/appointment-journey-title.njk" import appointmentJourneyTitle %}
+
+{% set pageTitle = appointmentJourneyTitle("no attendess", session.appointmentJourney) %}
+{% set pageHeading = "There are no attendees for this appointment" %}
+
+{% set pageId = 'appointments-no-attendees-page' %}
+{% set jsBackLink = true %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <span class="govuk-caption-l" data-qa="caption">Schedule an Appointment</span>
+            <h1 class="govuk-heading-l">{{  pageHeading }}</h1>
+            <p>Attendees from {{ appointmentJourney.appointmentName }} on {{ appointmentJourney.startDate | toDate | formatDate }} have left {{ user.activeCaseLoadDescription }}.</p>
+            <p>If you want to continue copying the appointment, you must add someone.</p>
+
+            <form method="POST" action="no-attendees">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+                <div class='govuk-button-group appointment-copy'>
+                    {{ govukButton({ text: "Add someone to the list"}) }}
+                    <a class="govuk-link govuk-link--no-visited-state" href="/appointments/{{ appointmentJourney.originalAppointmentId }}">Cancel and return to appointment</a>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
When duplicating the appointment remove any existing attendees who are either permanently release or in another prison.

New "no attendees" view:

<img width="595" alt="image" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/1684766/7690d552-88e9-499d-b3fb-c992d5c3bd1d">
