### PR TITLE
SAA-1737: Redirect to single activity session view if only one instances is selected for updating attendance

### DIFF
--- a/integration_tests/e2e/activities/attendance/multipleActivities.cy.ts
+++ b/integration_tests/e2e/activities/attendance/multipleActivities.cy.ts
@@ -3,7 +3,8 @@ import IndexPage from '../../../pages'
 import Page from '../../../pages/page'
 import SelectPeriodPage from '../../../pages/recordAttendance/selectPeriod'
 import ActivitiesPage from '../../../pages/recordAttendance/activitiesPage'
-import AttendanceListPage from '../../../pages/recordAttendance/attendanceListMultiple'
+import MultipleAttendanceListPage from '../../../pages/recordAttendance/attendanceListMultiple'
+import SingleAttendanceListPage from '../../../pages/recordAttendance/attendanceList'
 import getAttendanceSummary from '../../../fixtures/activitiesApi/getAttendanceSummary.json'
 import getScheduledInstanceEnglishLevel1 from '../../../fixtures/activitiesApi/getScheduledInstance93.json'
 import getScheduledInstanceEnglishLevel2 from '../../../fixtures/activitiesApi/getScheduledInstance11.json'
@@ -74,7 +75,7 @@ context('Record attendance', () => {
     activitiesPage.selectActivitiesWithNames('English level 1', 'English level 2')
     activitiesPage.getButton('Record or edit attendance').click()
 
-    const attendanceListPage = Page.verifyOnPage(AttendanceListPage)
+    const attendanceListPage = Page.verifyOnPage(MultipleAttendanceListPage)
     attendanceListPage.assertRow(
       0,
       false,
@@ -112,7 +113,7 @@ context('Record attendance', () => {
 
     attendanceListPage.markAsAttended()
 
-    Page.verifyOnPage(AttendanceListPage)
+    Page.verifyOnPage(MultipleAttendanceListPage)
 
     attendanceListPage.assertRow(
       2,
@@ -161,7 +162,7 @@ context('Record attendance', () => {
     activitiesPage.selectActivitiesWithNames('English level 1', 'English level 2')
     activitiesPage.getButton('Record or edit attendance').click()
 
-    const attendanceListPage = Page.verifyOnPage(AttendanceListPage)
+    const attendanceListPage = Page.verifyOnPage(MultipleAttendanceListPage)
     attendanceListPage.assertRow(3, true, 'Arianniver, Eeteljan', '1-3-024', 'English level 1', 'PM', 'Not recorded')
     attendanceListPage.assertRow(7, true, 'Arianniver, Eeteljan', '1-3-024', 'English level 2', 'PM', 'Not recorded')
     attendanceListPage.clickRows(3, 7)
@@ -187,7 +188,7 @@ context('Record attendance', () => {
 
     notAttendedReasonPage.submit()
 
-    Page.verifyOnPage(AttendanceListPage)
+    Page.verifyOnPage(MultipleAttendanceListPage)
 
     attendanceListPage.assertRow(
       3,
@@ -209,5 +210,65 @@ context('Record attendance', () => {
       'Sick No pay',
       'View or Edit',
     )
+  })
+
+  it('Mark attendances for single activity when not in standalone mode', () => {
+    const indexPage = Page.verifyOnPage(IndexPage)
+    indexPage.activitiesCard().click()
+
+    const activitiesIndexPage = Page.verifyOnPage(ActivitiesIndexPage)
+    activitiesIndexPage.recordAttendanceCard().click()
+
+    const recordAttendancePage = Page.verifyOnPage(AttendanceDashboardPage)
+    recordAttendancePage.recordAttendanceCard().click()
+
+    const selectPeriodPage = Page.verifyOnPage(SelectPeriodPage)
+    selectPeriodPage.enterDate(new Date(todayStr))
+    selectPeriodPage.selectAM()
+    selectPeriodPage.continue()
+
+    const activitiesPage = Page.verifyOnPage(ActivitiesPage)
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1')
+    activitiesPage.selectActivitiesWithNames('English level 1')
+    activitiesPage.getButton('Record or edit attendance').click()
+
+    const attendanceListPage = Page.verifyOnPage(SingleAttendanceListPage)
+    attendanceListPage.checkAttendanceStatus('Andy, Booking', 'Attended')
+    attendanceListPage.checkAttendanceStatus('Andy, Booking', 'Pay')
+    attendanceListPage
+      .backLink()
+      .contains(`Go back to activities for ${formatDate(today, 'EEEE, d MMMM yyyy')} - AM`)
+      .click()
+
+    Page.verifyOnPage(ActivitiesPage)
+  })
+
+  it('Mark attendances for single activity in standalone mode', () => {
+    const indexPage = Page.verifyOnPage(IndexPage)
+    indexPage.activitiesCard().click()
+
+    const activitiesIndexPage = Page.verifyOnPage(ActivitiesIndexPage)
+    activitiesIndexPage.recordAttendanceCard().click()
+
+    const recordAttendancePage = Page.verifyOnPage(AttendanceDashboardPage)
+    recordAttendancePage.recordAttendanceCard().click()
+
+    const selectPeriodPage = Page.verifyOnPage(SelectPeriodPage)
+    selectPeriodPage.enterDate(new Date(todayStr))
+    selectPeriodPage.selectAM()
+    selectPeriodPage.continue()
+
+    const activitiesPage = Page.verifyOnPage(ActivitiesPage)
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1')
+    activitiesPage.selectActivitiesWithNames('English level 1')
+    activitiesPage.getButton('Record or edit attendance').click()
+
+    Page.verifyOnPage(SingleAttendanceListPage)
+
+    cy.visit('activities/attendance/activities/93/attendance-list?mode=standalone')
+
+    const attendanceListPage = Page.verifyOnPage(SingleAttendanceListPage)
+
+    attendanceListPage.backLink().should('not.exist')
   })
 })

--- a/integration_tests/pages/recordAttendance/attendanceList.ts
+++ b/integration_tests/pages/recordAttendance/attendanceList.ts
@@ -28,4 +28,6 @@ export default class AttendanceListPage extends Page {
   markAsNotAttended = () => cy.get('button').contains('Mark as not attended').click()
 
   cancelSessionButton = () => cy.get('a').contains('Cancel this session')
+
+  backLink = (): Cypress.Chainable => cy.get('.govuk-back-link')
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "NODE_ENV=unit-test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --detectOpenHandles --collectCoverage=true --testPathPattern='(server|frontend)/.*'",
     "security_audit": "better-npm-audit audit",
     "int-test": "cypress run --config video=false",
-    "int-test-ui": "cypress open",
+    "int-test-ui": "cypress open --config watchForFileChanges=false",
     "clean": "rm -rf dist assets build node_modules stylesheets"
   },
   "engines": {

--- a/server/routes/activities/record-attendance/handlers/activities.test.ts
+++ b/server/routes/activities/record-attendance/handlers/activities.test.ts
@@ -60,6 +60,10 @@ describe('Route Handlers - Activities', () => {
     ] as ActivityCategory[]
 
     beforeEach(() => {
+      req = {
+        session: {},
+      } as unknown as Request
+
       config.recordAttendanceSelectSlotFirst = false
 
       when(activitiesService.getActivityCategories).calledWith(res.locals.user).mockResolvedValue(mockCategories)
@@ -70,14 +74,12 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should render with the expected view', async () => {
-      req = {
-        query: {
-          date: dateString,
-          sessionFilters: 'pm,ed',
-          categoryFilters: 'SAA_EDUCATION',
-          locationFilters: 'IN_CELL,OUT_OF_CELL',
-        },
-      } as unknown as Request
+      req.query = {
+        date: dateString,
+        sessionFilters: 'pm,ed',
+        categoryFilters: 'SAA_EDUCATION',
+        locationFilters: 'IN_CELL,OUT_OF_CELL',
+      }
 
       await handler.GET(req, res)
 
@@ -125,14 +127,12 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should render with the expected view when multiple sessions are returned', async () => {
-      req = {
-        query: {
-          date: dateString,
-          sessionFilters: 'am,pm',
-          categoryFilters: 'SAA_EDUCATION,SAA_INDUSTRIES',
-          locationFilters: 'IN_CELL,OUT_OF_CELL',
-        },
-      } as unknown as Request
+      req.query = {
+        date: dateString,
+        sessionFilters: 'am,pm',
+        categoryFilters: 'SAA_EDUCATION,SAA_INDUSTRIES',
+        locationFilters: 'IN_CELL,OUT_OF_CELL',
+      }
 
       await handler.GET(req, res)
 
@@ -180,11 +180,9 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should redirect back to select date page if selected date is out of range', async () => {
-      req = {
-        query: {
-          date: format(addDays(new Date(), 61), 'yyyy-MM-dd'),
-        },
-      } as unknown as Request
+      req.query = {
+        date: format(addDays(new Date(), 61), 'yyyy-MM-dd'),
+      }
 
       await handler.GET(req, res)
 
@@ -192,12 +190,10 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should filter the activities based on the search term', async () => {
-      req = {
-        query: {
-          date: dateString,
-          searchTerm: 'english',
-        },
-      } as unknown as Request
+      req.query = {
+        date: dateString,
+        searchTerm: 'english',
+      }
 
       await handler.GET(req, res)
 
@@ -235,9 +231,7 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should filter the activities based on the time slot', async () => {
-      req = {
-        query: { date: dateString, sessionFilters: 'am' },
-      } as unknown as Request
+      req.query = { date: dateString, sessionFilters: 'am' }
 
       await handler.GET(req, res)
 
@@ -275,9 +269,7 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should filter the activities based on the category', async () => {
-      req = {
-        query: { date: dateString, categoryFilters: 'SAA_EDUCATION' },
-      } as unknown as Request
+      req.query = { date: dateString, categoryFilters: 'SAA_EDUCATION' }
 
       await handler.GET(req, res)
 
@@ -325,12 +317,10 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should filter the activities based on the location', async () => {
-      req = {
-        query: {
-          date: dateString,
-          locationFilters: 'IN_CELL',
-        },
-      } as unknown as Request
+      req.query = {
+        date: dateString,
+        locationFilters: 'IN_CELL',
+      }
 
       await handler.GET(req, res)
 
@@ -389,6 +379,10 @@ describe('Route Handlers - Activities', () => {
     ] as ActivityCategory[]
 
     beforeEach(() => {
+      req = {
+        session: {},
+      } as unknown as Request
+
       config.recordAttendanceSelectSlotFirst = true
 
       when(activitiesService.getActivityCategories).calledWith(res.locals.user).mockResolvedValue(mockCategories)
@@ -399,15 +393,13 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should render with the expected view', async () => {
-      req = {
-        query: {
-          date: dateString,
-          sessionFilters: 'pm,ed',
-          categoryFilters: 'SAA_EDUCATION',
-          locationType: LocationType.IN_CELL,
-          locationId: 100,
-        },
-      } as unknown as Request
+      req.query = {
+        date: dateString,
+        sessionFilters: 'pm,ed',
+        categoryFilters: 'SAA_EDUCATION',
+        locationType: LocationType.IN_CELL,
+        locationId: '100',
+      }
 
       await handler.GET(req, res)
 
@@ -439,15 +431,11 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should render with the expected view when multiple sessions are returned', async () => {
-      req = {
-        query: {
-          date: dateString,
-          sessionFilters: 'am,pm',
-          categoryFilters: 'SAA_EDUCATION,SAA_INDUSTRIES',
-          // locationFilters: 'IN_CELL,OUT_OF_CELL',
-          // locationType: null,
-        },
-      } as unknown as Request
+      req.query = {
+        date: dateString,
+        sessionFilters: 'am,pm',
+        categoryFilters: 'SAA_EDUCATION,SAA_INDUSTRIES',
+      }
 
       await handler.GET(req, res)
 
@@ -489,11 +477,9 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should redirect back to select date page if selected date is out of range', async () => {
-      req = {
-        query: {
-          date: format(addDays(new Date(), 61), 'yyyy-MM-dd'),
-        },
-      } as unknown as Request
+      req.query = {
+        date: format(addDays(new Date(), 61), 'yyyy-MM-dd'),
+      }
 
       await handler.GET(req, res)
 
@@ -501,12 +487,10 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should filter the activities based on the search term', async () => {
-      req = {
-        query: {
-          date: dateString,
-          searchTerm: 'english',
-        },
-      } as unknown as Request
+      req.query = {
+        date: dateString,
+        searchTerm: 'english',
+      }
 
       await handler.GET(req, res)
 
@@ -538,9 +522,7 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should filter the activities based on the time slot', async () => {
-      req = {
-        query: { date: dateString, sessionFilters: 'am' },
-      } as unknown as Request
+      req.query = { date: dateString, sessionFilters: 'am' }
 
       await handler.GET(req, res)
 
@@ -572,9 +554,7 @@ describe('Route Handlers - Activities', () => {
     })
 
     it('should filter the activities based on the category', async () => {
-      req = {
-        query: { date: dateString, categoryFilters: 'SAA_EDUCATION' },
-      } as unknown as Request
+      req.query = { date: dateString, categoryFilters: 'SAA_EDUCATION' }
 
       await handler.GET(req, res)
 
@@ -615,14 +595,32 @@ describe('Route Handlers - Activities', () => {
       })
     })
 
+    it('should clear any session data for record attendance', async () => {
+      req = {
+        query: {
+          date: dateString,
+          sessionFilters: 'am,pm',
+          categoryFilters: 'SAA_EDUCATION,SAA_INDUSTRIES',
+          locationFilters: 'IN_CELL,OUT_OF_CELL',
+        },
+        session: {
+          recordAttendanceRequests: {
+            mode: AttendActivityMode.MULTIPLE,
+          },
+        },
+      } as unknown as Request
+
+      await handler.GET(req, res)
+
+      expect(req.session.recordAttendanceRequests).toEqual({})
+    })
+
     describe('Filter by location', () => {
       it('should filter IN_CELL activities', async () => {
-        req = {
-          query: {
-            date: dateString,
-            locationType: 'IN_CELL',
-          },
-        } as unknown as Request
+        req.query = {
+          date: dateString,
+          locationType: 'IN_CELL',
+        }
 
         await handler.GET(req, res)
 
@@ -654,12 +652,10 @@ describe('Route Handlers - Activities', () => {
       })
 
       it('should filter ON_WING activities', async () => {
-        req = {
-          query: {
-            date: dateString,
-            locationType: 'ON_WING',
-          },
-        } as unknown as Request
+        req.query = {
+          date: dateString,
+          locationType: 'ON_WING',
+        }
 
         await handler.GET(req, res)
 
@@ -691,12 +687,10 @@ describe('Route Handlers - Activities', () => {
       })
 
       it('should filter OFF_WING activities', async () => {
-        req = {
-          query: {
-            date: dateString,
-            locationType: 'OFF_WING',
-          },
-        } as unknown as Request
+        req.query = {
+          date: dateString,
+          locationType: 'OFF_WING',
+        }
 
         await handler.GET(req, res)
 
@@ -728,13 +722,11 @@ describe('Route Handlers - Activities', () => {
       })
 
       it('should filter OUT_OF_CELL activities', async () => {
-        req = {
-          query: {
-            date: dateString,
-            locationType: 'OUT_OF_CELL',
-            locationId: 100,
-          },
-        } as unknown as Request
+        req.query = {
+          date: dateString,
+          locationType: 'OUT_OF_CELL',
+          locationId: '100',
+        }
 
         await handler.GET(req, res)
 
@@ -768,10 +760,12 @@ describe('Route Handlers - Activities', () => {
   })
 
   describe('POST_ATTENDANCES', () => {
-    it('should save the selected instance ids and redirect', async () => {
+    it('should save the selected instance ids and redirect when multiple instances are chosen', async () => {
       req = {
         body: {
           selectedInstanceIds: [345, 567],
+          activityDate: '2024-01-24',
+          sessionFilters: ['am', 'ed'],
         },
         session: {},
       } as unknown as Request
@@ -781,9 +775,29 @@ describe('Route Handlers - Activities', () => {
       expect(req.session.recordAttendanceRequests).toEqual({
         mode: AttendActivityMode.MULTIPLE,
         selectedInstanceIds: [345, 567],
+        activityDate: '2024-01-24',
+        sessionFilters: ['am', 'ed'],
       })
 
       expect(res.redirect).toHaveBeenCalledWith('/activities/attendance/activities/attendance-list')
+    })
+
+    it('should save the selected instance ids and redirect when a single instance is chosen', async () => {
+      req = {
+        body: {
+          selectedInstanceIds: [345],
+        },
+        session: {},
+      } as unknown as Request
+
+      await handler.POST_ATTENDANCES(req, res)
+
+      expect(req.session.recordAttendanceRequests).toEqual({
+        mode: AttendActivityMode.MULTIPLE,
+        selectedInstanceIds: [345],
+      })
+
+      expect(res.redirect).toHaveBeenCalledWith('/activities/attendance/activities/345/attendance-list')
     })
   })
 })

--- a/server/routes/activities/record-attendance/handlers/activities.ts
+++ b/server/routes/activities/record-attendance/handlers/activities.ts
@@ -79,6 +79,8 @@ export default class ActivitiesRoutes {
         return a.sessionOrderIndex - b.sessionOrderIndex
       })
 
+    req.session.recordAttendanceRequests = {}
+
     if (config.recordAttendanceSelectSlotFirst) {
       const locations = await this.prisonService.getEventLocations(user.activeCaseLoadId, user)
       const uniqueLocations = _.uniqBy(locations, 'locationId')
@@ -137,13 +139,17 @@ export default class ActivitiesRoutes {
 
   POST_ATTENDANCES = async (req: Request, res: Response): Promise<void> => {
     const { selectedInstanceIds, activityDate, sessionFilters } = req.body
+    const selectedInstanceIdsArr = selectedInstanceIds ? convertToArray(selectedInstanceIds) : []
     req.session.recordAttendanceRequests = {
       mode: AttendActivityMode.MULTIPLE,
-      selectedInstanceIds: selectedInstanceIds ? convertToArray(req.body.selectedInstanceIds) : [],
+      selectedInstanceIds: selectedInstanceIdsArr,
       activityDate,
       sessionFilters,
     }
-    res.redirect('/activities/attendance/activities/attendance-list')
+    if (selectedInstanceIdsArr.length === 1) {
+      return res.redirect(`/activities/attendance/activities/${selectedInstanceIdsArr[0]}/attendance-list`)
+    }
+    return res.redirect('/activities/attendance/activities/attendance-list')
   }
 }
 

--- a/server/views/pages/activities/daily-attendance-summary/attendances.njk
+++ b/server/views/pages/activities/daily-attendance-summary/attendances.njk
@@ -192,7 +192,7 @@
                 },
                 {
                     attributes: { id: 'activity-' + loop.index, "data-sort-value": attendee.attendance.activitySummary },
-                    html: '<a href="/activities/attendance/activities/' + attendee.attendance.scheduledInstanceId + '/attendance-list" class="govuk-link govuk-link--no-visited-state" target="_blank">' + (attendee.attendance.activitySummary | escape) + '</a>',
+                    html: '<a href="/activities/attendance/activities/' + attendee.attendance.scheduledInstanceId + '/attendance-list?mode=standalone" class="govuk-link govuk-link--no-visited-state" target="_blank">' + (attendee.attendance.activitySummary | escape) + '</a>',
                     classes: 'govuk-table__cell'
                 },
                 {

--- a/server/views/pages/activities/daily-attendance-summary/cancelled-sessions.njk
+++ b/server/views/pages/activities/daily-attendance-summary/cancelled-sessions.njk
@@ -96,7 +96,7 @@
             {% set cancelledSessionsRows = (cancelledSessionsRows.push([
                 {
                     attributes: { id: 'activity-' + loop.index, "data-sort-value": cancelledSession.summary },
-                    html: '<a href=/activities/attendance/activities/' + cancelledSession.id + '/attendance-list class="govuk-link govuk-link--no-visited-state" target="_blank">' + (cancelledSession.summary | escape) + '</a>',
+                    html: '<a href=/activities/attendance/activities/' + cancelledSession.id + '/attendance-list?mode=standalone class="govuk-link govuk-link--no-visited-state" target="_blank">' + (cancelledSession.summary | escape) + '</a>',
                     classes: 'govuk-table_cell'
                 },
                 {

--- a/server/views/pages/activities/daily-attendance-summary/suspended-prisoners.njk
+++ b/server/views/pages/activities/daily-attendance-summary/suspended-prisoners.njk
@@ -179,7 +179,7 @@
                 <div class="govuk-body-s govuk-!-margin-0">
                     <div class="govuk-!-margin-right-2">
                         <div class="govuk-!-font-weight-bold">
-                            <a href="/activities/attendance/activities/{{ session.sessionId }}/attendance-list"
+                            <a href="/activities/attendance/activities/{{ session.sessionId }}/attendance-list?mode=standalone"
                                    class="govuk-link govuk-link--no-visited-state" target='_blank'>{{ session.sessionSummary }}</a>
                         </div>
                         <div>{{ session.sessionStartTime }} - {{ session.sessionEndTime }}</div>

--- a/server/views/pages/activities/movement-list/location-events.njk
+++ b/server/views/pages/activities/movement-list/location-events.njk
@@ -24,7 +24,7 @@
 
                 {% if event.eventType == EventType.ACTIVITY and event.eventSource =='SAA' %}
                     <div>
-                        <a href="/activities/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list"
+                        <a href="/activities/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list?mode=standalone"
                            class="govuk-link govuk-link--no-visited-state" target="_blank">
                             {{ event.summary | trim }}
                         </a>

--- a/server/views/pages/activities/record-attendance/attendance-list-multiple.njk
+++ b/server/views/pages/activities/record-attendance/attendance-list-multiple.njk
@@ -6,15 +6,8 @@
 {% from "partials/attendance/otherEvent.njk" import otherEvent %}
 {% from "partials/statusBasedCellLocation.njk" import statusBasedCellLocation %}
 {% from "partials/showProfileLink.njk" import showProfileLink %}
+{% from "partials/formatSessions.njk" import formatSessions %}
 {% from "components/searchBar.njk" import searchBar %}
-
-{% macro formatSessions(selectedSessions) %}
-    {% set comma = joiner(', ') %}
-    {%- for session in selectedSessions -%}
-        {{- ' and ' if loop.last and not loop.first else comma() }}
-        {{ session | upper }}
-    {%- endfor -%}
-{% endmacro %}
 
 {% set pageTitle = applicationName + " - Record attendance" %}
 {% set pageId = 'attendance-list-page' %}

--- a/server/views/pages/activities/record-attendance/attendance-list-single.njk
+++ b/server/views/pages/activities/record-attendance/attendance-list-single.njk
@@ -12,14 +12,19 @@
 {% from "partials/attendance/otherEvent.njk" import otherEvent %}
 {% from "partials/statusBasedCellLocation.njk" import statusBasedCellLocation %}
 {% from "partials/showProfileLink.njk" import showProfileLink %}
+{% from "partials/formatSessions.njk" import formatSessions %}
 {% from "partials/service-user-name.njk" import serviceUserName %}
 
 {% set pageTitle = applicationName + " - Record attendance" %}
 {% set pageId = 'attendance-list-page' %}
-{% set jsBackLink = true %}
 {% set cancelledComment = '' %}
 {% if instance.comment !== undefined and instance.comment !== null %}
- {% set cancelledComment = " - "+instance.comment %}
+  {% set cancelledComment = " - "+instance.comment %}
+{% endif %}
+{% set activityDate = instance.date | toDate | formatDate %}
+{% if selectedSessions.length > 0 %}
+    {% set hardBackLinkText = 'Go back to activities for ' + activityDate + ' - ' + formatSessions(selectedSessions) %}
+    {% set hardBackLinkHref = '/activities/attendance/activities?date=' + session.recordAttendanceRequests.activityDate + '&sessionFilters=' + selectedSessions | join(",") %}
 {% endif %}
 
 {% block content %}
@@ -43,9 +48,7 @@
                 <span class="govuk-caption-l">
                     {{ instance.startTime }} to {{ instance.endTime }} ({{ instance.startTime | getTimeSlotFromTime | upper }})
                 </span>
-                <span class="govuk-caption-l">
-                    {{ instance.date | toDate | formatDate }}
-                </span>
+                <span class="govuk-caption-l">{{ activityDate }}</span>
                 <span class="govuk-caption-l">
                     {{ 
                         ("In cell" if instance.activitySchedule.activity.inCell) or 

--- a/server/views/partials/formatSessions.njk
+++ b/server/views/partials/formatSessions.njk
@@ -1,0 +1,7 @@
+{% macro formatSessions(selectedSessions) %}
+    {% set comma = joiner(', ') %}
+    {%- for session in selectedSessions -%}
+        {{- ' and ' if loop.last and not loop.first else comma() }}
+        {{ session | upper }}
+    {%- endfor -%}
+{% endmacro %}

--- a/server/views/partials/showUnlockEvents.njk
+++ b/server/views/partials/showUnlockEvents.njk
@@ -7,7 +7,7 @@
             <div class="govuk-!-margin-right-2 event-details">
                 <div class="govuk-!-font-weight-bold">
                     {% if event.eventType === 'ACTIVITY' and event.eventSource === 'SAA' %}
-                        <a href="/activities/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list?preserveHistory=true"
+                        <a href="/activities/attendance/activities/{{ event.scheduledInstanceId }}/attendance-list?mode=standalone&preserveHistory=true"
                         class="govuk-link govuk-link--no-visited-state"
                         target="_blank">
                             {{- event.summary | trim -}}<span class="govuk-visually-hidden"> (opens in new tab)</span>


### PR DESCRIPTION
If use selects only one atcivity session from activites list during mark attendance then redirect to single attendance list view such that they user can cancel / print.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/b055976d-0e40-4fd8-9a6f-2d868eb80406">

