### PR TITLE
SAA-2004: Fix location in attendances clashing events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,6 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
-        "@jest-mock/express": "^2.1.0",
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/bunyan": "^1.8.11",
@@ -117,7 +116,7 @@
         "prettier-plugin-jinja-template": "^1.4.0",
         "rollup": "^4.18.0",
         "sass": "^1.77.5",
-        "sinon": "^18.0.0",
+        "sinon": "^18.0.1",
         "supertest": "^7.0.0",
         "ts-jest": "^29.1.4",
         "ts-node": "^10.9.2",
@@ -1443,16 +1442,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@jest-mock/express": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@jest-mock/express/-/express-2.1.0.tgz",
-      "integrity": "sha512-wwij1960SVxJL+v5Eqw3Akn3S5TLfCtHnFqs2K9Zto7RLU5I/7YhOsYDZQfNcnGyiBdisDz5iT21SRO1CVfvKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "^4.17.21"
       }
     },
     "node_modules/@jest/console": {
@@ -14037,13 +14026,13 @@
       }
     },
     "node_modules/sinon": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.0.tgz",
-      "integrity": "sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/fake-timers": "11.2.2",
         "@sinonjs/samsam": "^8.0.0",
         "diff": "^5.2.0",
         "nise": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
-    "@jest-mock/express": "^2.1.0",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@types/bunyan": "^1.8.11",
@@ -183,7 +182,7 @@
     "prettier-plugin-jinja-template": "^1.4.0",
     "rollup": "^4.18.0",
     "sass": "^1.77.5",
-    "sinon": "^18.0.0",
+    "sinon": "^18.0.1",
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.4",
     "ts-node": "^10.9.2",

--- a/server/views/pages/activities/create-an-activity/check-answers.njk
+++ b/server/views/pages/activities/create-an-activity/check-answers.njk
@@ -3,7 +3,8 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "partials/activities/activity-journey-caption.njk" import activityJourneyCaption %}
-{% from "../../../partials/activities/days-and-custom-times.njk" import daysAndCustomTimes %}
+{% from "partials/activities/days-and-custom-times.njk" import daysAndCustomTimes %}
+{% from "partials/showLocation.njk" import showLocation %}
 
 {% set pageTitle = applicationName + " - Create an activity - Check answers" %}
 {% set pageId = 'check-answers-page' %}
@@ -257,7 +258,7 @@
                             text: "Location"
                         },
                         value: {
-                            text: locationText(session.createJourney)
+                            text: showLocation(session.createJourney)
                         },
                         actions: {
                             items: [
@@ -338,14 +339,3 @@
     {% endfor %}
 {% endmacro %}
 
-{% macro locationText(journey) %}
-    {% if journey.inCell %}
-        {{ "In cell" }}
-    {% elseif journey.onWing %}
-        {{ "On wing" }}
-    {% elseif journey.offWing %}
-        {{ "Off wing" }}
-    {% else %}
-        {{ journey.location.name }}
-    {% endif %}
-{% endmacro %}

--- a/server/views/pages/activities/daily-attendance-summary/cancelled-sessions.njk
+++ b/server/views/pages/activities/daily-attendance-summary/cancelled-sessions.njk
@@ -7,6 +7,7 @@
 {% from "partials/showProfileLink.njk" import showProfileLink %}
 {% from "partials/searchInput.njk" import searchInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "partials/showLocation.njk" import showLocation %}
 
 {% set pageTitle = applicationName + " - Cancelled Sessions" %}
 {% set pageId = 'cancelled-sessions-detail-page' %}
@@ -94,6 +95,7 @@
     {% for cancelledSession in cancelledSessions %}
         {% set sesstionTimes = cancelledSession.startTime + ' to ' + cancelledSession.endTime %}
         {% if timeSlot === 'DAY' or timeSlot === cancelledSession.timeSlot %}
+            {% set location = showLocation(cancelledSession) %}
             {% set cancelledSessionsRows = (cancelledSessionsRows.push([
                 {
                     attributes: { id: 'activity-' + loop.index, "data-sort-value": cancelledSession.summary },
@@ -101,8 +103,8 @@
                     classes: 'govuk-table_cell'
                 },
                 {
-                    attributes: { id: 'cell-location-' + loop.index, "data-sort-value": ("In cell" if cancelledSession.inCell) or ("On wing" if cancelledSession.onWing) or ("Off wing" if cancelledSession.offWing) or cancelledSession.location },
-                    text: ("In cell" if cancelledSession.inCell) or ("On wing" if cancelledSession.onWing) or ("Off wing" if cancelledSession.offWing) or cancelledSession.location,
+                    attributes: { id: 'cell-location-' + loop.index, "data-sort-value": location },
+                    text: location,
                     classes: 'govuk-table_cell'
                 },
                 {

--- a/server/views/pages/activities/manage-allocations/check-answers.njk
+++ b/server/views/pages/activities/manage-allocations/check-answers.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "partials/activities/days-and-custom-times.njk" import daysAndCustomTimes %}
 {% from "partials/statusBasedCellLocation.njk" import statusBasedCellLocation %}
+{% from "partials/showLocation.njk" import showLocation %}
 
 {% set pageTitle = applicationName + " - Allocate to an activity - Check answers" %}
 {% set pageId = 'check-answers-page' %}
@@ -75,14 +76,7 @@
                         },
                         {
                             key: { text: "Location" },
-                            value: {
-                                text: (
-                                    session.allocateJourney.activity.location or
-                                    ("In cell" if session.allocateJourney.activity.inCell) or
-                                    ("On wing" if session.allocateJourney.activity.onWing) or
-                                    ("Off wing" if session.allocateJourney.activity.offWing)
-                                )
-                            }
+                            value: { text: showLocation(session.allocateJourney.activity) }
                         },
                         {
                             key: { text: "Start of allocation" },

--- a/server/views/pages/activities/manage-allocations/exclusions.njk
+++ b/server/views/pages/activities/manage-allocations/exclusions.njk
@@ -35,7 +35,7 @@
                 <div class="govuk-grid-row">
                 {% for week in weeks %}
                     <div class="govuk-grid-column-one-half">
-                    {% if weeks | length %}
+                    {% if weeks.length > 1 %}
                         <h2 class="govuk-heading-l govuk-!-margin-bottom-6">
                             Week {{ week.weekNumber }}
                             {{ govukTag({

--- a/server/views/pages/activities/record-attendance/activities.njk
+++ b/server/views/pages/activities/record-attendance/activities.njk
@@ -10,6 +10,7 @@
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "partials/attendance/activitiesTable.njk" import activitiesTable %}
+{% from "partials/showLocation.njk" import showLocation %}
 
 {% set pageTitle = applicationName + " - Record attendance" %}
 {% set pageId = 'activities-page' %}
@@ -195,7 +196,7 @@
     {% if activities[session].length %}
         {% set rows = [] %}
         {% for activity in activities[session] %}
-            {% set activityLocation = ("In cell" if activity.inCell) or ("On wing" if activity.onWing) or ("Off wing" if activity.offWing) or activity.internalLocation.description | capitalize %}
+            {% set activityLocation = showLocation(activity, makeCapitals = true) %}
             {% set rows = (rows.push([
                 {
                     attributes: {

--- a/server/views/pages/activities/record-attendance/attendance-list-single.njk
+++ b/server/views/pages/activities/record-attendance/attendance-list-single.njk
@@ -14,6 +14,7 @@
 {% from "partials/showProfileLink.njk" import showProfileLink %}
 {% from "partials/formatSessions.njk" import formatSessions %}
 {% from "partials/service-user-name.njk" import serviceUserName %}
+{% from "partials/showLocation.njk" import showLocation %}
 
 {% set pageTitle = applicationName + " - Record attendance" %}
 {% set pageId = 'attendance-list-page' %}
@@ -49,13 +50,7 @@
                     {{ instance.startTime }} to {{ instance.endTime }} ({{ instance.timeSlot }})
                 </span>
                 <span class="govuk-caption-l">{{ activityDate }}</span>
-                <span class="govuk-caption-l">
-                    {{ 
-                        ("In cell" if instance.activitySchedule.activity.inCell) or 
-                        ("On wing" if instance.activitySchedule.activity.onWing) or 
-                        ("Off wing" if instance.activitySchedule.activity.offWing) or 
-                        instance.activitySchedule.activity.location | capitalize }}
-                </span>
+                <span class="govuk-caption-l">{{ showLocation(instance.activitySchedule.activity, instance.activitySchedule.internalLocation.description, true) }} </span>
             </h1>
 
             <div class="govuk-button-group govuk-!-display-none-print">

--- a/server/views/partials/attendance/activitiesTable.njk
+++ b/server/views/partials/attendance/activitiesTable.njk
@@ -1,11 +1,12 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "components/sticky-select.njk" import stickySelect %}
+{% from "partials/showLocation.njk" import showLocation %}
 
 {% macro activitiesTable(activities, activityDate, filterParams, now) %}
     {% set rows = [] %}
 
     {% for activity in activities %}
-        {% set activityLocation = ("In cell" if activity.inCell) or ("On wing" if activity.onWing) or ("Off wing" if activity.offWing) or activity.internalLocation.description | capitalize %}
+        {% set activityLocation = showLocation(activity, makeCapitals = true) %}
         {% set rows = (rows.push({
             visuallyHiddenText: 'Select ' + activity.summary + ' ' + (activity.session),
             value: activity.scheduledInstanceId,

--- a/server/views/partials/attendance/otherEvent.njk
+++ b/server/views/partials/attendance/otherEvent.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "partials/showLocation.njk" import showLocation %}
 
 {% macro otherEvent(event) %}
   <div class="govuk-body govuk-!-margin-0">
@@ -21,7 +22,7 @@
       </div>
       {% if event.eventType != 'EXTERNAL_TRANSFER' and event.eventType != 'COURT_HEARING' %}
         <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-0">{{ event.startTime }}{{ " to " + event.endTime if event.endTime }}</div>
-        <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-0">{{ event.internalLocationUserDescription or event.internalLocationDescription }}</div>
+        <div class="govuk-hint govuk-!-font-size-16 govuk-!-margin-0">{{ showLocation(event) }}</div>
       {% endif %}
   </div>
 {% endmacro %}

--- a/server/views/partials/showLocation.njk
+++ b/server/views/partials/showLocation.njk
@@ -1,0 +1,27 @@
+{% macro showLocation(event, internalLocation, makeCapitals = false) %}
+    {%  set location = '' %}
+    {% if event.inCell %}
+        {% set location = "In cell" %}
+    {% elseif event.onWing %}
+        {% set location = "On wing" %}
+    {% elseif event.offWing %}
+        {% set location = "Off wing" %}
+    {% elseif internalLocation %}
+        {% set location = internalLocation %}
+    {% else %}
+        {%  set location = (
+                event.location.name or
+                event.location or
+                event.internalLocation.description or
+                event.internalLocationUserDescription or
+                event.internalLocationDescription
+            )
+        %}
+    {% endif %}
+
+    {% if makeCapitals %}
+        {{ location | trim | capitalize }}
+    {% else %}
+        {{ location | trim }}
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
- Show non internal locations for clashing events in attendance list.
- Show selected week in exclusions when allocation bi-weekly activity
- Create a re-usable macro for showing location

<img width="647" alt="image" src="https://github.com/user-attachments/assets/5e011699-1078-4b51-a83e-f80df619cefe">

<img width="656" alt="image" src="https://github.com/user-attachments/assets/8a252620-6f25-4678-b773-bbbb7324326b">
