### PR TITLE
SAA-647 add incentive levels to the pay rates screen

### DIFF
--- a/integration_tests/e2e/activities/createActivity.cy.ts
+++ b/integration_tests/e2e/activities/createActivity.cy.ts
@@ -86,13 +86,12 @@ context('Create activity', () => {
     payOptionPage.continue()
 
     const payRateTypePage = Page.verifyOnPage(PayRateTypePage)
-    payRateTypePage.payRateType('A single pay rate for one incentive level')
+    payRateTypePage.incentiveLevel('Standard')
     payRateTypePage.continue()
 
     const payPage = Page.verifyOnPage(PayPage)
     payPage.enterPayAmount('1.00')
     payPage.selectPayBand('Low')
-    payPage.incentiveLevel('Basic')
     payPage.reviewAndAddMoreRates()
 
     const checkPayPage = Page.verifyOnPage(CheckPayPage)
@@ -100,18 +99,17 @@ context('Create activity', () => {
     checkPayPage.addAnother()
 
     const payRateTypePage2 = Page.verifyOnPage(PayRateTypePage)
-    payRateTypePage2.payRateType('A single pay rate for one incentive level')
+    payRateTypePage2.incentiveLevel('Enhanced')
     payRateTypePage2.continue()
 
     const payPage2 = Page.verifyOnPage(PayPage)
     payPage2.enterPayAmount('1.50')
     payPage2.selectPayBand('Medium')
-    payPage2.incentiveLevel('Basic')
     payPage2.reviewAndAddMoreRates()
 
     const checkPayPage2 = Page.verifyOnPage(CheckPayPage)
     checkPayPage2.payRows().should('have.length', 2)
-    checkPayPage2.confirmPayRates()
+    checkPayPage2.continuePayRates()
 
     const qualificationPage = Page.verifyOnPage(QualificationPage)
     qualificationPage.selectQualification('Yes')

--- a/integration_tests/pages/createActivity/checkPay.ts
+++ b/integration_tests/pages/createActivity/checkPay.ts
@@ -10,7 +10,7 @@ export default class CheckPayPage extends Page {
       return Cypress.$.makeArray($el)
     })
 
-  confirmPayRates = () => cy.get('button').contains('Confirm').click()
+  continuePayRates = () => cy.get('button').contains('Continue').click()
 
-  addAnother = () => cy.get('a').contains('Add another pay rate').click()
+  addAnother = () => cy.get('a').contains('Add a pay rate').click()
 }

--- a/integration_tests/pages/createActivity/pay.ts
+++ b/integration_tests/pages/createActivity/pay.ts
@@ -11,5 +11,5 @@ export default class PayPage extends Page {
 
   incentiveLevel = (text: string) => this.getInputByLabel(text).click()
 
-  reviewAndAddMoreRates = () => cy.get('button').contains('Review and add more rates').click()
+  reviewAndAddMoreRates = () => cy.get('button').contains('Save and continue').click()
 }

--- a/integration_tests/pages/createActivity/payRateType.ts
+++ b/integration_tests/pages/createActivity/payRateType.ts
@@ -5,5 +5,5 @@ export default class PayRateTypePage extends Page {
     super('create-activity-pay-rate-type-page')
   }
 
-  payRateType = (text: string) => this.getInputByLabel(text).click()
+  incentiveLevel = (text: string) => this.getInputByLabel(text).click()
 }

--- a/server/routes/activities/create-an-activity/createAndEditRoutes.ts
+++ b/server/routes/activities/create-an-activity/createAndEditRoutes.ts
@@ -43,7 +43,7 @@ export default function Index({ activitiesService, prisonService }: Services): R
   const riskLevelHandler = new RiskLevelRoutes(activitiesService)
   const attendanceRequired = new AttendanceRequired(activitiesService)
   const payOption = new PayOption(activitiesService, prisonService)
-  const payRateTypeHandler = new PayRateTypeRoutes()
+  const payRateTypeHandler = new PayRateTypeRoutes(prisonService)
   const payHandler = new PayRoutes(prisonService, activitiesService)
   const checkPayHandler = new CheckPayRoutes(prisonService)
   const removePayHandler = new RemovePayRoutes(activitiesService, prisonService)

--- a/server/routes/activities/create-an-activity/handlers/payRateType.ts
+++ b/server/routes/activities/create-an-activity/handlers/payRateType.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from 'express'
 import { Expose } from 'class-transformer'
 import { IsNotEmpty } from 'class-validator'
+import { IncentiveLevel } from '../../../../@types/incentivesApi/types'
+import PrisonService from '../../../../services/prisonService'
 
 export class PayRateType {
   @Expose()
@@ -8,16 +10,32 @@ export class PayRateType {
     message:
       'Select if you want to create a pay rate for a single incentive level or a flat rate for all incentive levels',
   })
-  payRateTypeOption: string
+  incentiveLevel: string
 }
 
 export default class PayRateTypeRoutes {
+  constructor(private readonly prisonService: PrisonService) {}
+
   GET = async (req: Request, res: Response): Promise<void> => {
-    res.render('pages/activities/create-an-activity/pay-rate-type')
+    const { user } = res.locals
+    const incentiveLevels: IncentiveLevel[] = await this.prisonService.getIncentiveLevels(user.activeCaseLoadId, user)
+
+    res.render('pages/activities/create-an-activity/pay-rate-type', {
+      incentiveLevels,
+    })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
-    const { payRateTypeOption } = req.body
+    const { incentiveLevel } = req.body
+    let payRateTypeOption
+
+    if (incentiveLevel === 'FLAT_RATE') {
+      payRateTypeOption = 'flat'
+    } else {
+      payRateTypeOption = 'single'
+      req.session.createJourney.incentiveLevel = incentiveLevel
+    }
+
     const { preserveHistory } = req.query
     res.redirect(`pay/${payRateTypeOption}${preserveHistory ? '?preserveHistory=true' : ''}`)
   }

--- a/server/routes/activities/create-an-activity/journey.ts
+++ b/server/routes/activities/create-an-activity/journey.ts
@@ -60,4 +60,5 @@ export type CreateAnActivityJourney = {
   capacity?: number
   allocations?: Allocation[]
   runsOnBankHoliday?: boolean
+  incentiveLevel?: string
 }

--- a/server/views/pages/activities/create-an-activity/check-pay.njk
+++ b/server/views/pages/activities/create-an-activity/check-pay.njk
@@ -1,6 +1,7 @@
 {% extends "layout.njk" %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "partials/activities/activity-journey-caption.njk" import activityJourneyCaption %}
 
@@ -91,22 +92,27 @@
             }) if rows | length }}
 
             {% if flatPay | length == 0 and incentiveLevelPays | length == 0 %}
-                <p class="govuk-body">No pay rates have been set for this activity.</p>
-                <p class="govuk-body">You must set at least one pay rate or <a href="pay-option{{ "?" + preserveHistoryText if preserveHistoryText }}" class="govuk-link">change the activity to unpaid</a>.</p>
+                <p class="govuk-body">No pay rates have been set for this activity. You must set at least one pay rate.</p>
             {% endif %}
 
             <form method="POST">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                {{ govukInsetText({
+                    text: 'You can create up to 10 rates for each incentive level.'
+                }) }}
+
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Confirm",
-                        preventDoubleClick: true
-                    }) if flatPay | length > 0 or incentiveLevelPays | length > 0 }}
-                    {{ govukButton({
-                        text: "Add another pay rate",
+                        text: "Add a pay rate",
                         href: 'pay-rate-type' + (("?" + preserveHistoryText) if preserveHistoryText),
                         classes: "govuk-button--secondary"
                     }) }}
+                </div>
+                <div class="govuk-button-group">
+                    {{ govukButton({
+                        text: "Continue",
+                        preventDoubleClick: true
+                    }) if flatPay | length > 0 or incentiveLevelPays | length > 0 }}
                 </div>
             </form>
         </div>

--- a/server/views/pages/activities/create-an-activity/pay-rate-type.njk
+++ b/server/views/pages/activities/create-an-activity/pay-rate-type.njk
@@ -14,30 +14,49 @@
             <form method="POST">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
                 {{ activityJourneyCaption(session.createJourney) }}
-                {{ govukRadios({
-                    name: "payRateTypeOption",
-                    fieldset: {
-                        legend: {
-                            text: "What type of rate do you want to create?",
-                            isPageHeading: true,
-                            classes: "govuk-fieldset__legend--l"
-                        }
-                    },
-                    items: [
+                {% if session.req.params.mode == 'edit' and hasAllocations %}
+                    <input type='hidden' name='incentiveLevel' value='{{ iep }}' >
+                {% else %}
+                    {% set incentiveLevelOptions = [] %}
+                    {% for incentiveLevel in incentiveLevels %}
+                        {% set incentiveLevelOptions = (incentiveLevelOptions.push(
+                            {
+                                value: incentiveLevel.levelName,
+                                text: incentiveLevel.levelName,
+                                checked: incentiveLevel.levelName == formResponses.incentiveLevel or (incentiveLevel.levelName == iep and not formResponses)
+                            }
+                        ), incentiveLevelOptions)
+                        %}
+                    {% endfor %}
+                    {% set incentiveLevelOptions = (incentiveLevelOptions.push(
                         {
-                            value: "single",
-                            text: "A single pay rate for one incentive level",
-                            checked: session.createJourney.payRateTypeOption == "single"
+                            divider: "or"
+                        }), incentiveLevelOptions)
+                    %}
+                    {%
+                        set incentiveLevelOptions = (incentiveLevelOptions.push(
+                        {
+                            value: "FLAT_RATE",
+                            text: "A flat rate that applies to all incentive levels"
+                        }), incentiveLevelOptions)
+                    %}
+                    {{ govukRadios({
+                        name: "incentiveLevel",
+                        id: "incentiveLevel",
+                        fieldset: {
+                            legend: {
+                                text: "Choose what kind of pay rate you want to set up for the activity",
+                                isPageHeading: true,
+                                classes: "govuk-fieldset__legend--l"
+                            }
                         },
-                        {
-                            value: "flat",
-                            text: "A flat rate that applies to all incentive levels",
-                            checked: session.createJourney.payRateTypeOption == "flat"
-                        }
-                    ],
-                    errorMessage: validationErrors | findError('payRateTypeOption')
-                }) }}
-
+                        hint: {
+                            text: 'Only prisoners with the specified incentive level can be allocated to this pay rate.'
+                        },
+                        items: incentiveLevelOptions,
+                        errorMessage: validationErrors | findError('incentiveLevel')
+                    }) }}
+                {% endif %}
                 {{ govukButton({
                     text: "Continue"
                 }) }}

--- a/server/views/pages/activities/create-an-activity/pay-rate-type.njk.test.ts
+++ b/server/views/pages/activities/create-an-activity/pay-rate-type.njk.test.ts
@@ -1,0 +1,123 @@
+import cheerio from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import fs from 'fs'
+import { registerNunjucks } from '../../../../nunjucks/nunjucksSetup'
+
+const view = fs.readFileSync('server/views/pages/activities/create-an-activity/pay-rate-type.njk')
+
+describe('Views - Activity create - pay rate type', () => {
+  const incentiveLevels = [
+    {
+      levelCode: 'BAS',
+      levelName: 'Basic',
+      prisonId: 'RSI',
+      active: true,
+      defaultOnAdmission: false,
+      remandTransferLimitInPence: 2500,
+      remandSpendLimitInPence: 25000,
+      convictedTransferLimitInPence: 550,
+      convictedSpendLimitInPence: 5500,
+      visitOrders: 2,
+      privilegedVisitOrders: 0,
+    },
+    {
+      levelCode: 'STD',
+      levelName: 'Standard',
+      prisonId: 'RSI',
+      active: true,
+      defaultOnAdmission: true,
+      remandTransferLimitInPence: 5500,
+      remandSpendLimitInPence: 55000,
+      convictedTransferLimitInPence: 1980,
+      convictedSpendLimitInPence: 19800,
+      visitOrders: 2,
+      privilegedVisitOrders: 1,
+    },
+    {
+      levelCode: 'ENH',
+      levelName: 'Enhanced',
+      prisonId: 'RSI',
+      active: true,
+      defaultOnAdmission: false,
+      remandTransferLimitInPence: 6000,
+      remandSpendLimitInPence: 60000,
+      convictedTransferLimitInPence: 3300,
+      convictedSpendLimitInPence: 33000,
+      visitOrders: 2,
+      privilegedVisitOrders: 2,
+    },
+    {
+      levelCode: 'EN2',
+      levelName: 'Enhanced 2',
+      prisonId: 'RSI',
+      active: true,
+      defaultOnAdmission: false,
+      remandTransferLimitInPence: 6700,
+      remandSpendLimitInPence: 66000,
+      convictedTransferLimitInPence: 3300,
+      convictedSpendLimitInPence: 33000,
+      visitOrders: 2,
+      privilegedVisitOrders: 1,
+    },
+    {
+      levelCode: 'BAN',
+      levelName: 'Gold',
+      prisonId: 'RSI',
+      active: true,
+      defaultOnAdmission: false,
+      remandTransferLimitInPence: 6700,
+      remandSpendLimitInPence: 66000,
+      convictedTransferLimitInPence: 3300,
+      convictedSpendLimitInPence: 33000,
+      visitOrders: 2,
+      privilegedVisitOrders: 1,
+    },
+    {
+      levelCode: 'MW1',
+      levelName: 'New Mike Level',
+      prisonId: 'RSI',
+      active: true,
+      defaultOnAdmission: false,
+      remandTransferLimitInPence: 670000,
+      remandSpendLimitInPence: 66000,
+      convictedTransferLimitInPence: 3300,
+      convictedSpendLimitInPence: 33000,
+      visitOrders: 2,
+      privilegedVisitOrders: 1,
+    },
+  ]
+
+  let compiledTemplate: Template
+  const viewContext = {
+    session: {
+      createJourney: {
+        category: {
+          id: 1,
+          code: 'SAA_EDUCATION',
+          name: 'Education',
+        },
+        name: 'Test Activity',
+        tierCode: 'FOUNDATION',
+        riskLevel: 'low',
+        attendanceRequired: true,
+        paid: true,
+      },
+    },
+    params: {},
+    query: {},
+    body: {},
+    incentiveLevels,
+  }
+
+  const njkEnv = registerNunjucks()
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(view.toString(), njkEnv)
+  })
+
+  it('Views - Create Activity - pay rate type', () => {
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('input[name="incentiveLevel"][type="radio"]').length).toBe(7)
+  })
+})

--- a/server/views/pages/activities/create-an-activity/pay.njk
+++ b/server/views/pages/activities/create-an-activity/pay.njk
@@ -85,9 +85,9 @@
                 {{ govukDetails({
                     summaryText: "What is a pay band?",
                     html: '
-                            <p>A \'pay band\' is a label to help you easily tell the difference between the pay rates that someone can be paid for
-                            for this activity.</p>
-                            <p>Depending on which prison you work in, pay bands may be numbered, or named, for example \'Skilled\' or \'General\'</p>
+                            <p>\'Pay band\' is a label to help you easily tell the difference between the pay rates that someone can be paid for
+                            this activity.</p>
+                            <p>For example you might have a pay band called \'unskilled\' and another called \'skilled\'.</p>
                           '
                 }) }}
 
@@ -126,7 +126,7 @@
                 {% endif %}
 
                 {{ govukButton({
-                    text: "Review and add more rates"
+                    text: "Save and continue"
                 }) }}
             </form>
         </div>

--- a/server/views/pages/activities/create-an-activity/pay.njk
+++ b/server/views/pages/activities/create-an-activity/pay.njk
@@ -21,7 +21,11 @@
             {% if editMode %}
                 <h1 class="govuk-heading-l">Change {{ iep }} incentive level: {{ band.alias }}</h1>
             {% else %}
-                <h1 class="govuk-heading-l">Enter pay for {{ session.createJourney.name }}</h1>
+                {% if payRateType === "single" %}
+                    <h1 class="govuk-heading-l">Enter pay amount and pay band name for the {{ session.createJourney.incentiveLevel }} incentive level pay rate</h1>
+                {% else %}
+                    <h1 class="govuk-heading-l">Enter pay amount and pay band name for the flat-rate incentive level pay rate</h1>
+                {% endif %}
             {% endif %}
 
             <form method="POST">
@@ -31,11 +35,7 @@
                     {{ govukInsetText({
                         text: 'Any changes you make to this pay rate will take effect from tomorrow.'
                     }) }}
-                {% else %}
-                    <p class="govuk-body">Add all the pay rates available for this activity.</p>
-                    <p class="govuk-body">You can add up to {{ payBands | length }} rates for each incentive level. Each time you add one you'll have the option to add another.</p>
-                    <p class="govuk-body">When you come to allocate someone to this activity, all the rates that can be paid will be displayed.</p>
-                {% endif %}
+                 {% endif %}
 
                 {{ govukInput({
                     id: "rate",
@@ -95,6 +95,8 @@
                 {% if payRateType === "single" %}
                     {% if session.req.params.mode == 'edit' and hasAllocations %}
                         <input type='hidden' name='incentiveLevel' value='{{ iep }}' >
+                    {% elseif session.req.params.mode == 'create' and session.createJourney.incentiveLevel !== null %}
+                        <input type='hidden' name='incentiveLevel' value='{{ session.createJourney.incentiveLevel }}' >
                     {% else %}
                         {% set incentiveLevelOptions = [] %}
                         {% for incentiveLevel in incentiveLevels %}


### PR DESCRIPTION
On the create activity journey change the pay rate screen to add incentive levels for a single pay rate or the flat rate. This replaces adding incentive levels on the following pay screen.

 <img width="1516" alt="Screenshot 2024-06-17 at 11 44 55" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/159147179/3c6f94de-ae94-4505-8522-143b949b5afc">
<img width="1516" alt="Screenshot 2024-06-17 at 11 48 06" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/159147179/ed6a9790-f0f1-4250-a5a3-9dc800fb6b24">
<img width="1516" alt="Screenshot 2024-06-17 at 11 53 30" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/159147179/6dfc8d20-154f-459a-b022-eeb15f60d2b4">
<img width="1516" alt="Screenshot 2024-06-17 at 11 55 07" src="https://github.com/ministryofjustice/hmpps-activities-management/assets/159147179/9ca8bdef-83c1-4b4d-bd2b-cd11d6a5f693">



