### PR TITLE
BAVL-381: Convert BVLS toggle to namespace secret

### DIFF
--- a/helm_deploy/hmpps-activities-management/values.yaml
+++ b/helm_deploy/hmpps-activities-management/values.yaml
@@ -49,6 +49,8 @@ generic-service:
     elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
+    feature-toggles:
+      BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED: "BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED"
 
   allowlist:
     ark-nps-hmcts-ttp2: 194.33.192.0/25

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,7 +23,6 @@ generic-service:
     MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
     BOOK_A_VIDEO_LINK_API_URL: "https://book-a-video-link-api-dev.prison.service.justice.gov.uk"
     REPORTING_API_URL: "http://hmpps-digital-prison-reporting-mi-dev.hmpps-digital-prison-reporting-mi-dev.svc.cluster.local"
-    BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED: "true"
     FUTURE_PAY_RATES_TOGGLE_ENABLED: "true"
     DEALLOCATE_TODAY_SESSION_TOGGLE_ENABLED: "true"
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -23,7 +23,6 @@ generic-service:
     MANAGE_USERS_API_URL: "https://manage-users-api-preprod.hmpps.service.justice.gov.uk"
     BOOK_A_VIDEO_LINK_API_URL: "https://book-a-video-link-api-preprod.prison.service.justice.gov.uk"
     REPORTING_API_URL: "http://hmpps-digital-prison-reporting-mi-preprod.hmpps-digital-prison-reporting-mi-preprod.svc.cluster.local"
-    BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED: "true"
     FUTURE_PAY_RATES_TOGGLE_ENABLED: "true"
     DEALLOCATE_TODAY_SESSION_TOGGLE_ENABLED: "true"
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -21,7 +21,6 @@ generic-service:
     MANAGE_USERS_API_URL: "https://manage-users-api.hmpps.service.justice.gov.uk"
     BOOK_A_VIDEO_LINK_API_URL: "https://book-a-video-link-api.prison.service.justice.gov.uk"
     REPORTING_API_URL: "http://hmpps-digital-prison-reporting-mi-prod.hmpps-digital-prison-reporting-mi-prod.svc.cluster.local"
-    BOOK_A_VIDEO_LINK_FEATURE_TOGGLE_ENABLED: "false"
     FUTURE_PAY_RATES_TOGGLE_ENABLED: "true"
     DEALLOCATE_TODAY_SESSION_TOGGLE_ENABLED: "true"
 


### PR DESCRIPTION
The BVLS team are preparing for rollout, and we have various feature toggles to flip on, on the day of rollout. To reduce dependency and disruption on other teams, we want to convert the toggles to namespace secrets, so that we can flip their value without the need for a new helm deployment