### PR TITLE
SAA-1940: Select start end times session page

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -25,6 +25,7 @@ generic-service:
     REPORTING_API_URL: "http://hmpps-digital-prison-reporting-mi-dev.hmpps-digital-prison-reporting-mi-dev.svc.cluster.local"
     BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED: "true"
     ALLOCATE_TO_NEXT_SESSION: "true"
+    CUSTOM_START_END_TIMES_ENABLED: "true"
 
   allowlist: null
 

--- a/server/routes/activities/create-an-activity/handlers/sessionTimes.test.ts
+++ b/server/routes/activities/create-an-activity/handlers/sessionTimes.test.ts
@@ -1,0 +1,211 @@
+import { Request, Response } from 'express'
+import SessionTimesRoutes from './sessionTimes'
+import ActivitiesService from '../../../../services/activitiesService'
+import { PrisonRegime } from '../../../../@types/activitiesAPI/types'
+import SimpleTime from '../../../../commonValidationTypes/simpleTime'
+import TimeSlot from '../../../../enum/timeSlot'
+
+jest.mock('../../../../services/activitiesService')
+
+const activitiesService = new ActivitiesService(null) as jest.Mocked<ActivitiesService>
+
+const prisonRegime: PrisonRegime[] = [
+  {
+    id: 3,
+    prisonCode: 'RSI',
+    amStart: '08:30',
+    amFinish: '11:45',
+    pmStart: '13:45',
+    pmFinish: '16:45',
+    edStart: '17:30',
+    edFinish: '19:15',
+    dayOfWeek: 'MONDAY',
+  },
+  {
+    id: 3,
+    prisonCode: 'RSI',
+    amStart: '08:30',
+    amFinish: '11:45',
+    pmStart: '13:45',
+    pmFinish: '16:45',
+    edStart: '17:30',
+    edFinish: '19:15',
+    dayOfWeek: 'TUESDAY',
+  },
+  {
+    id: 3,
+    prisonCode: 'RSI',
+    amStart: '08:30',
+    amFinish: '11:45',
+    pmStart: '13:45',
+    pmFinish: '16:45',
+    edStart: '17:30',
+    edFinish: '19:15',
+    dayOfWeek: 'WEDNESDAY',
+  },
+  {
+    id: 3,
+    prisonCode: 'RSI',
+    amStart: '08:30',
+    amFinish: '11:45',
+    pmStart: '13:45',
+    pmFinish: '16:45',
+    edStart: '17:30',
+    edFinish: '19:15',
+    dayOfWeek: 'THURSDAY',
+  },
+  {
+    id: 3,
+    prisonCode: 'RSI',
+    amStart: '08:30',
+    amFinish: '11:45',
+    pmStart: '13:45',
+    pmFinish: '16:45',
+    edStart: '17:30',
+    edFinish: '19:15',
+    dayOfWeek: 'FRIDAY',
+  },
+  {
+    id: 3,
+    prisonCode: 'RSI',
+    amStart: '08:30',
+    amFinish: '11:45',
+    pmStart: '13:45',
+    pmFinish: '16:45',
+    edStart: '17:30',
+    edFinish: '19:15',
+    dayOfWeek: 'SATURDAY',
+  },
+  {
+    id: 3,
+    prisonCode: 'RSI',
+    amStart: '08:30',
+    amFinish: '11:45',
+    pmStart: '13:45',
+    pmFinish: '16:45',
+    edStart: '17:30',
+    edFinish: '19:15',
+    dayOfWeek: 'SUNDAY',
+  },
+]
+
+describe('Route Handlers - Create an activity schedule - session times', () => {
+  const handler = new SessionTimesRoutes(activitiesService)
+  let req: Request
+  let res: Response
+
+  beforeEach(() => {
+    res = {
+      locals: {
+        user: {
+          username: 'joebloggs',
+        },
+      },
+      render: jest.fn(),
+      redirectOrReturn: jest.fn(),
+      redirectOrReturnWithSuccess: jest.fn(),
+    } as unknown as Response
+
+    req = {
+      session: {
+        createJourney: {
+          slots: {
+            '1': {
+              days: ['tuesday', 'friday'],
+              timeSlotsTuesday: ['AM'],
+              timeSlotsFriday: ['PM', 'ED'],
+            },
+          },
+        },
+      },
+      params: {},
+    } as unknown as Request
+
+    activitiesService.getPrisonRegime.mockReturnValue(Promise.resolve(prisonRegime))
+  })
+
+  describe('GET', () => {
+    it('should render the expected view', async () => {
+      await handler.GET(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/activities/create-an-activity/session-times', {
+        regimeTimes: [
+          { amFinish: '11:45', amStart: '08:30', dayOfWeek: 'TUESDAY' },
+          { dayOfWeek: 'FRIDAY', edFinish: '19:15', edStart: '17:30', pmFinish: '16:45', pmStart: '13:45' },
+        ],
+        sessionSlots: [
+          {
+            dayOfWeek: 'TUESDAY',
+            timeSlot: 'AM',
+            start: '08:30',
+            finish: '11:45',
+            isFirst: true,
+          },
+          {
+            dayOfWeek: 'FRIDAY',
+            timeSlot: 'PM',
+            start: '13:45',
+            finish: '16:45',
+            isFirst: true,
+          },
+          {
+            dayOfWeek: 'FRIDAY',
+            timeSlot: 'ED',
+            start: '17:30',
+            finish: '19:15',
+            isFirst: false,
+          },
+        ],
+      })
+    })
+  })
+
+  describe('POST', () => {
+    it('when using custom times redirect to the location page', async () => {
+      const startMap: Map<string, SimpleTime> = new Map<string, SimpleTime>()
+      const endMap: Map<string, SimpleTime> = new Map<string, SimpleTime>()
+
+      const startTime = new SimpleTime()
+      startTime.hour = 5
+      startTime.minute = 30
+
+      startMap.set('MONDAY-AM', startTime)
+
+      const endTime = new SimpleTime()
+      endTime.hour = 9
+      endTime.minute = 44
+
+      endMap.set('MONDAY-AM', endTime)
+
+      req.body = {
+        startTime: startMap,
+        endTime: endMap,
+      }
+
+      await handler.POST(req, res)
+
+      expect(req.session.createJourney.customSlots).toEqual([
+        {
+          customStartTime: '05:30',
+          customEndTime: '09:44',
+          daysOfWeek: ['MONDAY'],
+          friday: false,
+          monday: true,
+          saturday: false,
+          sunday: false,
+          thursday: false,
+          timeSlot: TimeSlot.AM,
+          tuesday: false,
+          wednesday: false,
+          weekNumber: 1,
+        },
+      ])
+
+      expect(res.redirectOrReturn).toHaveBeenCalledWith('location')
+    })
+  })
+
+  // FIXME: validation needs implementing
+  // describe('type validation', () => {
+  //   it('validation fails if a value is not entered', async () => {})
+  // })
+})

--- a/server/routes/activities/create-an-activity/handlers/sessionTimes.ts
+++ b/server/routes/activities/create-an-activity/handlers/sessionTimes.ts
@@ -1,15 +1,25 @@
 import { Request, Response } from 'express'
 import { ValidateNested } from 'class-validator'
-import { Transform, plainToInstance } from 'class-transformer'
+import { plainToInstance, Transform } from 'class-transformer'
 import ActivitiesService from '../../../../services/activitiesService'
-import getApplicableDaysAndSlotsInRegime from '../../../../utils/helpers/applicableRegimeTimeUtil'
+import getApplicableDaysAndSlotsInRegime, {
+  DaysAndSlotsInRegime,
+} from '../../../../utils/helpers/applicableRegimeTimeUtil'
 import { Slots } from '../journey'
-import { journeySlotsToCustomSlots } from '../../../../utils/helpers/activityTimeSlotMappers'
 import { Slot } from '../../../../@types/activitiesAPI/types'
 import TimeSlot from '../../../../enum/timeSlot'
 import SimpleTime from '../../../../commonValidationTypes/simpleTime'
+import { createCustomSlots } from '../../../../utils/helpers/activityTimeSlotMappers'
 
+type SessionSlot = {
+  dayOfWeek: string
+  timeSlot: TimeSlot
+  start: string
+  finish: string
+  isFirst: boolean
+}
 export class SessionTimes {
+  // validate start before end & sessions (do not overlap???)
   @Transform(({ value }) =>
     Object.keys(value).reduce((acc, k) => acc.set(k, plainToInstance(SimpleTime, value[k])), new Map()),
   )
@@ -23,6 +33,41 @@ export class SessionTimes {
   endTime: Map<string, SimpleTime>
 }
 
+function createSessionSlots(applicableRegimeTimesForActivity: DaysAndSlotsInRegime[]): SessionSlot[] {
+  const sessionSlots: SessionSlot[] = []
+  applicableRegimeTimesForActivity.forEach(day => {
+    if (day.amStart) {
+      sessionSlots.push({
+        dayOfWeek: day.dayOfWeek,
+        timeSlot: TimeSlot.AM,
+        start: day.amStart,
+        finish: day.amFinish,
+        isFirst: true,
+      })
+    }
+    if (day.pmStart) {
+      sessionSlots.push({
+        dayOfWeek: day.dayOfWeek,
+        timeSlot: TimeSlot.PM,
+        start: day.pmStart,
+        finish: day.pmFinish,
+        isFirst: !day.amStart,
+      })
+    }
+    if (day.edStart) {
+      sessionSlots.push({
+        dayOfWeek: day.dayOfWeek,
+        timeSlot: TimeSlot.ED,
+        start: day.edStart,
+        finish: day.edFinish,
+        isFirst: !day.amStart && !day.pmStart,
+      })
+    }
+  })
+
+  return sessionSlots
+}
+
 export default class SessionTimesRoutes {
   constructor(private readonly activitiesService: ActivitiesService) {}
 
@@ -32,47 +77,16 @@ export default class SessionTimesRoutes {
 
     // TODO: the week will have to be passed through from previous pages once we do split regimes, rather than hardcoded as ['1']
     const slots: Slots = req.session.createJourney.slots['1']
-    // TODO: implement real custom slots
-    const customSlots: Slot[] = journeySlotsToCustomSlots(slots)
 
-    const applicableRegimeTimesForActivity = getApplicableDaysAndSlotsInRegime(regimeTimes, slots)
+    const applicableRegimeTimesForActivity: DaysAndSlotsInRegime[] = getApplicableDaysAndSlotsInRegime(
+      regimeTimes,
+      slots,
+    )
 
-    const sessionSlots: { dayOfWeek: string; timeSlot: TimeSlot; start: string; finish: string; isFirst: boolean }[] =
-      []
-
-    applicableRegimeTimesForActivity.forEach(day => {
-      if (day.amStart) {
-        sessionSlots.push({
-          dayOfWeek: day.dayOfWeek,
-          timeSlot: TimeSlot.AM,
-          start: day.amStart,
-          finish: day.amFinish,
-          isFirst: true,
-        })
-      }
-      if (day.pmStart) {
-        sessionSlots.push({
-          dayOfWeek: day.dayOfWeek,
-          timeSlot: TimeSlot.PM,
-          start: day.pmStart,
-          finish: day.pmFinish,
-          isFirst: !day.amStart,
-        })
-      }
-      if (day.edStart) {
-        sessionSlots.push({
-          dayOfWeek: day.dayOfWeek,
-          timeSlot: TimeSlot.ED,
-          start: day.edStart,
-          finish: day.edFinish,
-          isFirst: !day.amStart && !day.pmStart,
-        })
-      }
-    })
+    const sessionSlots: SessionSlot[] = createSessionSlots(applicableRegimeTimesForActivity)
 
     res.render(`pages/activities/create-an-activity/session-times`, {
       regimeTimes: applicableRegimeTimesForActivity,
-      customSlots,
       sessionSlots,
     })
   }
@@ -80,35 +94,9 @@ export default class SessionTimesRoutes {
   POST = async (req: Request, res: Response): Promise<void> => {
     const { startTime, endTime }: SessionTimes = req.body
 
-    const startTimeObj = Array.from(startTime.keys()).reduce((acc, value) => {
-      acc[value] = startTime.get(value)
-      return value
-    })
+    const customSlots: Slot[] = createCustomSlots(startTime, endTime)
+    req.session.createJourney.customSlots = customSlots
 
-    const endTimeObj = Array.from(endTime.keys()).reduce((acc, value) => {
-      acc[value] = endTime.get(value)
-      return value
-    })
-
-    req.body.startTime = startTimeObj
-    req.body.endTime = endTimeObj
-
-    // const customSlots = req.session.createJourney.customSlots.map(customSlot => ({
-    //   customStartTime: startTimeObj,
-    //   customEndTime: endTimeObj,
-    //   daysOfWeek: customSlot.daysOfWeek,
-    //   friday: customSlot.friday,
-    //   monday: customSlot.monday,
-    //   saturday: customSlot.saturday,
-    //   sunday: customSlot.sunday,
-    //   thursday: customSlot.thursday,
-    //   timeSlot: customSlot.timeSlot,
-    //   tuesday: customSlot.tuesday,
-    //   wednesday: customSlot.wednesday,
-    //   weekNumber: 1,
-    // }))
-    // // const { customSlots } = req.body
-    // req.session.createJourney.customSlots = customSlots
     res.redirectOrReturn('location')
   }
 }

--- a/server/utils/helpers/activityTimeSlotMappers.test.ts
+++ b/server/utils/helpers/activityTimeSlotMappers.test.ts
@@ -1,17 +1,16 @@
-import { CreateAnActivityJourney, Slots } from '../../routes/activities/create-an-activity/journey'
+import { CreateAnActivityJourney } from '../../routes/activities/create-an-activity/journey'
 import activitySessionToDailyTimeSlots, {
-  activityScheduleSlotsToCustomTimeSlots,
   activitySlotsMinusExclusions,
   calculateUniqueSlots,
-  journeySlotsToCustomSlots,
+  createCustomSlots,
+  createSlot,
   mapActivityScheduleSlotsToSlots,
   mapSlotsToCompleteWeeklyTimeSlots,
   mapSlotsToWeeklyTimeSlots,
-  slotsToCustomTimeSlots,
-  WeeklyCustomTimeSlots,
 } from './activityTimeSlotMappers'
 import { ActivityScheduleSlot, Slot } from '../../@types/activitiesAPI/types'
 import TimeSlot from '../../enum/timeSlot'
+import SimpleTime from '../../commonValidationTypes/simpleTime'
 
 describe('Activity session slots to daily time slots mapper', () => {
   it("should map a activity session's slots to daily time slots", () => {
@@ -376,23 +375,21 @@ describe('calculateUniqueSlots', () => {
   })
 })
 
-describe('Journey slots to custom slots mapper', () => {
-  it('should map a journey slot to custom slots', () => {
-    const slots: Slots = {
-      timeSlotsMonday: ['AM', 'PM', 'ED'],
-      timeSlotsTuesday: ['AM', 'PM'],
-      timeSlotsWednesday: ['AM'],
-      timeSlotsThursday: ['PM'],
-      timeSlotsFriday: ['ED'],
-      timeSlotsSaturday: ['PM'],
-      timeSlotsSunday: ['AM'],
-    }
+describe('Create custom slots from session time', () => {
+  it('should map a monday morning session time to a custom slot', () => {
+    const startTime = new SimpleTime()
+    startTime.hour = 5
+    startTime.minute = 30
 
-    const customSlots: Slot[] = journeySlotsToCustomSlots(slots)
+    const endTime = new SimpleTime()
+    endTime.hour = 9
+    endTime.minute = 45
+
+    const expected: Slot = createSlot('MONDAY-AM', startTime, endTime)
 
     const mondayAM: Slot = {
-      customEndTime: '',
-      customStartTime: '',
+      customStartTime: '05:30',
+      customEndTime: '09:45',
       daysOfWeek: ['MONDAY'],
       friday: false,
       monday: true,
@@ -404,55 +401,23 @@ describe('Journey slots to custom slots mapper', () => {
       wednesday: false,
       weekNumber: 1,
     }
+    expect(expected).toEqual(mondayAM)
+  })
 
-    const mondayPM: Slot = {
-      customEndTime: '',
-      customStartTime: '',
-      daysOfWeek: ['MONDAY'],
-      friday: false,
-      monday: true,
-      saturday: false,
-      sunday: false,
-      thursday: false,
-      timeSlot: TimeSlot.PM,
-      tuesday: false,
-      wednesday: false,
-      weekNumber: 1,
-    }
+  it('should map a tuesday afternoon session time to a custom slot', () => {
+    const startTime = new SimpleTime()
+    startTime.hour = 15
+    startTime.minute = 30
 
-    const mondayED: Slot = {
-      customEndTime: '',
-      customStartTime: '',
-      daysOfWeek: ['MONDAY'],
-      friday: false,
-      monday: true,
-      saturday: false,
-      sunday: false,
-      thursday: false,
-      timeSlot: TimeSlot.ED,
-      tuesday: false,
-      wednesday: false,
-      weekNumber: 1,
-    }
+    const endTime = new SimpleTime()
+    endTime.hour = 17
+    endTime.minute = 45
 
-    const tuesdayAM: Slot = {
-      customEndTime: '',
-      customStartTime: '',
-      daysOfWeek: ['TUESDAY'],
-      friday: false,
-      monday: false,
-      saturday: false,
-      sunday: false,
-      thursday: false,
-      timeSlot: TimeSlot.AM,
-      tuesday: true,
-      wednesday: false,
-      weekNumber: 1,
-    }
+    const expected: Slot = createSlot('TUESDAY-PM', startTime, endTime)
 
     const tuesdayPM: Slot = {
-      customEndTime: '',
-      customStartTime: '',
+      customStartTime: '15:30',
+      customEndTime: '17:45',
       daysOfWeek: ['TUESDAY'],
       friday: false,
       monday: false,
@@ -464,40 +429,23 @@ describe('Journey slots to custom slots mapper', () => {
       wednesday: false,
       weekNumber: 1,
     }
+    expect(expected).toEqual(tuesdayPM)
+  })
 
-    const wednesdayAM: Slot = {
-      customEndTime: '',
-      customStartTime: '',
-      daysOfWeek: ['WEDNESDAY'],
-      friday: false,
-      monday: false,
-      saturday: false,
-      sunday: false,
-      thursday: false,
-      timeSlot: TimeSlot.AM,
-      tuesday: false,
-      wednesday: true,
-      weekNumber: 1,
-    }
+  it('should map a friday evening session time to a custom slot', () => {
+    const startTime = new SimpleTime()
+    startTime.hour = 21
+    startTime.minute = 30
 
-    const thursdayPM: Slot = {
-      customEndTime: '',
-      customStartTime: '',
-      daysOfWeek: ['THURSDAY'],
-      friday: false,
-      monday: false,
-      saturday: false,
-      sunday: false,
-      thursday: true,
-      timeSlot: TimeSlot.PM,
-      tuesday: false,
-      wednesday: false,
-      weekNumber: 1,
-    }
+    const endTime = new SimpleTime()
+    endTime.hour = 23
+    endTime.minute = 45
+
+    const expected: Slot = createSlot('FRIDAY-ED', startTime, endTime)
 
     const fridayED: Slot = {
-      customEndTime: '',
-      customStartTime: '',
+      customStartTime: '21:30',
+      customEndTime: '23:45',
       daysOfWeek: ['FRIDAY'],
       friday: true,
       monday: false,
@@ -509,770 +457,96 @@ describe('Journey slots to custom slots mapper', () => {
       wednesday: false,
       weekNumber: 1,
     }
-
-    const saturdayPM: Slot = {
-      customEndTime: '',
-      customStartTime: '',
-      daysOfWeek: ['SATURDAY'],
-      friday: false,
-      monday: false,
-      saturday: true,
-      sunday: false,
-      thursday: false,
-      timeSlot: TimeSlot.PM,
-      tuesday: false,
-      wednesday: false,
-      weekNumber: 1,
-    }
-
-    const sundayPM: Slot = {
-      customEndTime: '',
-      customStartTime: '',
-      daysOfWeek: ['SUNDAY'],
-      friday: false,
-      monday: false,
-      saturday: false,
-      sunday: true,
-      thursday: false,
-      timeSlot: TimeSlot.AM,
-      tuesday: false,
-      wednesday: false,
-      weekNumber: 1,
-    }
-
-    expect(customSlots).toEqual([
-      mondayAM,
-      mondayPM,
-      mondayED,
-      tuesdayAM,
-      tuesdayPM,
-      wednesdayAM,
-      thursdayPM,
-      fridayED,
-      saturdayPM,
-      sundayPM,
-    ])
+    expect(expected).toEqual(fridayED)
   })
 
-  it('schedule week and activity schedule slots to custom time slots', () => {
-    const slots: ActivityScheduleSlot[] = [
-      {
-        id: 52,
-        timeSlot: 'AM',
-        weekNumber: 1,
-        startTime: '09:15',
-        endTime: '11:30',
-        daysOfWeek: ['Mon'],
-        mondayFlag: true,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: false,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 53,
-        timeSlot: 'ED',
-        weekNumber: 1,
-        startTime: '18:15',
-        endTime: '21:45',
-        daysOfWeek: ['Mon'],
-        mondayFlag: true,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: false,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 54,
-        timeSlot: 'PM',
-        weekNumber: 1,
-        startTime: '14:45',
-        endTime: '16:00',
-        daysOfWeek: ['Tue'],
-        mondayFlag: false,
-        tuesdayFlag: true,
-        wednesdayFlag: false,
-        thursdayFlag: false,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 55,
-        timeSlot: 'AM',
-        weekNumber: 1,
-        startTime: '08:30',
-        endTime: '11:45',
-        daysOfWeek: ['Thu'],
-        mondayFlag: false,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: true,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 56,
-        timeSlot: 'PM',
-        weekNumber: 1,
-        startTime: '15:12',
-        endTime: '16:35',
-        daysOfWeek: ['Thu'],
-        mondayFlag: false,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: true,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 57,
-        timeSlot: 'ED',
-        weekNumber: 1,
-        startTime: '18:56',
-        endTime: '19:55',
-        daysOfWeek: ['Thu'],
-        mondayFlag: false,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: true,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 58,
-        timeSlot: 'ED',
-        weekNumber: 1,
-        startTime: '21:03',
-        endTime: '22:54',
-        daysOfWeek: ['Sat'],
-        mondayFlag: false,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: false,
-        fridayFlag: false,
-        saturdayFlag: true,
-        sundayFlag: false,
-      },
-    ]
+  it('should map custom start and end times to an array of custom slot', () => {
+    const startMap: Map<string, SimpleTime> = new Map<string, SimpleTime>()
+    const endMap: Map<string, SimpleTime> = new Map<string, SimpleTime>()
 
-    const customSlots: WeeklyCustomTimeSlots = activityScheduleSlotsToCustomTimeSlots(1, slots)
+    const startTime = new SimpleTime()
+    startTime.hour = 5
+    startTime.minute = 30
 
-    expect(customSlots).toEqual({
-      '1': [
-        {
-          day: 'Monday',
-          slots: [
-            {
-              timeSlot: 'AM',
-              startTime: '09:15',
-              endTime: '11:30',
-            },
-            {
-              timeSlot: 'ED',
-              startTime: '18:15',
-              endTime: '21:45',
-            },
-          ],
-        },
-        {
-          day: 'Tuesday',
-          slots: [
-            {
-              timeSlot: 'PM',
-              startTime: '14:45',
-              endTime: '16:00',
-            },
-          ],
-        },
-        {
-          day: 'Wednesday',
-          slots: [],
-        },
-        {
-          day: 'Thursday',
-          slots: [
-            {
-              timeSlot: 'AM',
-              startTime: '08:30',
-              endTime: '11:45',
-            },
-            {
-              timeSlot: 'PM',
-              startTime: '15:12',
-              endTime: '16:35',
-            },
-            {
-              timeSlot: 'ED',
-              startTime: '18:56',
-              endTime: '19:55',
-            },
-          ],
-        },
-        {
-          day: 'Friday',
-          slots: [],
-        },
-        {
-          day: 'Saturday',
-          slots: [
-            {
-              timeSlot: 'ED',
-              startTime: '21:03',
-              endTime: '22:54',
-            },
-          ],
-        },
-        {
-          day: 'Sunday',
-          slots: [],
-        },
-      ],
-    })
-  })
+    startMap.set('MONDAY-AM', startTime)
 
-  it('schedule week and activity schedule slots out of order to custom time slots', () => {
-    const slots: ActivityScheduleSlot[] = [
-      {
-        id: 56,
-        timeSlot: 'PM',
-        weekNumber: 1,
-        startTime: '15:12',
-        endTime: '16:35',
-        daysOfWeek: ['Thu'],
-        mondayFlag: false,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: true,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 53,
-        timeSlot: 'ED',
-        weekNumber: 1,
-        startTime: '18:15',
-        endTime: '21:45',
-        daysOfWeek: ['Mon'],
-        mondayFlag: true,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: false,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 52,
-        timeSlot: 'AM',
-        weekNumber: 1,
-        startTime: '09:15',
-        endTime: '11:30',
-        daysOfWeek: ['Mon'],
-        mondayFlag: true,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: false,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 54,
-        timeSlot: 'PM',
-        weekNumber: 1,
-        startTime: '14:45',
-        endTime: '16:00',
-        daysOfWeek: ['Tue'],
-        mondayFlag: false,
-        tuesdayFlag: true,
-        wednesdayFlag: false,
-        thursdayFlag: false,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 55,
-        timeSlot: 'AM',
-        weekNumber: 1,
-        startTime: '08:30',
-        endTime: '11:45',
-        daysOfWeek: ['Thu'],
-        mondayFlag: false,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: true,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 57,
-        timeSlot: 'ED',
-        weekNumber: 1,
-        startTime: '18:56',
-        endTime: '19:55',
-        daysOfWeek: ['Thu'],
-        mondayFlag: false,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: true,
-        fridayFlag: false,
-        saturdayFlag: false,
-        sundayFlag: false,
-      },
-      {
-        id: 58,
-        timeSlot: 'ED',
-        weekNumber: 1,
-        startTime: '21:03',
-        endTime: '22:54',
-        daysOfWeek: ['Sat'],
-        mondayFlag: false,
-        tuesdayFlag: false,
-        wednesdayFlag: false,
-        thursdayFlag: false,
-        fridayFlag: false,
-        saturdayFlag: true,
-        sundayFlag: false,
-      },
-    ]
+    const startTime2 = new SimpleTime()
+    startTime2.hour = 15
+    startTime2.minute = 45
 
-    const customSlots: WeeklyCustomTimeSlots = activityScheduleSlotsToCustomTimeSlots(1, slots)
+    startMap.set('WEDNESDAY-PM', startTime2)
 
-    expect(customSlots).toEqual({
-      '1': [
-        {
-          day: 'Monday',
-          slots: [
-            {
-              timeSlot: 'AM',
-              startTime: '09:15',
-              endTime: '11:30',
-            },
-            {
-              timeSlot: 'ED',
-              startTime: '18:15',
-              endTime: '21:45',
-            },
-          ],
-        },
-        {
-          day: 'Tuesday',
-          slots: [
-            {
-              timeSlot: 'PM',
-              startTime: '14:45',
-              endTime: '16:00',
-            },
-          ],
-        },
-        {
-          day: 'Wednesday',
-          slots: [],
-        },
-        {
-          day: 'Thursday',
-          slots: [
-            {
-              timeSlot: 'AM',
-              startTime: '08:30',
-              endTime: '11:45',
-            },
-            {
-              timeSlot: 'PM',
-              startTime: '15:12',
-              endTime: '16:35',
-            },
-            {
-              timeSlot: 'ED',
-              startTime: '18:56',
-              endTime: '19:55',
-            },
-          ],
-        },
-        {
-          day: 'Friday',
-          slots: [],
-        },
-        {
-          day: 'Saturday',
-          slots: [
-            {
-              timeSlot: 'ED',
-              startTime: '21:03',
-              endTime: '22:54',
-            },
-          ],
-        },
-        {
-          day: 'Sunday',
-          slots: [],
-        },
-      ],
-    })
-  })
+    const startTime3 = new SimpleTime()
+    startTime3.hour = 19
+    startTime3.minute = 34
 
-  it('schedule week and slots to custom time slots', () => {
-    const slots: Slot[] = [
+    startMap.set('FRIDAY-ED', startTime3)
+
+    const endTime = new SimpleTime()
+    endTime.hour = 9
+    endTime.minute = 45
+
+    endMap.set('MONDAY-AM', endTime)
+
+    const endTime2 = new SimpleTime()
+    endTime2.hour = 17
+    endTime2.minute = 41
+
+    endMap.set('WEDNESDAY-PM', endTime2)
+
+    const endTime3 = new SimpleTime()
+    endTime3.hour = 21
+    endTime3.minute = 22
+
+    endMap.set('FRIDAY-ED', endTime3)
+
+    const expected: Slot[] = createCustomSlots(startMap, endMap)
+
+    const customSlots: Slot[] = [
       {
-        customStartTime: '09:15',
-        customEndTime: '11:30',
+        customStartTime: '05:30',
+        customEndTime: '09:45',
         daysOfWeek: ['MONDAY'],
         friday: false,
         monday: true,
         saturday: false,
         sunday: false,
         thursday: false,
-        timeSlot: 'AM',
+        timeSlot: TimeSlot.AM,
         tuesday: false,
         wednesday: false,
         weekNumber: 1,
       },
       {
-        customStartTime: '18:15',
-        customEndTime: '21:45',
-        daysOfWeek: ['MONDAY'],
-        friday: false,
-        monday: true,
-        saturday: false,
-        sunday: false,
-        thursday: false,
-        timeSlot: 'ED',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '14:45',
-        customEndTime: '16:00',
-        daysOfWeek: ['TUESDAY'],
+        customStartTime: '15:45',
+        customEndTime: '17:41',
+        daysOfWeek: ['WEDNESDAY'],
         friday: false,
         monday: false,
         saturday: false,
         sunday: false,
         thursday: false,
-        timeSlot: 'PM',
-        tuesday: true,
-        wednesday: false,
+        timeSlot: TimeSlot.PM,
+        tuesday: false,
+        wednesday: true,
         weekNumber: 1,
       },
       {
-        customStartTime: '07:30',
-        customEndTime: '10:14',
-        daysOfWeek: ['THURSDAY'],
-        friday: false,
+        customStartTime: '19:34',
+        customEndTime: '21:22',
+        daysOfWeek: ['FRIDAY'],
+        friday: true,
         monday: false,
         saturday: false,
-        sunday: false,
-        thursday: true,
-        timeSlot: 'AM',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '15:12',
-        customEndTime: '16:35',
-        daysOfWeek: ['THURSDAY'],
-        friday: false,
-        monday: false,
-        saturday: false,
-        sunday: false,
-        thursday: true,
-        timeSlot: 'PM',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '18:56',
-        customEndTime: '19:55',
-        daysOfWeek: ['THURSDAY'],
-        friday: false,
-        monday: false,
-        saturday: false,
-        sunday: false,
-        thursday: true,
-        timeSlot: 'ED',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '21:03',
-        customEndTime: '22:54',
-        daysOfWeek: ['SATURDAY'],
-        friday: false,
-        monday: false,
-        saturday: true,
         sunday: false,
         thursday: false,
-        timeSlot: 'ED',
+        timeSlot: TimeSlot.ED,
         tuesday: false,
         wednesday: false,
         weekNumber: 1,
       },
     ]
 
-    const customSlots: WeeklyCustomTimeSlots = slotsToCustomTimeSlots(1, slots)
-
-    expect(customSlots).toEqual({
-      '1': [
-        {
-          day: 'Monday',
-          slots: [
-            {
-              timeSlot: 'AM',
-              startTime: '09:15',
-              endTime: '11:30',
-            },
-            {
-              timeSlot: 'ED',
-              startTime: '18:15',
-              endTime: '21:45',
-            },
-          ],
-        },
-        {
-          day: 'Tuesday',
-          slots: [
-            {
-              timeSlot: 'PM',
-              startTime: '14:45',
-              endTime: '16:00',
-            },
-          ],
-        },
-        {
-          day: 'Wednesday',
-          slots: [],
-        },
-        {
-          day: 'Thursday',
-          slots: [
-            {
-              timeSlot: 'AM',
-              startTime: '07:30',
-              endTime: '10:14',
-            },
-            {
-              timeSlot: 'PM',
-              startTime: '15:12',
-              endTime: '16:35',
-            },
-            {
-              timeSlot: 'ED',
-              startTime: '18:56',
-              endTime: '19:55',
-            },
-          ],
-        },
-        {
-          day: 'Friday',
-          slots: [],
-        },
-        {
-          day: 'Saturday',
-          slots: [
-            {
-              timeSlot: 'ED',
-              startTime: '21:03',
-              endTime: '22:54',
-            },
-          ],
-        },
-        {
-          day: 'Sunday',
-          slots: [],
-        },
-      ],
-    })
-  })
-
-  it('schedule week and slots out of order to custom time slots', () => {
-    const slots: Slot[] = [
-      {
-        customStartTime: '14:45',
-        customEndTime: '16:00',
-        daysOfWeek: ['TUESDAY'],
-        friday: false,
-        monday: false,
-        saturday: false,
-        sunday: false,
-        thursday: false,
-        timeSlot: 'PM',
-        tuesday: true,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '09:15',
-        customEndTime: '11:30',
-        daysOfWeek: ['MONDAY'],
-        friday: false,
-        monday: true,
-        saturday: false,
-        sunday: false,
-        thursday: false,
-        timeSlot: 'AM',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '18:15',
-        customEndTime: '21:45',
-        daysOfWeek: ['MONDAY'],
-        friday: false,
-        monday: true,
-        saturday: false,
-        sunday: false,
-        thursday: false,
-        timeSlot: 'ED',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '07:30',
-        customEndTime: '10:14',
-        daysOfWeek: ['THURSDAY'],
-        friday: false,
-        monday: false,
-        saturday: false,
-        sunday: false,
-        thursday: true,
-        timeSlot: 'AM',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '21:03',
-        customEndTime: '22:54',
-        daysOfWeek: ['SATURDAY'],
-        friday: false,
-        monday: false,
-        saturday: true,
-        sunday: false,
-        thursday: false,
-        timeSlot: 'ED',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '15:12',
-        customEndTime: '16:35',
-        daysOfWeek: ['THURSDAY'],
-        friday: false,
-        monday: false,
-        saturday: false,
-        sunday: false,
-        thursday: true,
-        timeSlot: 'PM',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-      {
-        customStartTime: '18:56',
-        customEndTime: '19:55',
-        daysOfWeek: ['THURSDAY'],
-        friday: false,
-        monday: false,
-        saturday: false,
-        sunday: false,
-        thursday: true,
-        timeSlot: 'ED',
-        tuesday: false,
-        wednesday: false,
-        weekNumber: 1,
-      },
-    ]
-
-    const customSlots: WeeklyCustomTimeSlots = slotsToCustomTimeSlots(1, slots)
-
-    expect(customSlots).toEqual({
-      '1': [
-        {
-          day: 'Monday',
-          slots: [
-            {
-              timeSlot: 'AM',
-              startTime: '09:15',
-              endTime: '11:30',
-            },
-            {
-              timeSlot: 'ED',
-              startTime: '18:15',
-              endTime: '21:45',
-            },
-          ],
-        },
-        {
-          day: 'Tuesday',
-          slots: [
-            {
-              timeSlot: 'PM',
-              startTime: '14:45',
-              endTime: '16:00',
-            },
-          ],
-        },
-        {
-          day: 'Wednesday',
-          slots: [],
-        },
-        {
-          day: 'Thursday',
-          slots: [
-            {
-              timeSlot: 'AM',
-              startTime: '07:30',
-              endTime: '10:14',
-            },
-            {
-              timeSlot: 'PM',
-              startTime: '15:12',
-              endTime: '16:35',
-            },
-            {
-              timeSlot: 'ED',
-              startTime: '18:56',
-              endTime: '19:55',
-            },
-          ],
-        },
-        {
-          day: 'Friday',
-          slots: [],
-        },
-        {
-          day: 'Saturday',
-          slots: [
-            {
-              timeSlot: 'ED',
-              startTime: '21:03',
-              endTime: '22:54',
-            },
-          ],
-        },
-        {
-          day: 'Sunday',
-          slots: [],
-        },
-      ],
-    })
+    expect(expected).toEqual(customSlots)
   })
 })

--- a/server/utils/helpers/activityTimeSlotMappers.ts
+++ b/server/utils/helpers/activityTimeSlotMappers.ts
@@ -2,6 +2,7 @@ import { uniq } from 'lodash'
 import TimeSlot from '../../enum/timeSlot'
 import { Slots } from '../../routes/activities/create-an-activity/journey'
 import { ActivityScheduleSlot, Slot } from '../../@types/activitiesAPI/types'
+import SimpleTime from '../../commonValidationTypes/simpleTime'
 
 export interface WeeklyTimeSlots {
   [weekNumber: string]: {
@@ -236,63 +237,33 @@ export function calculateUniqueSlots(slotsA: Slot[], slotsB: Slot[]): Slot[] {
     .filter(s => s.daysOfWeek.length > 0)
 }
 
-export function journeySlotsToCustomSlots(journeySlots: Slots): Slot[] {
-  const slots: Slot[] = []
+export function createCustomSlots(startTimes: Map<string, SimpleTime>, endTimes: Map<string, SimpleTime>): Slot[] {
+  const customSlots: Slot[] = []
 
-  journeySlots.timeSlotsMonday.forEach(timeSlot => {
-    const slot = createSlot('MONDAY', timeSlot)
-    slot.monday = true
-    slots.push(slot)
+  startTimes.forEach((value, key) => {
+    const slot: Slot = createSlot(key, value, endTimes.get(key))
+    customSlots.push(slot)
   })
-  journeySlots.timeSlotsTuesday.forEach(timeSlot => {
-    const slot = createSlot('TUESDAY', timeSlot)
-    slot.tuesday = true
-    slots.push(slot)
-  })
-  journeySlots.timeSlotsWednesday.forEach(timeSlot => {
-    const slot = createSlot('WEDNESDAY', timeSlot)
-    slot.wednesday = true
-    slots.push(slot)
-  })
-  journeySlots.timeSlotsThursday.forEach(timeSlot => {
-    const slot = createSlot('THURSDAY', timeSlot)
-    slot.thursday = true
-    slots.push(slot)
-  })
-  journeySlots.timeSlotsFriday.forEach(timeSlot => {
-    const slot = createSlot('FRIDAY', timeSlot)
-    slot.friday = true
-    slots.push(slot)
-  })
-  journeySlots.timeSlotsSaturday.forEach(timeSlot => {
-    const slot = createSlot('SATURDAY', timeSlot)
-    slot.saturday = true
-    slots.push(slot)
-  })
-  journeySlots.timeSlotsSunday.forEach(timeSlot => {
-    const slot = createSlot('SUNDAY', timeSlot)
-    slot.sunday = true
-    slots.push(slot)
-  })
-  return slots
+
+  return customSlots
 }
 
-function createSlot(
-  day: 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY' | 'SUNDAY',
-  timeSlot: string,
-) {
+export function createSlot(daySlot: string, startTime: SimpleTime, endTime: SimpleTime): Slot {
+  const day: DayOfWeek = daySlot.substring(0, daySlot.indexOf('-')) as DayOfWeek
+  const timeSlot: TimeSlot = daySlot.substring(daySlot.indexOf('-') + 1) as TimeSlot
+
   const slot: Slot = {
-    customEndTime: '',
-    customStartTime: '',
+    customStartTime: startTime.toIsoString(),
+    customEndTime: endTime.toIsoString(),
     daysOfWeek: [day],
-    friday: false,
-    monday: false,
-    saturday: false,
-    sunday: false,
-    thursday: false,
-    timeSlot: timeSlot as TimeSlot,
-    tuesday: false,
-    wednesday: false,
+    monday: day === 'MONDAY',
+    tuesday: day === 'TUESDAY',
+    wednesday: day === 'WEDNESDAY',
+    thursday: day === 'THURSDAY',
+    friday: day === 'FRIDAY',
+    saturday: day === 'SATURDAY',
+    sunday: day === 'SUNDAY',
+    timeSlot,
     weekNumber: 1,
   }
   return slot

--- a/server/utils/helpers/applicableRegimeTimeUtil.ts
+++ b/server/utils/helpers/applicableRegimeTimeUtil.ts
@@ -2,7 +2,7 @@ import { convertToTitleCase } from '../utils'
 import { Slots } from '../../routes/activities/create-an-activity/journey'
 import { PrisonRegime } from '../../@types/activitiesAPI/types'
 
-type DaysAndSlotsInRegime = {
+export type DaysAndSlotsInRegime = {
   dayOfWeek: string
   amStart?: string
   amFinish?: string
@@ -12,7 +12,10 @@ type DaysAndSlotsInRegime = {
   edFinish?: string
 }
 
-export default function getApplicableDaysAndSlotsInRegime(regimeTimes: PrisonRegime[], daysAndSlots: Slots) {
+export default function getApplicableDaysAndSlotsInRegime(
+  regimeTimes: PrisonRegime[],
+  daysAndSlots: Slots,
+): DaysAndSlotsInRegime[] {
   return daysAndSlots.days
     .map((day: string) => {
       const dayUpper: string = day.toUpperCase()

--- a/server/views/pages/activities/create-an-activity/session-times.njk
+++ b/server/views/pages/activities/create-an-activity/session-times.njk
@@ -1,7 +1,9 @@
 {% extends "layout.njk" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
+
 {% from "partials/activities/activity-journey-caption.njk" import activityJourneyCaption %}
 
 {% from "components/timePicker.njk" import timePicker %}
@@ -9,7 +11,6 @@
 {% set pageTitle = applicationName + " - Create a schedule - Activity session times" %}
 {% set pageId = 'activity-session-times-page' %}
 {% set pageHeading = "Select the start and end times for the sessions when this activity runs" %}
-
 {% set jsBackLink = true %}
 
 {% block content %}
@@ -17,8 +18,55 @@
         <div class="govuk-grid-column-two-thirds">
             {{ activityJourneyCaption(session.createJourney) }}
             <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
+            {{ validationErrors | dump }}
             <form method="POST">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                        {% set rows = [] %} 
+                        {% for customSlot in sessionSlots %}                  
+                            {% set rows = (rows.push([
+                                {
+                                    html: customSlot.dayOfWeek | title if customSlot.isFirst
+                                },
+                                {
+                                    html: customSlot.timeSlot
+                                },
+                                {
+                                    html: timePicker({
+                                        id: 'startTime-' + customSlot.dayOfWeek + '-' + customSlot.timeSlot,
+                                        name: 'startTime[' + customSlot.dayOfWeek + '-' + customSlot.timeSlot + ']',
+                                        renderedErrorMessage: validationErrors | findError('startTime-' + customSlot.dayOfWeek + '-' + customSlot.timeSlot),
+                                        validationErrors: validationErrors,
+                                        formResponses: formResponses.startTime
+                                    })
+                                },
+                                {
+                                    html: timePicker({
+                                        id: 'endTime-' + customSlot.dayOfWeek + '-' + customSlot.timeSlot,
+                                        name: 'endTime[' + customSlot.dayOfWeek + '-' + customSlot.timeSlot + ']',
+                                        renderedErrorMessage: validationErrors | findError('endTime-' + customSlot.dayOfWeek + '-' + customSlot.timeSlot),
+                                        validationErrors: validationErrors,
+                                        formResponses: formResponses.endTime
+                                    })
+                                }]), rows) %}
+                        {% endfor %}
+                    
+                    {{ govukTable({
+                        head: [
+                                {
+                                text: "Day"
+                                },
+                                 {
+                                text: "Session"
+                                },
+                                {
+                                text: "Start Time"
+                                },
+                                {
+                                text: "End Time"
+                                }
+                            ],
+                        rows: rows                      
+                    }) }}
                 {{ govukButton({
                     text: "Continue"
                 }) }}


### PR DESCRIPTION
This allows the creation of custom times for an activity. It also switches on the functionality in Dev. NB. Validation is not covered yet. 

![custom_session_times](https://github.com/user-attachments/assets/ceecb03d-31dc-496f-a35d-abea2a6a6195)

