### PR TITLE
Fix error handling of async middleware in book a video link journey

### DIFF
--- a/server/routes/appointments/video-link-booking/middleware/initialiseJourney.ts
+++ b/server/routes/appointments/video-link-booking/middleware/initialiseJourney.ts
@@ -2,9 +2,10 @@ import { RequestHandler } from 'express'
 import { parse } from 'date-fns'
 import _ from 'lodash'
 import { Services } from '../../../../services'
+import asyncMiddleware from '../../../../middleware/asyncMiddleware'
 
 export default ({ activitiesService, bookAVideoLinkService, prisonService }: Services): RequestHandler => {
-  return async (req, res, next) => {
+  return asyncMiddleware(async (req, res, next) => {
     const { bookingId } = req.params
     const { user } = res.locals
 
@@ -81,5 +82,5 @@ export default ({ activitiesService, bookAVideoLinkService, prisonService }: Ser
     }
 
     return next()
-  }
+  })
 }


### PR DESCRIPTION
This middleware was not wrapped in any kind of try-catch method. So if an error occurred during communication with the APIs it calls, the pod would just crash.

There are more examples of this issue across the codebase which all should be addressed, I propose this precedent for what I think the fix should be