### PR TITLE
SAA-1655: Add Cypress tests

### DIFF
--- a/integration_tests/e2e/appointments/createAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createAppointment.cy.ts
@@ -78,24 +78,13 @@ context('Create group appointment', () => {
 
   it('Should complete create group appointment journey', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.appointmentsManagementCard().should('contain.text', 'Appointments scheduling and attendance')
-    indexPage
-      .appointmentsManagementCard()
-      .should(
-        'contain.text',
-        'Create, manage and edit appointments. Print movement slips. Record appointment attendance.',
-      )
     indexPage.appointmentsManagementCard().click()
 
     const appointmentsManagementPage = Page.verifyOnPage(AppointmentsManagementPage)
-    appointmentsManagementPage.createGroupAppointmentCard().should('contain.text', 'Schedule an appointment')
-    appointmentsManagementPage
-      .createGroupAppointmentCard()
-      .should('contain.text', 'Set up a one-off or repeating appointment for one or more people.')
     appointmentsManagementPage.createGroupAppointmentCard().click()
 
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)

--- a/integration_tests/e2e/appointments/createAppointmentBackLinks.cy.ts
+++ b/integration_tests/e2e/appointments/createAppointmentBackLinks.cy.ts
@@ -64,7 +64,7 @@ context('Create group appointment - back links', () => {
     cy.visit('/appointments/create/start-group')
 
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Search for them one by one')
+    howToAddPrisonersPage.selectOneByOne()
     howToAddPrisonersPage.continue()
 
     const selectPrisonerPage = Page.verifyOnPage(SelectPrisonerPage)

--- a/integration_tests/e2e/appointments/createAppointmentCheckAnswers.cy.ts
+++ b/integration_tests/e2e/appointments/createAppointmentCheckAnswers.cy.ts
@@ -78,7 +78,7 @@ context('Create group appointment - check answers change links', () => {
     cy.visit('/appointments/create/start-group')
 
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Search for them one by one')
+    howToAddPrisonersPage.selectOneByOne()
     howToAddPrisonersPage.continue()
 
     const selectPrisonerPage = Page.verifyOnPage(SelectPrisonerPage)

--- a/integration_tests/e2e/appointments/createAppointmentCsvUploadValidation.cy.ts
+++ b/integration_tests/e2e/appointments/createAppointmentCsvUploadValidation.cy.ts
@@ -15,7 +15,7 @@ context('Create group appointment - CSV upload validation', () => {
 
   it('Should fail validation when no file is selected', () => {
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)
@@ -33,7 +33,7 @@ context('Create group appointment - CSV upload validation', () => {
     cy.writeFile('integration_tests/fixtures/fileUpload/larger-than-100kb.csv', largerThan100kbData.join('\r\n'))
 
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)
@@ -47,7 +47,7 @@ context('Create group appointment - CSV upload validation', () => {
 
   it('Should fail validation when uploading an empty CSV file', () => {
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)
@@ -59,7 +59,7 @@ context('Create group appointment - CSV upload validation', () => {
 
   it('Should fail validation when uploading a non CSV file', () => {
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)
@@ -71,7 +71,7 @@ context('Create group appointment - CSV upload validation', () => {
 
   it('Should fail validation when uploading a non CSV file with the .csv extension', () => {
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)
@@ -83,7 +83,7 @@ context('Create group appointment - CSV upload validation', () => {
 
   it('Should fail validation when CSV file does not contain any prisoner numbers', () => {
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)
@@ -95,7 +95,7 @@ context('Create group appointment - CSV upload validation', () => {
 
   it('Should fail validation when one prisoner not found', () => {
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)
@@ -107,7 +107,7 @@ context('Create group appointment - CSV upload validation', () => {
 
   it('Should fail validation when two prisoners not found', () => {
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)

--- a/integration_tests/e2e/appointments/createInCellAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createInCellAppointment.cy.ts
@@ -59,30 +59,18 @@ context('Create group appointment', () => {
 
   it('Should create an in cell appointment journey', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.appointmentsManagementCard().should('contain.text', 'Appointments scheduling and attendance')
-    indexPage
-      .appointmentsManagementCard()
-      .should(
-        'contain.text',
-        'Create, manage and edit appointments. Print movement slips. Record appointment attendance.',
-      )
     indexPage.appointmentsManagementCard().click()
 
     const appointmentsManagementPage = Page.verifyOnPage(AppointmentsManagementPage)
-    appointmentsManagementPage.createGroupAppointmentCard().should('contain.text', 'Schedule an appointment')
-    appointmentsManagementPage
-      .createGroupAppointmentCard()
-      .should('contain.text', 'Set up a one-off or repeating appointment for one or more people.')
     appointmentsManagementPage.createGroupAppointmentCard().click()
 
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Search for them one by one')
+    howToAddPrisonersPage.selectOneByOne()
     howToAddPrisonersPage.continue()
 
     const selectPrisonerPage = Page.verifyOnPage(SelectPrisonerPage)
     selectPrisonerPage.enterPrisonerNumber('A8644DY')
     selectPrisonerPage.searchButton().click()
-
     selectPrisonerPage.continueButton().click()
 
     const reviewPrisonersPage = Page.verifyOnPage(ReviewPrisonersPage)

--- a/integration_tests/e2e/appointments/createRepeatAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createRepeatAppointment.cy.ts
@@ -87,24 +87,13 @@ context('Create group appointment', () => {
 
   it('Should complete create group appointment journey', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.appointmentsManagementCard().should('contain.text', 'Appointments scheduling and attendance')
-    indexPage
-      .appointmentsManagementCard()
-      .should(
-        'contain.text',
-        'Create, manage and edit appointments. Print movement slips. Record appointment attendance.',
-      )
     indexPage.appointmentsManagementCard().click()
 
     const appointmentsManagementPage = Page.verifyOnPage(AppointmentsManagementPage)
-    appointmentsManagementPage.createGroupAppointmentCard().should('contain.text', 'Schedule an appointment')
-    appointmentsManagementPage
-      .createGroupAppointmentCard()
-      .should('contain.text', 'Set up a one-off or repeating appointment for one or more people.')
     appointmentsManagementPage.createGroupAppointmentCard().click()
 
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)

--- a/integration_tests/e2e/appointments/createRetrospectiveAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/createRetrospectiveAppointment.cy.ts
@@ -74,24 +74,13 @@ context('Create a retrospective appointment', () => {
 
   it('Should complete create group appointment journey for a retrospective appointment', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
-    indexPage.appointmentsManagementCard().should('contain.text', 'Appointments scheduling and attendance')
-    indexPage
-      .appointmentsManagementCard()
-      .should(
-        'contain.text',
-        'Create, manage and edit appointments. Print movement slips. Record appointment attendance.',
-      )
     indexPage.appointmentsManagementCard().click()
 
     const appointmentsManagementPage = Page.verifyOnPage(AppointmentsManagementPage)
-    appointmentsManagementPage.createGroupAppointmentCard().should('contain.text', 'Schedule an appointment')
-    appointmentsManagementPage
-      .createGroupAppointmentCard()
-      .should('contain.text', 'Set up a one-off or repeating appointment for one or more people.')
     appointmentsManagementPage.createGroupAppointmentCard().click()
 
     const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
-    howToAddPrisonersPage.selectHowToAdd('Add a group of people using a CSV file')
+    howToAddPrisonersPage.selectGroup()
     howToAddPrisonersPage.continue()
 
     const uploadPrisonerListPage = Page.verifyOnPage(UploadPrisonerListPage)

--- a/integration_tests/e2e/appointments/duplicateAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/duplicateAppointment.cy.ts
@@ -1,0 +1,410 @@
+import { addDays, subDays } from 'date-fns'
+import Page from '../../pages/page'
+import IndexPage from '../../pages'
+import getCategories from '../../fixtures/activitiesApi/getAppointmentCategories.json'
+import getAppointmentLocations from '../../fixtures/prisonApi/getMdiAppointmentLocations.json'
+import getAppointmentSearchResults from '../../fixtures/activitiesApi/getAppointmentSearchResults.json'
+import postPrisonerNumbers from '../../fixtures/prisonerSearchApi/postPrisonerNumbers-A1350DZ-A8644DY-A1351DZ.json'
+import AppointmentsManagementPage from '../../pages/appointments/appointmentsManagementPage'
+import SearchSelectDatePage from '../../pages/appointments/appointment/searchSelectDatePage'
+import SearchResultsPage from '../../pages/appointments/appointment/appointmentsSearchResultsPage'
+import getGroupAppointmentDetails from '../../fixtures/activitiesApi/getGroupAppointmentDetails.json'
+import AppointmentDetailsPage from '../../pages/appointments/appointment/appointmentDetailsPage'
+import CopySummaryPage from '../../pages/appointments/appointment/copySummaryPage'
+import ReviewPrisonersPage from '../../pages/appointments/create-and-edit/reviewPrisonersPage'
+import DateAndTimePage from '../../pages/appointments/create-and-edit/dateAndTimePage'
+import SchedulePage from '../../pages/appointments/create-and-edit/schedulePage'
+import getGroupAppointmentSeriesDetails from '../../fixtures/activitiesApi/getGroupAppointmentSeriesDetails.json'
+import getOffenderAlerts from '../../fixtures/activitiesApi/getOffenderAlerts.json'
+import getScheduledEvents from '../../fixtures/activitiesApi/getScheduledEventsMdi20230202.json'
+import { formatDate } from '../../../server/utils/utils'
+import CheckAnswersPage from '../../pages/appointments/create-and-edit/checkAnswersPage'
+import getAppointmentSeries from '../../fixtures/activitiesApi/getAppointmentSeries.json'
+import ConfirmationPage from '../../pages/appointments/create-and-edit/confirmationPage'
+import CopySeriesPage from '../../pages/appointments/create-and-edit/copySeriesPage'
+import NoAttendeesPage from '../../pages/appointments/create-and-edit/noAttendeesPage'
+import HowToAddPrisonersPage from '../../pages/appointments/create-and-edit/howToAddPrisonersPage'
+import ReviewPrisonerAlertsPage, {
+  arsonistBadge,
+  catABadge,
+  corruptorBadge,
+  noOneToOneBadge,
+  tactBadge,
+} from '../../pages/appointments/create-and-edit/reviewPrisonerAlertsPage'
+import SelectPrisonerPage from '../../pages/appointments/create-and-edit/selectPrisonerPage'
+import getPrisonPrisoners from '../../fixtures/prisonerSearchApi/getPrisonPrisoners-MDI-A8644DY.json'
+import getPrisonerA8644DY from '../../fixtures/prisonerSearchApi/getPrisoner-MDI-A8644DY.json'
+
+context('Duplicate appointment', () => {
+  const tomorrow = addDays(new Date(), 1)
+  const tomorrowFormatted = formatDate(tomorrow, 'yyyy-MM-dd')
+
+  getGroupAppointmentSeriesDetails.startDate = tomorrowFormatted
+  getGroupAppointmentSeriesDetails.appointments[0].startDate = getGroupAppointmentSeriesDetails.startDate
+  getGroupAppointmentDetails.startDate = tomorrowFormatted
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.signIn()
+    cy.stubEndpoint('GET', '/appointment-categories', getCategories)
+    cy.stubEndpoint('GET', '/appointment-locations/MDI', getAppointmentLocations)
+    cy.stubEndpoint('POST', '/appointments/MDI/search', getAppointmentSearchResults)
+    cy.stubEndpoint('GET', '/users/jsmith', JSON.parse('{"name": "John Smith", "username": "jsmith"}'))
+    cy.stubEndpoint('GET', '/appointment-series/10/details', getGroupAppointmentSeriesDetails)
+    cy.stubEndpoint('POST', '/api/bookings/offenderNo/MDI/alerts', getOffenderAlerts)
+    cy.stubEndpoint('POST', `/scheduled-events/prison/MDI\\?date=${tomorrowFormatted}`, getScheduledEvents)
+    cy.stubEndpoint('POST', '/appointment-series', getAppointmentSeries)
+  })
+
+  context('Single', () => {
+    it('Should be able to duplicate a single appointment', () => {
+      postPrisonerNumbers[0].status = 'ACTIVE_IN'
+      postPrisonerNumbers[1].inOutStatus = 'IN'
+
+      cy.stubEndpoint('POST', '/prisoner-search/prisoner-numbers', postPrisonerNumbers)
+      cy.stubEndpoint('GET', '/appointments/11/details', getGroupAppointmentDetails)
+
+      Page.verifyOnPage(IndexPage).appointmentsManagementCard().click()
+
+      Page.verifyOnPage(AppointmentsManagementPage).searchAppointmentsCard().click()
+
+      const searchSelectDatePage = Page.verifyOnPage(SearchSelectDatePage)
+      searchSelectDatePage.selectDatePickerDate(tomorrow)
+      searchSelectDatePage.continue()
+
+      verifySearchResults()
+
+      const originalAppointmentDetailsPage = Page.verifyOnPage(AppointmentDetailsPage)
+      originalAppointmentDetailsPage.copyAppointmentLink().click()
+
+      const copySummaryPage = Page.verifyOnPage(CopySummaryPage)
+      // cancel and return to original appointment
+      copySummaryPage.firstParagraphText(
+        `This will create a new appointment, using the details of ${getGroupAppointmentDetails.appointmentName} from ${formatDate(tomorrow, 'EEEE, d MMMM yyyy')}. It will have the same:`,
+      )
+      copySummaryPage.cancelLink().click()
+
+      originalAppointmentDetailsPage.copyAppointmentLink().click()
+
+      copySummaryPage.continue()
+
+      const reviewPrisonersPage = Page.verifyOnPage(ReviewPrisonersPage)
+      reviewPrisonersPage.continue()
+
+      verifyAlerts()
+
+      const dateAndTimePage = Page.verifyOnPage(DateAndTimePage)
+      dateAndTimePage.selectDatePickerDate(tomorrow)
+      dateAndTimePage.continue()
+
+      const schedulePage = Page.verifyOnPage(SchedulePage)
+      schedulePage.continue()
+
+      verifyCheckAnswers((checkAnswersPage: CheckAnswersPage) => {
+        checkAnswersPage.assertRepeat('No')
+      })
+
+      const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+      const successMessage = `You have successfully scheduled an appointment for 3 people on ${formatDate(
+        tomorrow,
+        'EEEE, d MMMM yyyy',
+      )}.`
+      confirmationPage.assertMessageEquals(successMessage)
+      confirmationPage.assertCreateAnotherLinkExists()
+      confirmationPage.assertViewAppointmentLinkExists()
+
+      confirmationPage.viewAppointmentLink().click()
+
+      verifyNewAppointment((appointmentDetailsPage: AppointmentDetailsPage) => {
+        appointmentDetailsPage.assertNoAppointmentSeriesDetails()
+      })
+    })
+  })
+
+  context('Repeat', () => {
+    beforeEach(() => {
+      getGroupAppointmentDetails.appointmentSeries = {
+        id: 10,
+        schedule: {
+          frequency: 'WEEKLY',
+          numberOfAppointments: 4,
+        },
+        appointmentCount: 4,
+        scheduledAppointmentCount: 4,
+      }
+
+      cy.stubEndpoint('POST', '/prisoner-search/prisoner-numbers', postPrisonerNumbers)
+      cy.stubEndpoint('GET', '/appointments/11/details', getGroupAppointmentDetails)
+    })
+
+    it('Duplicate series', () => {
+      Page.verifyOnPage(IndexPage).appointmentsManagementCard().click()
+
+      Page.verifyOnPage(AppointmentsManagementPage).searchAppointmentsCard().click()
+
+      const searchSelectDatePage = Page.verifyOnPage(SearchSelectDatePage)
+      searchSelectDatePage.selectDatePickerDate(tomorrow)
+      searchSelectDatePage.continue()
+
+      verifySearchResults()
+
+      const originalAppointmentDetailsPage = Page.verifyOnPage(AppointmentDetailsPage)
+      originalAppointmentDetailsPage.copyAppointmentLink().click()
+
+      const copySummaryPage = Page.verifyOnPage(CopySummaryPage)
+      copySummaryPage.firstParagraphText(
+        `This will create a new appointment, using the details of ${getGroupAppointmentDetails.appointmentName} from ${formatDate(tomorrow, 'EEEE, d MMMM yyyy')}. It will have the same:`,
+      )
+      copySummaryPage.continue()
+
+      const reviewPrisonersPage = Page.verifyOnPage(ReviewPrisonersPage)
+      reviewPrisonersPage.continue()
+
+      verifyAlerts()
+
+      const dateAndTimePage = Page.verifyOnPage(DateAndTimePage)
+      dateAndTimePage.selectDatePickerDate(tomorrow)
+      dateAndTimePage.continue()
+
+      const copySeriesPage = Page.verifyOnPage(CopySeriesPage)
+      copySeriesPage.seriesAppointment().click()
+      copySeriesPage.continue()
+
+      const schedulePage = Page.verifyOnPage(SchedulePage)
+      schedulePage.continue()
+
+      verifyCheckAnswers((checkAnswersPage: CheckAnswersPage) => {
+        checkAnswersPage.assertRepeat('Yes')
+        checkAnswersPage.assertFrequency('Weekly')
+        checkAnswersPage.assertNumberOfAppointments('4')
+      })
+
+      const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+      const successMessage = `You have successfully scheduled an appointment for 3 people starting on ${formatDate(
+        tomorrow,
+        'EEEE, d MMMM yyyy',
+      )}. It will repeat weekly for 4 appointments`
+      confirmationPage.assertMessageEquals(successMessage)
+      confirmationPage.assertCreateAnotherLinkExists()
+      confirmationPage.assertViewAppointmentLinkExists()
+
+      confirmationPage.viewAppointmentLink().click()
+
+      verifyNewAppointment((appointmentDetailsPage: AppointmentDetailsPage) => {
+        appointmentDetailsPage.assertAppointmentSeriesDetails()
+        appointmentDetailsPage.assertSeriesFrequency('Weekly')
+        appointmentDetailsPage.assertSeriesSequence('2 of 4')
+      })
+    })
+
+    it('Duplicate single appointment', () => {
+      Page.verifyOnPage(IndexPage).appointmentsManagementCard().click()
+
+      Page.verifyOnPage(AppointmentsManagementPage).searchAppointmentsCard().click()
+
+      const searchSelectDatePage = Page.verifyOnPage(SearchSelectDatePage)
+      searchSelectDatePage.selectDatePickerDate(tomorrow)
+      searchSelectDatePage.continue()
+
+      verifySearchResults()
+
+      const originalAppointmentDetailsPage = Page.verifyOnPage(AppointmentDetailsPage)
+      originalAppointmentDetailsPage.copyAppointmentLink().click()
+
+      const copySummaryPage = Page.verifyOnPage(CopySummaryPage)
+      copySummaryPage.firstParagraphText(
+        `This will create a new appointment, using the details of ${getGroupAppointmentDetails.appointmentName} from ${formatDate(tomorrow, 'EEEE, d MMMM yyyy')}. It will have the same:`,
+      )
+      copySummaryPage.continue()
+
+      const reviewPrisonersPage = Page.verifyOnPage(ReviewPrisonersPage)
+      reviewPrisonersPage.continue()
+
+      verifyAlerts()
+
+      const dateAndTimePage = Page.verifyOnPage(DateAndTimePage)
+      dateAndTimePage.selectDatePickerDate(tomorrow)
+      dateAndTimePage.continue()
+
+      const copySeriesPage = Page.verifyOnPage(CopySeriesPage)
+      copySeriesPage.oneOffAppointment().click()
+      copySeriesPage.continue()
+
+      const schedulePage = Page.verifyOnPage(SchedulePage)
+      schedulePage.continue()
+
+      verifyCheckAnswers((checkAnswersPage: CheckAnswersPage) => {
+        checkAnswersPage.assertRepeat('No')
+      })
+
+      const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+      const successMessage = `You have successfully scheduled an appointment for 3 people starting on ${formatDate(
+        tomorrow,
+        'EEEE, d MMMM yyyy',
+      )}. It will repeat weekly for 4 appointments`
+      confirmationPage.assertMessageEquals(successMessage)
+      confirmationPage.assertCreateAnotherLinkExists()
+      confirmationPage.assertViewAppointmentLinkExists()
+
+      confirmationPage.viewAppointmentLink().click()
+
+      verifyNewAppointment((appointmentDetailsPage: AppointmentDetailsPage) => {
+        appointmentDetailsPage.assertAppointmentSeriesDetails()
+        appointmentDetailsPage.assertSeriesFrequency('Weekly')
+        appointmentDetailsPage.assertSeriesSequence('2 of 4')
+      })
+    })
+  })
+
+  context('No prisoners copied', () => {
+    const yesterday = subDays(new Date(), 1)
+    const yesterdayFormatted = formatDate(yesterday, 'yyyy-MM-dd')
+
+    beforeEach(() => {
+      getGroupAppointmentDetails.appointmentSeries = {
+        id: 10,
+      }
+
+      postPrisonerNumbers[0].status = 'INACTIVE OUT'
+      postPrisonerNumbers[0].confirmedReleaseDate = yesterdayFormatted
+      postPrisonerNumbers[0].lastMovementTypeCode = 'REL'
+
+      postPrisonerNumbers[1].inOutStatus = 'OUT'
+      postPrisonerNumbers[1].prisonId = 'RSI'
+
+      const newPostPrisonerNumbers = postPrisonerNumbers.slice(0, 2)
+
+      cy.stubEndpoint('GET', '/appointments/11/details', getGroupAppointmentDetails)
+      cy.stubEndpoint('POST', '/prisoner-search/prisoner-numbers', newPostPrisonerNumbers)
+      cy.stubEndpoint('GET', '/prison/MDI/prisoners\\?term=A8644DY&size=50', getPrisonPrisoners)
+      cy.stubEndpoint('GET', '/prisoner/A8644DY', getPrisonerA8644DY)
+    })
+
+    it('Should be able to copy appointment', () => {
+      Page.verifyOnPage(IndexPage).appointmentsManagementCard().click()
+
+      Page.verifyOnPage(AppointmentsManagementPage).searchAppointmentsCard().click()
+
+      const searchSelectDatePage = Page.verifyOnPage(SearchSelectDatePage)
+      searchSelectDatePage.selectDatePickerDate(tomorrow)
+      searchSelectDatePage.continue()
+
+      verifySearchResults()
+
+      const originalAppointmentDetailsPage = Page.verifyOnPage(AppointmentDetailsPage)
+      originalAppointmentDetailsPage.copyAppointmentLink().click()
+
+      const copySummaryPage = Page.verifyOnPage(CopySummaryPage)
+      copySummaryPage.firstParagraphText(
+        `This will create a new appointment, using the details of ${getGroupAppointmentDetails.appointmentName} from ${formatDate(tomorrow, 'EEEE, d MMMM yyyy')}. It will have the same:`,
+      )
+      copySummaryPage.continue()
+
+      const noAttendeesPage = Page.verifyOnPage(NoAttendeesPage)
+      noAttendeesPage.summaryText(
+        `Attendees from ${getGroupAppointmentDetails.appointmentName} on ${formatDate(tomorrow, 'EEEE, d MMMM yyyy')} have left Moorland.`,
+      )
+      noAttendeesPage.addSomeoneToTheListButton().click()
+
+      const howToAddPrisonersPage = Page.verifyOnPage(HowToAddPrisonersPage)
+      howToAddPrisonersPage.selectOneByOne()
+      howToAddPrisonersPage.continue()
+
+      const selectPrisonerPage = Page.verifyOnPage(SelectPrisonerPage)
+      selectPrisonerPage.enterPrisonerNumber('A8644DY')
+      selectPrisonerPage.searchButton().click()
+
+      Page.verifyOnPage(SelectPrisonerPage)
+      selectPrisonerPage.continueButton().click()
+
+      const reviewPrisonersPage = Page.verifyOnPage(ReviewPrisonersPage)
+      reviewPrisonersPage.assertPrisonerInList('Gregs, Stephen')
+      reviewPrisonersPage.continue()
+
+      const dateAndTimePage = Page.verifyOnPage(DateAndTimePage)
+      dateAndTimePage.selectDatePickerDate(tomorrow)
+      dateAndTimePage.continue()
+
+      const schedulePage = Page.verifyOnPage(SchedulePage)
+      schedulePage.continue()
+
+      const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage)
+      checkAnswersPage.assertPrisonerInList('Gregs, Stephen', 'A8644DY')
+      checkAnswersPage.assertCategory('Chaplaincy')
+      checkAnswersPage.assertTier('Tier 2')
+      checkAnswersPage.assertHost('Prison staff')
+      checkAnswersPage.assertLocation('Chapel')
+      checkAnswersPage.assertStartDate(tomorrow)
+      checkAnswersPage.assertStartTime(14, 0)
+      checkAnswersPage.assertEndTime(15, 30)
+      checkAnswersPage.createAppointment()
+
+      const confirmationPage = Page.verifyOnPage(ConfirmationPage)
+      const successMessage = `You have successfully scheduled an appointment for 3 people on ${formatDate(
+        tomorrow,
+        'EEEE, d MMMM yyyy',
+      )}.`
+      confirmationPage.assertMessageEquals(successMessage)
+      confirmationPage.assertCreateAnotherLinkExists()
+      confirmationPage.assertViewAppointmentLinkExists()
+
+      confirmationPage.viewAppointmentLink().click()
+
+      verifyNewAppointment((appointmentDetailsPage: AppointmentDetailsPage) => {
+        appointmentDetailsPage.assertNoAppointmentSeriesDetails()
+      })
+    })
+  })
+
+  const verifySearchResults = () => {
+    const searchResultsDatePage = Page.verifyOnPage(SearchResultsPage)
+    searchResultsDatePage.assertResultsLocation(0, getAppointmentSearchResults[0].internalLocation.description)
+    searchResultsDatePage.assertResultsLocation(1, 'In cell')
+    searchResultsDatePage.viewLink(0).click()
+  }
+
+  const verifyAlerts = () => {
+    const reviewPrisonerAlertsPage = Page.verifyOnPage(ReviewPrisonerAlertsPage)
+    reviewPrisonerAlertsPage.assertPrisonerInList('Lee Jacobson')
+    reviewPrisonerAlertsPage.assertBadges(arsonistBadge, catABadge, corruptorBadge, noOneToOneBadge, tactBadge)
+    reviewPrisonerAlertsPage.assertAlertDescriptions(
+      'Arsonist',
+      'Corruptor',
+      'No 1 to 1 with this prisoner',
+      'Terrorism Act or Related Offence',
+    )
+    reviewPrisonerAlertsPage.continue()
+  }
+
+  const verifyCheckAnswers = (checkRepeats: (checkAnswersPage: CheckAnswersPage) => void) => {
+    const checkAnswersPage = Page.verifyOnPage(CheckAnswersPage)
+    checkAnswersPage.assertPrisonerInList('Winchurch, David', 'A1350DZ')
+    checkAnswersPage.assertPrisonerInList('Gregs, Stephen', 'A8644DY')
+    checkAnswersPage.assertPrisonerInList('Jacobson, Lee', 'A1351DZ')
+    checkAnswersPage.assertCategory('Chaplaincy')
+    checkAnswersPage.assertTier('Tier 2')
+    checkAnswersPage.assertHost('Prison staff')
+    checkAnswersPage.assertLocation('Chapel')
+    checkAnswersPage.assertStartDate(tomorrow)
+    checkAnswersPage.assertStartTime(14, 0)
+    checkAnswersPage.assertEndTime(15, 30)
+    checkRepeats(checkAnswersPage)
+    checkAnswersPage.createAppointment()
+  }
+
+  const verifyNewAppointment = (verifySeries: (appointmentDetailsPage: AppointmentDetailsPage) => void) => {
+    const newAppointmentDetailsPage = Page.verifyOnPage(AppointmentDetailsPage)
+    verifySeries(newAppointmentDetailsPage)
+    newAppointmentDetailsPage.assertName('Chaplaincy')
+    newAppointmentDetailsPage.assertLocation('Chapel')
+    newAppointmentDetailsPage.assertStartDate(tomorrow)
+    newAppointmentDetailsPage.assertStartTime(14, 0)
+    newAppointmentDetailsPage.assertEndTime(15, 30)
+    newAppointmentDetailsPage.assertPrisonerSummary('Gregs, Stephen', 'A8644DY', '1-3')
+    newAppointmentDetailsPage.assertPrisonerSummary('Winchurch, David', 'A1350DZ', '2-2-024')
+    newAppointmentDetailsPage.assertPrisonerSummary('Jacobson, Lee', 'A1351DZ', '1')
+
+    newAppointmentDetailsPage.assertCreatedBy('J. Smith')
+  }
+})

--- a/integration_tests/e2e/appointments/manageAppointment.cy.ts
+++ b/integration_tests/e2e/appointments/manageAppointment.cy.ts
@@ -25,22 +25,9 @@ context('Manage appointment', () => {
   it('Should be able to view appointments', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.appointmentsManagementCard().should('contain.text', 'Appointments scheduling and attendance')
-    indexPage
-      .appointmentsManagementCard()
-      .should(
-        'contain.text',
-        'Create, manage and edit appointments. Print movement slips. Record appointment attendance.',
-      )
     indexPage.appointmentsManagementCard().click()
 
     const searchAppointmentsPage = Page.verifyOnPage(AppointmentsManagementPage)
-    searchAppointmentsPage.searchAppointmentsCard().should('contain.text', 'Manage existing appointments')
-    searchAppointmentsPage
-      .searchAppointmentsCard()
-      .should(
-        'contain.text',
-        'Edit the details of an appointment, including cancelling, adding and removing people, and printing movement slips.',
-      )
     searchAppointmentsPage.searchAppointmentsCard().click()
 
     const searchSelectDatePage = Page.verifyOnPage(SearchSelectDatePage)

--- a/integration_tests/fixtures/activitiesApi/getAppointmentSearchResults.json
+++ b/integration_tests/fixtures/activitiesApi/getAppointmentSearchResults.json
@@ -1,7 +1,7 @@
 [
   {
     "appointmentSeriesId": 1,
-    "appointmentId": 1,
+    "appointmentId": 11,
     "appointmentType": "INDIVIDUAL",
     "attendees": [
       {
@@ -20,12 +20,13 @@
     "startTime": "09:30",
     "endTime": "11:00",
     "isRepeat": false,
+    "isExpired": true,
     "sequenceNumber": 1,
     "maxSequenceNumber": 1
   },
   {
     "appointmentSeriesId": 1,
-    "appointmentId": 2,
+    "appointmentId": 12,
     "appointmentType": "INDIVIDUAL",
     "attendees": [
       {
@@ -42,6 +43,7 @@
     "startTime": "09:30",
     "endTime": "11:00",
     "isRepeat": false,
+    "isExpired": true,
     "sequenceNumber": 1,
     "maxSequenceNumber": 1
   }

--- a/integration_tests/fixtures/activitiesApi/getGroupAppointmentDetails.json
+++ b/integration_tests/fixtures/activitiesApi/getGroupAppointmentDetails.json
@@ -8,6 +8,16 @@
     "code": "CHAP",
     "description": "Chaplaincy"
   },
+  "tier": {
+    "id": 2,
+    "code": "TIER_2",
+    "description": "Tier 2"
+  },
+  "organiser": {
+    "id": 1,
+    "code": "PRISON_STAFF",
+    "description": "Prison staff"
+  },
   "prisonCode": "MDI",
   "appointmentName": "Chaplain Meeting (Chaplaincy)",
   "internalLocation": {
@@ -37,7 +47,8 @@
         "firstName": "STEPHEN",
         "lastName": "GREGS",
         "prisonCode": "MDI",
-        "cellLocation": "1-3"
+        "cellLocation": "1-3",
+        "category": "C"
       }
     },
     {
@@ -59,7 +70,8 @@
         "firstName": "LEE",
         "lastName": "JACOBSON",
         "prisonCode": "MDI",
-        "cellLocation": "1"
+        "cellLocation": "1",
+        "category": "A"
       }
     }
   ]

--- a/integration_tests/fixtures/prisonerSearchApi/postPrisonerNumbers-A1350DZ-A8644DY-A1351DZ.json
+++ b/integration_tests/fixtures/prisonerSearchApi/postPrisonerNumbers-A1350DZ-A8644DY-A1351DZ.json
@@ -1,0 +1,111 @@
+[
+  {
+    "prisonerNumber": "A1350DZ",
+    "bookingId": "1205032",
+    "bookNumber": "42035A",
+    "firstName": "DAVID",
+    "middleNames": "BOB",
+    "lastName": "WINCHURCH",
+    "dateOfBirth": "1976-03-14",
+    "gender": "Male",
+    "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+    "youthOffender": false,
+    "status": "ACTIVE IN",
+    "lastMovementTypeCode": "ADM",
+    "lastMovementReasonCode": "V",
+    "inOutStatus": "IN",
+    "prisonId": "MDI",
+    "prisonName": "Moorland (HMP & YOI)",
+    "cellLocation": "2-2-024",
+    "aliases": [],
+    "alerts": [],
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "RECEP_DET",
+    "imprisonmentStatusDescription": "Determinate sentence (reception)",
+    "recall": false,
+    "indeterminateSentence": false,
+    "receptionDate": "2023-02-16",
+    "locationDescription": "Moorland (HMP & YOI)",
+    "restrictedPatient": false,
+    "currentIncentive": {
+      "level": {
+        "code": "ENH",
+        "description": "Enhanced"
+      },
+      "dateTime": "2023-02-16T19:30:30",
+      "nextReviewDate": "2023-05-16"
+    }
+  },
+  {
+    "prisonerNumber": "A8644DY",
+    "bookingId": "1202189",
+    "bookNumber": "39298A",
+    "firstName": "STEPHEN",
+    "lastName": "GREGS",
+    "dateOfBirth": "1970-01-01",
+    "gender": "Male",
+    "youthOffender": false,
+    "status": "ACTIVE IN",
+    "lastMovementTypeCode": "ADM",
+    "lastMovementReasonCode": "I",
+    "inOutStatus": "IN",
+    "prisonId": "MDI",
+    "prisonName": "Moorland (HMP & YOI)",
+    "cellLocation": "1-3",
+    "aliases": [],
+    "alerts": [],
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "UNK_SENT",
+    "imprisonmentStatusDescription": "Unknown Sentenced",
+    "mostSeriousOffence": "Drive vehicle for more than 13 hours or more in a working day - domestic",
+    "recall": false,
+    "indeterminateSentence": false,
+    "receptionDate": "2022-04-25",
+    "locationDescription": "Moorland (HMP & YOI)",
+    "restrictedPatient": false,
+    "currentIncentive": {
+      "level": {
+        "code": "ENH",
+        "description": "Enhanced"
+      },
+      "dateTime": "2022-04-25T12:16:58",
+      "nextReviewDate": "2023-04-25"
+    }
+  },
+  {
+    "prisonerNumber": "A1351DZ",
+    "bookingId": "1205033",
+    "bookNumber": "39298A",
+    "firstName": "LEE",
+    "lastName": "JACOBSON",
+    "dateOfBirth": "1970-01-01",
+    "gender": "Male",
+    "youthOffender": false,
+    "status": "ACTIVE IN",
+    "lastMovementTypeCode": "ADM",
+    "lastMovementReasonCode": "I",
+    "inOutStatus": "IN",
+    "prisonId": "MDI",
+    "prisonName": "Moorland (HMP & YOI)",
+    "cellLocation": "1-3",
+    "aliases": [],
+    "alerts": [],
+    "legalStatus": "SENTENCED",
+    "imprisonmentStatus": "UNK_SENT",
+    "imprisonmentStatusDescription": "Unknown Sentenced",
+    "mostSeriousOffence": "Drive vehicle for more than 13 hours or more in a working day - domestic",
+    "recall": false,
+    "indeterminateSentence": false,
+    "receptionDate": "2022-04-25",
+    "locationDescription": "Moorland (HMP & YOI)",
+    "restrictedPatient": false,
+    "currentIncentive": {
+      "level": {
+        "code": "ENH",
+        "description": "Enhanced"
+      },
+      "dateTime": "2022-04-25T12:16:58",
+      "nextReviewDate": "2023-04-25"
+    }
+  }
+]

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -22,5 +22,11 @@ declare namespace Cypress {
      * @example cy.stubHealthPing('/health/ping', 500)
      */
     stubHealthPing(urlPattern: string, responseStatus?: number): Chainable<AUTWindow>
+
+    /**
+     * Custom command to check card is displayed.
+     * @example cy.cardIsDisplayed('[data-qa=the-card]', 'Card heading', 'Card description')
+     */
+    cardIsDisplayed(selector: string, heading: string, description: string)
   }
 }

--- a/integration_tests/pages/appointments/appointment/appointmentDetailsPage.ts
+++ b/integration_tests/pages/appointments/appointment/appointmentDetailsPage.ts
@@ -8,6 +8,9 @@ export default class AppointmentDetailsPage extends Page {
 
   printMovementSlipLink = () => cy.get('[data-qa=print-movement-slips]')
 
+  assertSeriesDetail = (header: string, value: string) =>
+    this.assertSummaryListValue('appointment-series-details', header, value)
+
   assertAppointmentDetail = (header: string, value: string) =>
     this.assertSummaryListValue('appointment-details', header, value)
 
@@ -55,4 +58,10 @@ export default class AppointmentDetailsPage extends Page {
       .find(`.govuk-summary-list__key:contains(${property})`)
       .parent()
       .find(`.govuk-summary-list__actions a:contains(Change)`)
+
+  copyAppointmentLink = (): Cypress.Chainable => cy.get('[data-qa=copy-appointment]')
+
+  assertSeriesFrequency = (frequency: string) => this.assertSeriesDetail('Frequency', frequency)
+
+  assertSeriesSequence = (sequence: string) => this.assertSeriesDetail('Appointment', sequence)
 }

--- a/integration_tests/pages/appointments/appointment/appointmentsSearchResultsPage.ts
+++ b/integration_tests/pages/appointments/appointment/appointmentsSearchResultsPage.ts
@@ -5,7 +5,12 @@ export default class SearchResultsPage extends Page {
     super('appointments-search-results-page')
   }
 
+  searchResultsTable = (): Cypress.Chainable => cy.get('table[data-qa=search-results]')
+
   assertResultsLocation = (row: number, expected: string) => {
-    cy.get('table[data-qa=search-results]').find(`td[data-qa=result-location-${row}]`).contains(expected)
+    this.searchResultsTable().find(`td[data-qa=result-location-${row}]`).contains(expected)
   }
+
+  viewLink = (row: number): Cypress.Chainable =>
+    this.searchResultsTable().find(`td[data-qa=view-and-edit-result-${row}]`)
 }

--- a/integration_tests/pages/appointments/appointment/copySummaryPage.ts
+++ b/integration_tests/pages/appointments/appointment/copySummaryPage.ts
@@ -1,0 +1,11 @@
+import Page from '../../page'
+
+export default class CopySummaryPage extends Page {
+  constructor() {
+    super('copy-appointment-page')
+  }
+
+  firstParagraphText = (text: string): Cypress.Chainable => cy.get('[data-qa=first-paragraph]').contains(text)
+
+  cancelLink = (): Cypress.Chainable => cy.get('a').contains('Cancel and return to appointment')
+}

--- a/integration_tests/pages/appointments/appointmentsManagementPage.ts
+++ b/integration_tests/pages/appointments/appointmentsManagementPage.ts
@@ -5,7 +5,17 @@ export default class AppointmentsManagementPage extends Page {
     super('appointments-management-page')
   }
 
-  createGroupAppointmentCard = (): Cypress.Chainable => cy.get('[data-qa=create-group-appointment-card]')
+  createGroupAppointmentCard = (): Cypress.Chainable =>
+    cy.cardIsDisplayed(
+      '[data-qa=create-group-appointment-card]',
+      'Schedule an appointment',
+      'Set up a one-off or repeating appointment for one or more people.',
+    )
 
-  searchAppointmentsCard = (): Cypress.Chainable => cy.get('[data-qa=search-appointments-card]')
+  searchAppointmentsCard = (): Cypress.Chainable =>
+    cy.cardIsDisplayed(
+      '[data-qa=search-appointments-card]',
+      'Manage existing appointments',
+      'Edit the details of an appointment, including cancelling, adding and removing people, and printing movement slips.',
+    )
 }

--- a/integration_tests/pages/appointments/create-and-edit/copySeriesPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/copySeriesPage.ts
@@ -1,0 +1,11 @@
+import Page from '../../page'
+
+export default class CopySeriesPage extends Page {
+  constructor() {
+    super('appointments-copy-series-page')
+  }
+
+  oneOffAppointment = (): Cypress.Chainable => this.getInputByLabel('A one-off appointment')
+
+  seriesAppointment = (): Cypress.Chainable => this.getInputByLabel('A series of repeating appointments')
+}

--- a/integration_tests/pages/appointments/create-and-edit/howToAddPrisonersPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/howToAddPrisonersPage.ts
@@ -5,7 +5,9 @@ export default class HowToAddPrisonersPage extends Page {
     super('appointments-create-how-to-add-prisoners-page')
   }
 
-  selectHowToAdd = (option: string) => this.getInputByLabel(option).click()
+  selectOneByOne = () => this.getInputByLabel('Search for them one by one').click()
+
+  selectGroup = () => this.getInputByLabel('Add a group of people using a CSV file').click()
 
   assertHowToAdd = (option: string) => cy.get(`[name='howToAdd']:checked`).next().should('contain.text', option)
 }

--- a/integration_tests/pages/appointments/create-and-edit/noAttendeesPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/noAttendeesPage.ts
@@ -1,0 +1,11 @@
+import Page from '../../page'
+
+export default class NoAttendeesPage extends Page {
+  constructor() {
+    super('appointments-no-attendees-page')
+  }
+
+  summaryText = (text: string): Cypress.Chainable => cy.get('p').contains(text)
+
+  addSomeoneToTheListButton = (): Cypress.Chainable => cy.get('button').contains('Add someone to the list')
+}

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -7,5 +7,10 @@ export default class IndexPage extends Page {
 
   activitiesCard = (): Cypress.Chainable => cy.get('[data-qa=activities-card]')
 
-  appointmentsManagementCard = (): Cypress.Chainable => cy.get('[data-qa=appointments-card]')
+  appointmentsManagementCard = (): Cypress.Chainable =>
+    cy.cardIsDisplayed(
+      '[data-qa=appointments-card]',
+      'Appointments scheduling and attendance',
+      'Create, manage and edit appointments. Print movement slips. Record appointment attendance.',
+    )
 }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -18,3 +18,7 @@ Cypress.Commands.add(
 Cypress.Commands.add('stubHealthPing', (urlPattern: string, responseStatus = 200) =>
   stubHealthPing(urlPattern, responseStatus),
 )
+
+Cypress.Commands.add('cardIsDisplayed', (selector: string, heading: string, description: string) => {
+  cy.get(selector).should('contain.text', heading).should('contain.text', description)
+})

--- a/server/services/appointeeAttendeeService.test.ts
+++ b/server/services/appointeeAttendeeService.test.ts
@@ -55,6 +55,19 @@ describe('Appointee Attendee Service', () => {
     prisoners = [prisonerA, prisonerB]
   })
 
+  it('Prisoner was not returned by search api', async () => {
+    prisonerB.inOutStatus = 'OUT'
+    prisonerB.prisonId = 'RSI'
+
+    when(prisonService.searchInmatesByPrisonerNumbers)
+      .calledWith(atLeast(['AAAAAAA', 'BBBBBBB'], user))
+      .mockResolvedValueOnce([prisonerB])
+
+    const unavailableAttendees = await appointeeAttendeeService.findUnavailableAttendees(['AAAAAAA', 'BBBBBBB'], user)
+
+    expect(unavailableAttendees).toEqual(['AAAAAAA', 'BBBBBBB'])
+  })
+
   describe('Status is INACTIVE OUT', () => {
     const nonReleaseMovementCodes = ['ADM', 'CRT', null, undefined]
 

--- a/server/services/appointeeAttendeeService.ts
+++ b/server/services/appointeeAttendeeService.ts
@@ -19,8 +19,14 @@ export default class AppointeeAttendeeService {
     const notInExpectedPrison = (prisoner: Prisoner) =>
       prisoner.inOutStatus === 'OUT' && prisoner.prisonId !== user.activeCaseLoadId
 
-    return prisoners
+    const unRecognisedPrisonerNumbers = attendeePrisonerNumbers.filter(
+      attendeePrisonerNumber => !prisoners.some(prisoner => prisoner.prisonerNumber === attendeePrisonerNumber),
+    )
+
+    const unavailablePrisoners = prisoners
       .filter(prisoner => isPermanentlyReleased(prisoner) || notInExpectedPrison(prisoner))
       .map(prisoner => prisoner.prisonerNumber)
+
+    return [...unRecognisedPrisonerNumbers, ...unavailablePrisoners]
   }
 }


### PR DESCRIPTION
- Add Cypress tests
- Ensure that that any prisoner not recognised by the search API from the original appointment is not copied to the new appointment
- Reduce boiler-plate in Cypress tests