### PR TITLE
override cookie child package dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5111,9 +5111,10 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6811,15 +6812,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/express-session/node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/express-session/node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
@@ -6856,15 +6848,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -189,6 +189,6 @@
   },
   "overrides": {
     "rollup": "~4.22.4",
-    "cookie": "~0.7.0"
+    "cookie": "~0.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "typescript": "^5.4.5"
   },
   "overrides": {
-    "rollup": "~4.22.4"
+    "rollup": "~4.22.4",
+    "cookie": "~0.7.0"
   }
 }


### PR DESCRIPTION
Fix for https://github.com/advisories/GHSA-pxg6-pf52-xh8x security issue in child dependency package as the 'csurf' package we use is deprecated/never going to be updated. Discussion for its replacement is ongoing.