### PR TITLE
SAA-1143 apply cancelled appointments rules on the unlock list

### DIFF
--- a/server/@types/activitiesAPI/index.d.ts
+++ b/server/@types/activitiesAPI/index.d.ts
@@ -2035,6 +2035,23 @@ export interface components {
        * @description The event priority - configurable by prison, or via defaults.
        */
       priority: number
+      /**
+       * Format: date
+       * @description The start date of the first appointment cancelled in the series
+       */
+      appointmentSeriesCancellationStartDate?: string
+      /**
+       * Format: partial-time
+       * @description The start time of the first appointment cancelled in the series
+       * @example 10:30
+       */
+      appointmentSeriesCancellationStartTime?: string
+      /**
+       * @description The appointment series frequency
+       * @example DAILY
+       * @enum {string}
+       */
+      appointmentSeriesFrequency?: 'WEEKDAY' | 'DAILY' | 'WEEKLY' | 'FORTNIGHTLY' | 'MONTHLY'
     }
     /**
      * @description
@@ -3448,7 +3465,10 @@ export interface components {
        */
       extraInformation?: string
       /**
-       * @description The id of the original appointment that the new appointment was copied from
+       * Format: int64
+       * @description
+       *     The id of the original appointment that the new appointment was copied from
+       *
        * @example 789
        */
       originalAppointmentId?: number
@@ -5658,6 +5678,12 @@ export interface components {
        * @example 20:00
        */
       edFinish: string
+      /**
+       * Format: int32
+       * @description The maximum number of days to expiry
+       * @example 21
+       */
+      maxDaysToExpiry: number
     }
     Location: {
       /**

--- a/server/services/unlockListService.test.ts
+++ b/server/services/unlockListService.test.ts
@@ -1,13 +1,16 @@
 import { when } from 'jest-when'
 import _ from 'lodash'
+import { subDays, subMonths, subWeeks } from 'date-fns'
 import ActivitiesApiClient from '../data/activitiesApiClient'
 import PrisonerSearchApiClient from '../data/prisonerSearchApiClient'
 import { ServiceUser } from '../@types/express'
-import UnlockListService from './unlockListService'
+import UnlockListService, { applyCancellationDispalyRule } from './unlockListService'
 import { PagePrisoner, PrisonerAlert } from '../@types/prisonerOffenderSearchImport/types'
-import { PrisonerScheduledEvents } from '../@types/activitiesAPI/types'
+import { PrisonerScheduledEvents, ScheduledEvent } from '../@types/activitiesAPI/types'
 import atLeast from '../../jest.setup'
 import AlertsFilterService from './alertsFilterService'
+import { AppointmentFrequency } from '../@types/appointments'
+import { toDateString } from '../utils/utils'
 
 jest.mock('../data/activitiesApiClient')
 jest.mock('../data/prisonerSearchApiClient')
@@ -464,6 +467,272 @@ describe('Unlock list service', () => {
         .map(({ alerts }) => alerts)
         .map(a => (!a ? undefined : _(a).map('alertCode').value()))
       expect(expectedAlertCodes).toEqual([undefined, ['HA', 'PEEP'], ['PEEP'], undefined])
+    })
+
+    it('filter cancelled appointments', async () => {
+      const appointmentScheduledEvents = {
+        prisonCode: 'MDI',
+        startDate: '',
+        endDate: '',
+        appointments: [
+          {
+            appointmentId: 1234,
+            prisonerNumber: 'A1111AA',
+            eventType: 'APPOINTMENT',
+            autoSuspended: false,
+            cancelled: true,
+            inCell: false,
+            offWing: false,
+            onWing: false,
+            outsidePrison: false,
+            priority: 0,
+            startTime: '',
+            suspended: false,
+            appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
+            appointmentSeriesCancellationStartDate: toDateString(subDays(new Date(), 5)),
+          },
+          {
+            appointmentId: 3456,
+            prisonerNumber: 'A2222AA',
+            eventType: 'APPOINTMENT',
+            autoSuspended: false,
+            cancelled: true,
+            inCell: false,
+            offWing: false,
+            onWing: false,
+            outsidePrison: false,
+            priority: 0,
+            startTime: '',
+            suspended: false,
+            appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
+            appointmentSeriesCancellationStartDate: toDateString(subDays(new Date(), 4)),
+          },
+        ],
+        visits: [],
+        adjudications: [],
+        externalTransfers: [],
+        courtHearings: [],
+        activities: [],
+      } as PrisonerScheduledEvents
+
+      when(prisonerSearchApiClient.searchPrisonersByLocationPrefix).mockResolvedValue(prisoners)
+      when(activitiesApiClient.getScheduledEventsByPrisonerNumbers).mockResolvedValue(appointmentScheduledEvents)
+
+      const unlockListItems = await unlockListService.getFilteredUnlockList(
+        new Date('2022-01-01'),
+        'am',
+        'HB1',
+        ['A-Wing', 'B-Wing', 'C-Wing'],
+        'With',
+        'Both',
+        [],
+        null,
+        user,
+      )
+
+      const appointments: ScheduledEvent[] = []
+
+      unlockListItems.forEach(i => {
+        i.events.forEach(item => {
+          if (item.eventType === 'APPOINTMENT') {
+            appointments.push(item)
+          }
+        })
+      })
+
+      expect(appointments).toHaveLength(1)
+    })
+  })
+
+  describe('cancelled appointment unlock list filters', () => {
+    it('should not show daily appointment more than 2 days ago', async () => {
+      const threeDaysAgo = subDays(new Date(), 3)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.DAILY,
+        appointmentSeriesCancellationStartDate: toDateString(threeDaysAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(false)
+    })
+
+    it('should show daily appointment that is 2 days old', async () => {
+      const twoDaysAgo = subDays(new Date(), 2)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.DAILY,
+        appointmentSeriesCancellationStartDate: toDateString(twoDaysAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(true)
+    })
+
+    it('should not show weekday appointment more than 4 days ago', async () => {
+      const fiveDaysAgo = subDays(new Date(), 5)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
+        appointmentSeriesCancellationStartDate: toDateString(fiveDaysAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(false)
+    })
+
+    it('should show weekday appointment that is 4 days old', async () => {
+      const fourDaysAgo = subDays(new Date(), 4)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
+        appointmentSeriesCancellationStartDate: toDateString(fourDaysAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(true)
+    })
+
+    it('should not show weekly appointment more than 2 weeks ago', async () => {
+      const fifteenDaysAgo = subDays(new Date(), 15)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.WEEKLY,
+        appointmentSeriesCancellationStartDate: toDateString(fifteenDaysAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(false)
+    })
+
+    it('should show weekly appointment that is 2 weeks old', async () => {
+      const twoWeeksAgo = subWeeks(new Date(), 2)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.WEEKLY,
+        appointmentSeriesCancellationStartDate: toDateString(twoWeeksAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(true)
+    })
+
+    it('should not show fortnightly appointment more than 4 weeks ago', async () => {
+      const twentyNineDaysAgo = subDays(new Date(), 29)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.FORTNIGHTLY,
+        appointmentSeriesCancellationStartDate: toDateString(twentyNineDaysAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(false)
+    })
+
+    it('should show fortnightly appointment that is 4 weeks old', async () => {
+      const fourWeeksAgo = subWeeks(new Date(), 4)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.FORTNIGHTLY,
+        appointmentSeriesCancellationStartDate: toDateString(fourWeeksAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(true)
+    })
+
+    it('should not show monthly appointment more than 2 months ago', async () => {
+      const overTwoMonthsAgo = subDays(subMonths(new Date(), 2), 1)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.MONTHLY,
+        appointmentSeriesCancellationStartDate: toDateString(overTwoMonthsAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(false)
+    })
+
+    it('should show monthly appointment that is 2 months old', async () => {
+      const twoMonthsAgo = subMonths(new Date(), 2)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        appointmentSeriesFrequency: AppointmentFrequency.MONTHLY,
+        appointmentSeriesCancellationStartDate: toDateString(twoMonthsAgo),
+      }
+      const showAppointment = applyCancellationDispalyRule(appointment)
+      expect(showAppointment).toEqual(true)
     })
   })
 })

--- a/server/services/unlockListService.test.ts
+++ b/server/services/unlockListService.test.ts
@@ -4,7 +4,7 @@ import { subDays, subMonths, subWeeks } from 'date-fns'
 import ActivitiesApiClient from '../data/activitiesApiClient'
 import PrisonerSearchApiClient from '../data/prisonerSearchApiClient'
 import { ServiceUser } from '../@types/express'
-import UnlockListService, { applyCancellationDispalyRule } from './unlockListService'
+import UnlockListService, { applyCancellationDisplayRule } from './unlockListService'
 import { PagePrisoner, PrisonerAlert } from '../@types/prisonerOffenderSearchImport/types'
 import { PrisonerScheduledEvents, ScheduledEvent } from '../@types/activitiesAPI/types'
 import atLeast from '../../jest.setup'
@@ -560,7 +560,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.DAILY,
         appointmentSeriesCancellationStartDate: toDateString(threeDaysAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(false)
     })
 
@@ -579,7 +579,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.DAILY,
         appointmentSeriesCancellationStartDate: toDateString(twoDaysAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)
     })
 
@@ -598,7 +598,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
         appointmentSeriesCancellationStartDate: toDateString(fiveDaysAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(false)
     })
 
@@ -617,7 +617,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
         appointmentSeriesCancellationStartDate: toDateString(fourDaysAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)
     })
 
@@ -636,7 +636,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.WEEKLY,
         appointmentSeriesCancellationStartDate: toDateString(fifteenDaysAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(false)
     })
 
@@ -655,7 +655,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.WEEKLY,
         appointmentSeriesCancellationStartDate: toDateString(twoWeeksAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)
     })
 
@@ -674,7 +674,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.FORTNIGHTLY,
         appointmentSeriesCancellationStartDate: toDateString(twentyNineDaysAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(false)
     })
 
@@ -693,7 +693,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.FORTNIGHTLY,
         appointmentSeriesCancellationStartDate: toDateString(fourWeeksAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)
     })
 
@@ -712,7 +712,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.MONTHLY,
         appointmentSeriesCancellationStartDate: toDateString(overTwoMonthsAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(false)
     })
 
@@ -731,7 +731,7 @@ describe('Unlock list service', () => {
         appointmentSeriesFrequency: AppointmentFrequency.MONTHLY,
         appointmentSeriesCancellationStartDate: toDateString(twoMonthsAgo),
       }
-      const showAppointment = applyCancellationDispalyRule(appointment)
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)
     })
   })

--- a/server/services/unlockListService.ts
+++ b/server/services/unlockListService.ts
@@ -8,7 +8,7 @@ import AlertsFilterService from './alertsFilterService'
 import { ScheduledEvent } from '../@types/activitiesAPI/types'
 import { AppointmentFrequency } from '../@types/appointments'
 
-export function applyCancellationDispalyRule(app: ScheduledEvent): boolean {
+export function applyCancellationDisplayRule(app: ScheduledEvent): boolean {
   let showAppointment = true
   const beginingOfToday = new Date().setHours(0, 0, 0, 0)
   if (app.cancelled) {
@@ -120,7 +120,7 @@ export default class UnlockListService {
     const unlockListItems = filteredPrisoners.map(prisoner => {
       const appointments = scheduledEvents?.appointments
         .filter(app => app.prisonerNumber === prisoner.prisonerNumber)
-        .filter(app => applyCancellationDispalyRule(app))
+        .filter(app => applyCancellationDisplayRule(app))
       const courtHearings = scheduledEvents?.courtHearings.filter(crt => crt.prisonerNumber === prisoner.prisonerNumber)
       const visits = scheduledEvents?.visits.filter(vis => vis.prisonerNumber === prisoner.prisonerNumber)
       const adjudications = scheduledEvents?.adjudications.filter(adj => adj.prisonerNumber === prisoner.prisonerNumber)


### PR DESCRIPTION
If the appointment repeats daily, the appointment will be shown on the ‘Unlock list’ for 2 days from the first cancelled appointment before being removed

If the appointment repeats every weekday, the appointment will be shown on the ‘Unlock list’  for 4 days from the first cancelled appointment before being removed

If the appointment repeats weekly, the appointment will be shown on the ‘Unlock list’ for 2 weeks from the first cancelled appointment before being removed

If the appointment repeats fortnightly, the appointment will be shown on the ‘Unlock list’ for 4 weeks from the first cancelled appointment before being removed

If the appointment repeats monthly, the appointment will be shown on the ‘Unlock list’ for 2 months from the first cancelled appointment before being removed