### PR TITLE
BAVL-301 show warning message on BVLS court booking confirmation page if court is disabled.

### DIFF
--- a/server/data/bookAVideoLinkApiClient.test.ts
+++ b/server/data/bookAVideoLinkApiClient.test.ts
@@ -94,7 +94,7 @@ describe('bookAVideoLinkApiClient', () => {
         .matchHeader('authorization', `Bearer accessToken`)
         .reply(200, response)
 
-      const output = await bookAVideoLinkApiClient.getAllEnabledCourts(user)
+      const output = await bookAVideoLinkApiClient.getAllCourts(user)
 
       expect(output).toEqual(response)
       expect(nock.isDone()).toBe(true)

--- a/server/data/bookAVideoLinkApiClient.ts
+++ b/server/data/bookAVideoLinkApiClient.ts
@@ -32,7 +32,7 @@ export default class BookAVideoLinkApiClient extends AbstractHmppsRestClient {
     return this.get({ path: `/prisons/${prisonCode}/locations` }, user)
   }
 
-  public getAllEnabledCourts(user: ServiceUser): Promise<Court[]> {
+  public getAllCourts(user: ServiceUser): Promise<Court[]> {
     return this.get({ path: '/courts', query: { enabledOnly: false } }, user)
   }
 

--- a/server/routes/appointments/video-link-booking/handlers/checkBooking.test.ts
+++ b/server/routes/appointments/video-link-booking/handlers/checkBooking.test.ts
@@ -41,7 +41,7 @@ describe('CheckBookingRoutes', () => {
         { key: 'Room1', description: 'Room 1', enabled: true },
         { key: 'Room2', description: 'Room 2', enabled: true },
       ])
-      bookAVideoLinkService.getAllEnabledCourts.mockResolvedValue([
+      bookAVideoLinkService.getAllCourts.mockResolvedValue([
         { courtId: 1, code: 'Court1', description: 'Court 1', enabled: true },
         { courtId: 2, code: 'Court2', description: 'Court 2', enabled: true },
       ])

--- a/server/routes/appointments/video-link-booking/handlers/checkBooking.ts
+++ b/server/routes/appointments/video-link-booking/handlers/checkBooking.ts
@@ -10,7 +10,7 @@ export default class CheckBookingRoutes {
 
     const [rooms, courts, hearingTypes] = await Promise.all([
       this.bookAVideoLinkService.getAppointmentLocations(prisoner.prisonCode, user),
-      this.bookAVideoLinkService.getAllEnabledCourts(user),
+      this.bookAVideoLinkService.getAllCourts(user),
       this.bookAVideoLinkService.getCourtHearingTypes(user),
     ])
 

--- a/server/routes/appointments/video-link-booking/handlers/confirmation.test.ts
+++ b/server/routes/appointments/video-link-booking/handlers/confirmation.test.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 import BookAVideoLinkService from '../../../../services/bookAVideoLinkService'
 import BookAVideoLinkApiClient from '../../../../data/bookAVideoLinkApiClient'
 import ConfirmationRoutes from './confirmation'
-import { VideoLinkBooking } from '../../../../@types/bookAVideoLinkApi/types'
+import { Court, VideoLinkBooking } from '../../../../@types/bookAVideoLinkApi/types'
 
 jest.mock('../../../../services/bookAVideoLinkService')
 jest.mock('../../../../data/bookAVideoLinkApiClient')
@@ -37,16 +37,18 @@ describe('ConfirmationRoutes', () => {
   })
 
   describe('GET', () => {
-    it('should render the confirmation page with video link booking details', async () => {
-      const vlb = { videoLinkBookingId: 1 } as VideoLinkBooking
+    it('should render the confirmation page with video link booking and court details', async () => {
+      const vlb = { videoLinkBookingId: 1, bookingType: 'COURT', courtCode: 'Court1' } as VideoLinkBooking
+      const court = { courtId: 1, code: 'Court1', description: 'Disabled Court', enabled: false } as Court
       bookAVideoLinkService.getVideoLinkBookingById.mockResolvedValue(vlb)
+      bookAVideoLinkService.getAllCourts.mockResolvedValue([court])
 
       req.params = { vlbId: '1' }
 
       await confirmationRoutes.GET(req as Request, res as Response)
 
       expect(bookAVideoLinkService.getVideoLinkBookingById).toHaveBeenCalledWith(1, res.locals.user)
-      expect(res.render).toHaveBeenCalledWith('pages/appointments/video-link-booking/confirmation', { vlb })
+      expect(res.render).toHaveBeenCalledWith('pages/appointments/video-link-booking/confirmation', { vlb, court })
     })
   })
 })

--- a/server/routes/appointments/video-link-booking/handlers/confirmation.ts
+++ b/server/routes/appointments/video-link-booking/handlers/confirmation.ts
@@ -10,7 +10,10 @@ export default class ConfirmationRoutes {
     req.session.bookAVideoLinkJourney = null
 
     const vlb = await this.bookAVideoLinkService.getVideoLinkBookingById(+vlbId, user)
+    const court = await this.bookAVideoLinkService
+      .getAllCourts(user)
+      .then(courts => courts.find(c => c.code === vlb.courtCode))
 
-    return res.render('pages/appointments/video-link-booking/confirmation', { vlb })
+    return res.render('pages/appointments/video-link-booking/confirmation', { vlb, court })
   }
 }

--- a/server/routes/appointments/video-link-booking/handlers/hearingDetails.test.ts
+++ b/server/routes/appointments/video-link-booking/handlers/hearingDetails.test.ts
@@ -34,7 +34,7 @@ describe('HearingDetailsRoutes', () => {
     it('renders hearing details view with agencies and hearing types', async () => {
       const agencies = [{ code: 'COURT1', description: 'Court 1' }] as Court[]
       const hearingTypes = [{ code: 'TYPE1', description: 'Type 1' }] as ReferenceCode[]
-      bookAVideoLinkService.getAllEnabledCourts.mockResolvedValue(agencies)
+      bookAVideoLinkService.getAllCourts.mockResolvedValue(agencies)
       bookAVideoLinkService.getCourtHearingTypes.mockResolvedValue(hearingTypes)
 
       await hearingDetailsRoutes.GET(req as Request, res as Response)
@@ -51,7 +51,7 @@ describe('HearingDetailsRoutes', () => {
 
       const agencies = [{ code: 'COURT1', description: 'Court 1' }] as Court[]
       const hearingTypes = [{ code: 'TYPE1', description: 'Type 1' }] as ReferenceCode[]
-      bookAVideoLinkService.getAllEnabledCourts.mockResolvedValue(agencies)
+      bookAVideoLinkService.getAllCourts.mockResolvedValue(agencies)
       bookAVideoLinkService.getProbationMeetingTypes.mockResolvedValue(hearingTypes)
 
       await hearingDetailsRoutes.GET(req as Request, res as Response)

--- a/server/routes/appointments/video-link-booking/handlers/hearingDetails.ts
+++ b/server/routes/appointments/video-link-booking/handlers/hearingDetails.ts
@@ -26,7 +26,7 @@ export default class HearingDetailsRoutes {
     const { user } = res.locals
     const { type } = req.session.bookAVideoLinkJourney
 
-    const agencies = await this.bookAVideoLinkService.getAllEnabledCourts(user)
+    const agencies = await this.bookAVideoLinkService.getAllCourts(user)
     const hearingTypes =
       type === 'COURT'
         ? await this.bookAVideoLinkService.getCourtHearingTypes(user)

--- a/server/services/bookAVideoLinkService.test.ts
+++ b/server/services/bookAVideoLinkService.test.ts
@@ -126,11 +126,11 @@ describe('Book A Video link service', () => {
 
   describe('getAllEnabledCourts', () => {
     it('should call getAllEnabledCourts on the api client', async () => {
-      bookAVideoLinkClient.getAllEnabledCourts.mockResolvedValue([])
+      bookAVideoLinkClient.getAllCourts.mockResolvedValue([])
 
-      const result = await bookAVideoLinkService.getAllEnabledCourts(user)
+      const result = await bookAVideoLinkService.getAllCourts(user)
 
-      expect(bookAVideoLinkClient.getAllEnabledCourts).toHaveBeenCalledWith(user)
+      expect(bookAVideoLinkClient.getAllCourts).toHaveBeenCalledWith(user)
       expect(result).toEqual([])
     })
   })

--- a/server/services/bookAVideoLinkService.ts
+++ b/server/services/bookAVideoLinkService.ts
@@ -45,8 +45,8 @@ export default class BookAVideoLinkService {
     return bookingStatus !== 'CANCELLED' && exactTimeOfBooking > now
   }
 
-  public async getAllEnabledCourts(user: ServiceUser) {
-    return this.bookAVideoLinkApiClient.getAllEnabledCourts(user)
+  public async getAllCourts(user: ServiceUser) {
+    return this.bookAVideoLinkApiClient.getAllCourts(user)
   }
 
   public getCourtHearingTypes(user: ServiceUser) {

--- a/server/views/pages/appointments/video-link-booking/confirmation.njk
+++ b/server/views/pages/appointments/video-link-booking/confirmation.njk
@@ -18,6 +18,13 @@
                 You have successfully scheduled an appointment for 1 person on {{ vlb.prisonAppointments[0].appointmentDate | toDate | formatDate }}
             </p>
 
+            {% if not court.enabled %}
+            <h2 class="govuk-heading-m">Email {{ court.description }} to confirm the booking</h2>
+            <p class="govuk-body">
+                You must email {{ court.description }} to confirm the booking. This is because they do not yet have access to the Book a video link service.
+            </p>
+            {% endif %}
+
             <h2 class="govuk-heading-m">What you can do next</h2>
             <p class="govuk-body">
                 <a href="/appointments" class="govuk-link govuk-link--no-visited-state" data-qa="create-another-link">Schedule another appointment</a>


### PR DESCRIPTION
The following warning message is shown when creating a court video link booking if the court is disabled (i.e. BLVS not active for that court).

![disabled-court](https://github.com/user-attachments/assets/70365ccf-e5f9-4d29-aded-2878c121384b)
