### PR TITLE
SAA-1143: change to cancellation display rules to also count the day of the appointment

### DIFF
--- a/server/routes/activities/record-attendance/handlers/attendanceList.test.ts
+++ b/server/routes/activities/record-attendance/handlers/attendanceList.test.ts
@@ -114,12 +114,12 @@ describe('Route Handlers - Attendance List', () => {
     endTime: '11:00',
     prisonerNumber: 'ABC123',
     date: toDateString(subDays(new Date(), 2)),
-    appointmentSeriesCancellationStartDate: toDateString(subDays(new Date(), 4)),
+    appointmentSeriesCancellationStartDate: toDateString(subDays(new Date(), 3)),
     appointmentSeriesFrequency: AppointmentFrequency.DAILY,
   }
 
   const appointmentDate = subDays(new Date(), 2)
-  const threeDaysBefore = subDays(appointmentDate, 3)
+  const twoDaysBefore = subDays(appointmentDate, 2)
 
   const expiredCancelledAppointment: ScheduledEvent = {
     autoSuspended: false,
@@ -140,7 +140,7 @@ describe('Route Handlers - Attendance List', () => {
     endTime: '11:00',
     prisonerNumber: 'ABC123',
     date: toDateString(appointmentDate),
-    appointmentSeriesCancellationStartDate: toDateString(threeDaysBefore),
+    appointmentSeriesCancellationStartDate: toDateString(twoDaysBefore),
     appointmentSeriesFrequency: AppointmentFrequency.DAILY,
   }
 

--- a/server/services/unlockListService.test.ts
+++ b/server/services/unlockListService.test.ts
@@ -490,7 +490,7 @@ describe('Unlock list service', () => {
             suspended: false,
             date: toDateString(subDays(new Date(), 2)),
             appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
-            appointmentSeriesCancellationStartDate: toDateString(subDays(new Date(), 7)),
+            appointmentSeriesCancellationStartDate: toDateString(subDays(new Date(), 6)),
           },
           {
             appointmentId: 3456,
@@ -507,7 +507,7 @@ describe('Unlock list service', () => {
             suspended: false,
             date: toDateString(subDays(new Date(), 2)),
             appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
-            appointmentSeriesCancellationStartDate: toDateString(subDays(new Date(), 6)),
+            appointmentSeriesCancellationStartDate: toDateString(subDays(new Date(), 5)),
           },
         ],
         visits: [],

--- a/server/utils/applyCancellationDisplayRule.test.ts
+++ b/server/utils/applyCancellationDisplayRule.test.ts
@@ -6,28 +6,7 @@ import applyCancellationDisplayRule from './applyCancellationDisplayRule'
 
 describe('Unlock list service', () => {
   describe('cancelled appointment unlock list filters', () => {
-    it('should not show daily appointment more than 2 days before the appointment date', async () => {
-      const appointmentDate = subDays(new Date(), 2)
-      const threeDaysBefore = subDays(new Date(), 5)
-      const appointment: ScheduledEvent = {
-        autoSuspended: false,
-        cancelled: true,
-        inCell: false,
-        offWing: false,
-        onWing: false,
-        outsidePrison: false,
-        priority: 0,
-        startTime: '',
-        suspended: false,
-        date: toDateString(appointmentDate),
-        appointmentSeriesFrequency: AppointmentFrequency.DAILY,
-        appointmentSeriesCancellationStartDate: toDateString(threeDaysBefore),
-      }
-      const showAppointment = applyCancellationDisplayRule(appointment)
-      expect(showAppointment).toEqual(false)
-    })
-
-    it('should show daily appointment that is 2 days before the appointment date', async () => {
+    it('should not show daily appointment more than 1 days before the appointment date', async () => {
       const appointmentDate = subDays(new Date(), 2)
       const twoDaysBefore = subDays(new Date(), 4)
       const appointment: ScheduledEvent = {
@@ -45,12 +24,33 @@ describe('Unlock list service', () => {
         appointmentSeriesCancellationStartDate: toDateString(twoDaysBefore),
       }
       const showAppointment = applyCancellationDisplayRule(appointment)
+      expect(showAppointment).toEqual(false)
+    })
+
+    it('should show daily appointment that is 1 day before the appointment date', async () => {
+      const appointmentDate = subDays(new Date(), 2)
+      const oneDaysBefore = subDays(new Date(), 3)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        date: toDateString(appointmentDate),
+        appointmentSeriesFrequency: AppointmentFrequency.DAILY,
+        appointmentSeriesCancellationStartDate: toDateString(oneDaysBefore),
+      }
+      const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)
     })
 
-    it('should not show weekday appointment more than 4 days before the appointment date', async () => {
+    it('should not show weekday appointment more than 3 days before the appointment date', async () => {
       const appointmentDate = subDays(new Date(), 2)
-      const fiveDaysAgo = subDays(new Date(), 7)
+      const fourDaysAgo = subDays(new Date(), 6)
       const appointment: ScheduledEvent = {
         autoSuspended: false,
         cancelled: true,
@@ -63,15 +63,15 @@ describe('Unlock list service', () => {
         suspended: false,
         date: toDateString(appointmentDate),
         appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
-        appointmentSeriesCancellationStartDate: toDateString(fiveDaysAgo),
+        appointmentSeriesCancellationStartDate: toDateString(fourDaysAgo),
       }
       const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(false)
     })
 
-    it('should show weekday appointment that is 4 days before the appointment date', async () => {
+    it('should show weekday appointment that is 3 days before the appointment date', async () => {
       const appointmentDate = subDays(new Date(), 2)
-      const fourDaysBefore = subDays(new Date(), 6)
+      const threeDaysBefore = subDays(new Date(), 5)
       const appointment: ScheduledEvent = {
         autoSuspended: false,
         cancelled: true,
@@ -84,13 +84,55 @@ describe('Unlock list service', () => {
         suspended: false,
         date: toDateString(appointmentDate),
         appointmentSeriesFrequency: AppointmentFrequency.WEEKDAY,
-        appointmentSeriesCancellationStartDate: toDateString(fourDaysBefore),
+        appointmentSeriesCancellationStartDate: toDateString(threeDaysBefore),
       }
       const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)
     })
 
-    it('should not show weekly appointment more than 2 weeks before the appointment date', async () => {
+    it('should not show weekly appointment more than 1 week before the appointment date', async () => {
+      const appointmentDate = subDays(new Date(), 2)
+      const eightDaysBefore = subDays(new Date(), 10)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        date: toDateString(appointmentDate),
+        appointmentSeriesFrequency: AppointmentFrequency.WEEKLY,
+        appointmentSeriesCancellationStartDate: toDateString(eightDaysBefore),
+      }
+      const showAppointment = applyCancellationDisplayRule(appointment)
+      expect(showAppointment).toEqual(false)
+    })
+
+    it('should show weekly appointment that is 1 week before the appointment date', async () => {
+      const appointmentDate = subDays(new Date(), 2)
+      const oneWeekBefore = subDays(subWeeks(new Date(), 1), 2)
+      const appointment: ScheduledEvent = {
+        autoSuspended: false,
+        cancelled: true,
+        inCell: false,
+        offWing: false,
+        onWing: false,
+        outsidePrison: false,
+        priority: 0,
+        startTime: '',
+        suspended: false,
+        date: toDateString(appointmentDate),
+        appointmentSeriesFrequency: AppointmentFrequency.WEEKLY,
+        appointmentSeriesCancellationStartDate: toDateString(oneWeekBefore),
+      }
+      const showAppointment = applyCancellationDisplayRule(appointment)
+      expect(showAppointment).toEqual(true)
+    })
+
+    it('should not show fortnightly appointment more than 2 weeks before the appointment date', async () => {
       const appointmentDate = subDays(new Date(), 2)
       const fifteenDaysBefore = subDays(new Date(), 17)
       const appointment: ScheduledEvent = {
@@ -104,14 +146,14 @@ describe('Unlock list service', () => {
         startTime: '',
         suspended: false,
         date: toDateString(appointmentDate),
-        appointmentSeriesFrequency: AppointmentFrequency.WEEKLY,
+        appointmentSeriesFrequency: AppointmentFrequency.FORTNIGHTLY,
         appointmentSeriesCancellationStartDate: toDateString(fifteenDaysBefore),
       }
       const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(false)
     })
 
-    it('should show weekly appointment that is 2 weeks before the appointment date', async () => {
+    it('should show fortnightly appointment that is 2 weeks before the appointment date', async () => {
       const appointmentDate = subDays(new Date(), 2)
       const twoWeeksBefore = subDays(subWeeks(new Date(), 2), 2)
       const appointment: ScheduledEvent = {
@@ -125,58 +167,16 @@ describe('Unlock list service', () => {
         startTime: '',
         suspended: false,
         date: toDateString(appointmentDate),
-        appointmentSeriesFrequency: AppointmentFrequency.WEEKLY,
+        appointmentSeriesFrequency: AppointmentFrequency.FORTNIGHTLY,
         appointmentSeriesCancellationStartDate: toDateString(twoWeeksBefore),
       }
       const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)
     })
 
-    it('should not show fortnightly appointment more than 4 weeks before the appointment date', async () => {
+    it('should not show monthly appointment more than 1 month before the appointment date', async () => {
       const appointmentDate = subDays(new Date(), 2)
-      const twentyNineDaysBefore = subDays(new Date(), 31)
-      const appointment: ScheduledEvent = {
-        autoSuspended: false,
-        cancelled: true,
-        inCell: false,
-        offWing: false,
-        onWing: false,
-        outsidePrison: false,
-        priority: 0,
-        startTime: '',
-        suspended: false,
-        date: toDateString(appointmentDate),
-        appointmentSeriesFrequency: AppointmentFrequency.FORTNIGHTLY,
-        appointmentSeriesCancellationStartDate: toDateString(twentyNineDaysBefore),
-      }
-      const showAppointment = applyCancellationDisplayRule(appointment)
-      expect(showAppointment).toEqual(false)
-    })
-
-    it('should show fortnightly appointment that is 4 weeks before the appointment date', async () => {
-      const appointmentDate = subDays(new Date(), 2)
-      const fourWeeksBefore = subDays(subWeeks(new Date(), 4), 2)
-      const appointment: ScheduledEvent = {
-        autoSuspended: false,
-        cancelled: true,
-        inCell: false,
-        offWing: false,
-        onWing: false,
-        outsidePrison: false,
-        priority: 0,
-        startTime: '',
-        suspended: false,
-        date: toDateString(appointmentDate),
-        appointmentSeriesFrequency: AppointmentFrequency.FORTNIGHTLY,
-        appointmentSeriesCancellationStartDate: toDateString(fourWeeksBefore),
-      }
-      const showAppointment = applyCancellationDisplayRule(appointment)
-      expect(showAppointment).toEqual(true)
-    })
-
-    it('should not show monthly appointment more than 2 months before the appointment date', async () => {
-      const appointmentDate = subDays(new Date(), 2)
-      const overTwoMonthsBefore = subDays(subMonths(new Date(), 2), 3)
+      const overOneMonthBefore = subDays(subMonths(new Date(), 1), 3)
       const appointment: ScheduledEvent = {
         autoSuspended: false,
         cancelled: true,
@@ -189,15 +189,15 @@ describe('Unlock list service', () => {
         suspended: false,
         date: toDateString(appointmentDate),
         appointmentSeriesFrequency: AppointmentFrequency.MONTHLY,
-        appointmentSeriesCancellationStartDate: toDateString(overTwoMonthsBefore),
+        appointmentSeriesCancellationStartDate: toDateString(overOneMonthBefore),
       }
       const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(false)
     })
 
-    it('should show monthly appointment that is 2 months before the appointment date', async () => {
+    it('should show monthly appointment that is 1 month before the appointment date', async () => {
       const appointmentDate = subDays(new Date(), 2)
-      const twoMonthsBefore = subDays(subMonths(new Date(), 2), 2)
+      const oneMonthBefore = subDays(subMonths(new Date(), 1), 2)
       const appointment: ScheduledEvent = {
         autoSuspended: false,
         cancelled: true,
@@ -210,7 +210,7 @@ describe('Unlock list service', () => {
         suspended: false,
         date: toDateString(appointmentDate),
         appointmentSeriesFrequency: AppointmentFrequency.MONTHLY,
-        appointmentSeriesCancellationStartDate: toDateString(twoMonthsBefore),
+        appointmentSeriesCancellationStartDate: toDateString(oneMonthBefore),
       }
       const showAppointment = applyCancellationDisplayRule(appointment)
       expect(showAppointment).toEqual(true)

--- a/server/utils/applyCancellationDisplayRule.ts
+++ b/server/utils/applyCancellationDisplayRule.ts
@@ -9,27 +9,27 @@ export default function applyCancellationDisplayRule(app: ScheduledEvent): boole
   if (app.cancelled && app.appointmentSeriesCancellationStartDate && app.appointmentSeriesFrequency) {
     if (
       app.appointmentSeriesFrequency === AppointmentFrequency.DAILY &&
-      toDate(app.appointmentSeriesCancellationStartDate) < subDays(appointmentDate, 2)
+      toDate(app.appointmentSeriesCancellationStartDate) < subDays(appointmentDate, 1)
     ) {
       showAppointment = false
     } else if (
       app.appointmentSeriesFrequency === AppointmentFrequency.WEEKDAY &&
-      toDate(app.appointmentSeriesCancellationStartDate) < subDays(appointmentDate, 4)
+      toDate(app.appointmentSeriesCancellationStartDate) < subDays(appointmentDate, 3)
     ) {
       showAppointment = false
     } else if (
       app.appointmentSeriesFrequency === AppointmentFrequency.WEEKLY &&
-      toDate(app.appointmentSeriesCancellationStartDate) < subWeeks(appointmentDate, 2)
+      toDate(app.appointmentSeriesCancellationStartDate) < subWeeks(appointmentDate, 1)
     ) {
       showAppointment = false
     } else if (
       app.appointmentSeriesFrequency === AppointmentFrequency.FORTNIGHTLY &&
-      toDate(app.appointmentSeriesCancellationStartDate) < subWeeks(appointmentDate, 4)
+      toDate(app.appointmentSeriesCancellationStartDate) < subWeeks(appointmentDate, 2)
     ) {
       showAppointment = false
     } else if (
       app.appointmentSeriesFrequency === AppointmentFrequency.MONTHLY &&
-      toDate(app.appointmentSeriesCancellationStartDate) < subMonths(appointmentDate, 2)
+      toDate(app.appointmentSeriesCancellationStartDate) < subMonths(appointmentDate, 1)
     ) {
       showAppointment = false
     }


### PR DESCRIPTION
Currently it excludes today, so for example if DAILY it should only show for 1 historic day (include the appointment day), not 2.