### PR TITLE
SAA-1655: Add original appointment id to event metric

### DIFF
--- a/server/@types/activitiesAPI/index.d.ts
+++ b/server/@types/activitiesAPI/index.d.ts
@@ -3447,6 +3447,11 @@ export interface components {
        * @example This appointment will help adjusting to life outside of prison
        */
       extraInformation?: string
+      /**
+       * @description The id of the original appointment that the new appointment was copied from
+       * @example 789
+       */
+      originalAppointmentId?: number
     }
     /** @description The request with the prisoner waiting list details */
     WaitingListApplicationRequest: {

--- a/server/routes/appointments/create-and-edit/handlers/checkAnswers.test.ts
+++ b/server/routes/appointments/create-and-edit/handlers/checkAnswers.test.ts
@@ -171,6 +171,21 @@ describe('Route Handlers - Create Appointment - Check answers', () => {
       expect(res.redirect).toHaveBeenCalledWith('confirmation/16')
     })
 
+    it('should create the appointment series and redirect to confirmation page when duplicated from an original appointment', async () => {
+      req.session.appointmentJourney.originalAppointmentId = 789
+
+      expectedRequest.originalAppointmentId = 789
+
+      when(activitiesService.createAppointmentSeries)
+        .calledWith(atLeast(expectedRequest))
+        .mockResolvedValueOnce(expectedResponse)
+
+      await handler.POST(req, res)
+
+      expect(activitiesService.createAppointmentSeries).toHaveBeenCalledWith(expectedRequest, res.locals.user)
+      expect(res.redirect).toHaveBeenCalledWith('confirmation/16')
+    })
+
     it('should create the repeat appointment and redirect to confirmation page', async () => {
       req.session.appointmentJourney.repeat = YesNo.YES
       req.session.appointmentJourney.frequency = AppointmentFrequency.WEEKLY

--- a/server/routes/appointments/create-and-edit/handlers/checkAnswers.ts
+++ b/server/routes/appointments/create-and-edit/handlers/checkAnswers.ts
@@ -60,6 +60,7 @@ export default class CheckAnswersRoutes {
       startTime: plainToInstance(SimpleTime, appointmentJourney.startTime).toIsoString(),
       endTime: plainToInstance(SimpleTime, appointmentJourney.endTime).toIsoString(),
       extraInformation: appointmentJourney.extraInformation,
+      originalAppointmentId: appointmentJourney.originalAppointmentId,
     } as AppointmentSeriesCreateRequest
 
     if (appointmentJourney.repeat === YesNo.YES) {


### PR DESCRIPTION
Pass `originalAppointmentId` in create appointment request so API came add the id to the telemetry