### PR TITLE
SAA-1988: Deal with null response from api for non-associations

### DIFF
--- a/integration_tests/e2e/activities/allocations/allocateToActivity.cy.ts
+++ b/integration_tests/e2e/activities/allocations/allocateToActivity.cy.ts
@@ -70,9 +70,10 @@ context('Allocate to activity', () => {
     activitiesPage.selectActivityWithName('English level 1')
 
     const allocatePage = Page.verifyOnPage(AllocationDashboard)
-    allocatePage.allocatedPeopleRows().should('have.length', 2)
+    allocatePage.allocatedPeopleRows().should('have.length', 3)
     allocatePage.nonAssociationsLink('G4793VF').contains('View non-associations')
     allocatePage.nonAssociationsLink('A1351DZ').should('not.exist')
+    allocatePage.nonAssociationsLink('B1351RE').contains('View non-associations')
     allocatePage.tabWithTitle('Entry level English 1 schedule').click()
     allocatePage.activeTimeSlots().should('have.length', 1)
 
@@ -145,7 +146,7 @@ context('Allocate to activity', () => {
     activitiesPage.selectActivityWithName('English level 1')
 
     const allocatePage = Page.verifyOnPage(AllocationDashboard)
-    allocatePage.allocatedPeopleRows().should('have.length', 2)
+    allocatePage.allocatedPeopleRows().should('have.length', 3)
     allocatePage.tabWithTitle('Entry level English 1 schedule').click()
     allocatePage.activeTimeSlots().should('have.length', 1)
 

--- a/integration_tests/e2e/activities/allocations/deallocateFromActivity.cy.ts
+++ b/integration_tests/e2e/activities/allocations/deallocateFromActivity.cy.ts
@@ -62,7 +62,7 @@ context('Deallocation from activity', () => {
       activitiesPage.selectActivityWithName('English level 1')
 
       const allocationDashboardPage = Page.verifyOnPage(AllocationDashboard)
-      allocationDashboardPage.allocatedPeopleRows().should('have.length', 2)
+      allocationDashboardPage.allocatedPeopleRows().should('have.length', 3)
       allocationDashboardPage.selectAllocatedPrisonerByName('Bloggs, Jo')
       allocationDashboardPage.selectAllocatedPrisonerByName('Body, No')
       allocationDashboardPage.deallocateSelectedPrisoners()
@@ -107,7 +107,7 @@ context('Deallocation from activity', () => {
       )
 
       const allocationDashboardPage = Page.verifyOnPage(AllocationDashboard)
-      allocationDashboardPage.allocatedPeopleRows().should('have.length', 2)
+      allocationDashboardPage.allocatedPeopleRows().should('have.length', 3)
       allocationDashboardPage.selectAllocatedPrisonerByName('Bloggs, Jo')
       allocationDashboardPage.deallocateSelectedPrisoners()
 
@@ -152,7 +152,7 @@ context('Deallocation from activity', () => {
       )
 
       const allocationDashboardPage = Page.verifyOnPage(AllocationDashboard)
-      allocationDashboardPage.allocatedPeopleRows().should('have.length', 2)
+      allocationDashboardPage.allocatedPeopleRows().should('have.length', 3)
       allocationDashboardPage.selectAllocatedPrisonerByName('Bloggs, Jo')
       allocationDashboardPage.deallocateSelectedPrisoners()
 

--- a/integration_tests/fixtures/activitiesApi/getAllocations.json
+++ b/integration_tests/fixtures/activitiesApi/getAllocations.json
@@ -36,5 +36,24 @@
     "cellLocation": "1-3-004",
     "releaseDate": "2040-06-23",
     "nonAssociations": false
+  },
+  {
+    "id": 4,
+    "activityId": 2,
+    "prisonerNumber": "B1351RE",
+    "activitySummary": "English level 1",
+    "scheduleDescription": "Entry level English 1",
+    "payBand": "A",
+    "startDate": "2022-10-10",
+    "endDate": null,
+    "allocatedTime": "2022-10-10T09:30:00",
+    "allocatedBy": "MR BLOGS",
+    "deallocatedTime": null,
+    "deallocatedBy": null,
+    "deallocatedReason": null,
+    "prisonerName": "NO BODY",
+    "cellLocation": "1-3-004",
+    "releaseDate": "2040-06-23",
+    "nonAssociations": null
   }
 ]

--- a/server/views/partials/activities/allocation-dashboard/nonAssociationsHtml.njk
+++ b/server/views/partials/activities/allocation-dashboard/nonAssociationsHtml.njk
@@ -1,8 +1,10 @@
 {% macro nonAssociationsHtml(row, prisonerName, activityId) %}
     {% set activityIdentifier = row.activityId or activityId %}
-    {% if row.nonAssociations %}
+    {% if row.nonAssociations or row.nonAssociations == null %}
+        {# if the response is null or an array of non-associations, send them to the non-associations page #}
         <p class="govuk-body" data-qa="non-associations-link-{{ row.prisonerNumber }}"><a href='/activities/non-associations/{{ activityIdentifier }}/{{ row.prisonerNumber }}' class='govuk-link govuk-link--no-visited-state' target='_blank'>View non-associations<span class="govuk-visually-hidden">for {{ prisonerName }}</span></a></p>
     {% else %}
+        {# if the response is false, we know that there are no non-associations for the prisoner #}
         <p class="govuk-body">None</p>
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
We should send the user to the new non-associations page with a link in the correct column if the endpoint we call returns a null response (if non-associations API errors). The user should be able to get the information they need from the new non-associations page as that endpoint is working okay in the non-associations API.