### PR TITLE
SAA-2212: Fix checkboxes in absences view when moving from summary attendances view

### DIFF
--- a/server/routes/activities/daily-attendance-summary/handlers/applyFilters.test.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/applyFilters.test.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import ApplyFiltersRoutes from './applyFilters'
 import AttendanceReason from '../../../../enum/attendanceReason'
+import { PayNoPay } from '../../../../@types/activities'
 
 describe('Route Handlers - applyFilters', () => {
   const handler = new ApplyFiltersRoutes()
@@ -27,41 +28,99 @@ describe('Route Handlers - applyFilters', () => {
   })
 
   describe('APPLY', () => {
-    it('should apply populated list of filter', async () => {
-      req.body = {
-        categoryFilters: ['Prison Jobs'],
-        reasonFilter: 'SUSPENDED',
-        searchTerm: 'search',
-        absenceReasonFilters: [AttendanceReason.SICK],
-        payFilters: ['true'],
+    beforeEach(() => {
+      req.session.attendanceSummaryJourney = {
+        categoryFilters: ['Education'],
+        reasonFilter: 'BOTH',
+        searchTerm: undefined,
+        absenceReasonFilters: [AttendanceReason.CLASH],
+        payFilters: [PayNoPay.PAID],
       }
-      await handler.APPLY(req, res)
+    })
 
-      expect(req.session.attendanceSummaryJourney).toStrictEqual({
-        categoryFilters: ['Prison Jobs'],
-        reasonFilter: 'SUSPENDED',
-        searchTerm: 'search',
-        absenceReasonFilters: [AttendanceReason.SICK],
-        payFilters: ['true'],
+    describe('when view is not absences', () => {
+      it('should apply populated list of filter', async () => {
+        req.body = {
+          categoryFilters: ['Prison Jobs'],
+          reasonFilter: 'SUSPENDED',
+          searchTerm: 'search',
+          absenceReasonFilters: [AttendanceReason.SICK],
+          payFilters: ['true'],
+          isAbsencesFilter: undefined,
+        }
+
+        await handler.APPLY(req, res)
+
+        expect(req.session.attendanceSummaryJourney).toStrictEqual({
+          categoryFilters: ['Prison Jobs'],
+          reasonFilter: 'SUSPENDED',
+          searchTerm: 'search',
+          absenceReasonFilters: undefined,
+          payFilters: undefined,
+        })
+      })
+
+      it('should apply empty filters', async () => {
+        req.body = {
+          categoryFilters: [],
+          reasonFilter: '',
+          searchTerm: '',
+          absenceReasonFilters: [],
+          payFilters: [],
+          isAbsencesFilter: undefined,
+        }
+        await handler.APPLY(req, res)
+
+        expect(req.session.attendanceSummaryJourney).toStrictEqual({
+          categoryFilters: [],
+          reasonFilter: '',
+          searchTerm: '',
+          absenceReasonFilters: undefined,
+          payFilters: undefined,
+        })
       })
     })
 
-    it('should apply empty filters', async () => {
-      req.body = {
-        categoryFilters: [],
-        reasonFilter: '',
-        searchTerm: '',
-        absenceReasonFilters: [],
-        payFilters: [],
-      }
-      await handler.APPLY(req, res)
+    describe('when view is absences', () => {
+      it('should apply populated list of filter', async () => {
+        req.body = {
+          categoryFilters: ['Prison Jobs'],
+          reasonFilter: 'SUSPENDED',
+          searchTerm: 'search',
+          absenceReasonFilters: [AttendanceReason.SICK],
+          payFilters: ['true'],
+          isAbsencesFilter: true,
+        }
 
-      expect(req.session.attendanceSummaryJourney).toStrictEqual({
-        categoryFilters: [],
-        reasonFilter: '',
-        searchTerm: '',
-        absenceReasonFilters: [],
-        payFilters: [],
+        await handler.APPLY(req, res)
+
+        expect(req.session.attendanceSummaryJourney).toStrictEqual({
+          categoryFilters: ['Prison Jobs'],
+          reasonFilter: 'SUSPENDED',
+          searchTerm: 'search',
+          absenceReasonFilters: [AttendanceReason.SICK],
+          payFilters: ['true'],
+        })
+      })
+
+      it('should apply empty filters', async () => {
+        req.body = {
+          categoryFilters: [],
+          reasonFilter: '',
+          searchTerm: '',
+          absenceReasonFilters: [],
+          payFilters: [],
+          isAbsencesFilter: true,
+        }
+        await handler.APPLY(req, res)
+
+        expect(req.session.attendanceSummaryJourney).toStrictEqual({
+          categoryFilters: [],
+          reasonFilter: '',
+          searchTerm: '',
+          absenceReasonFilters: [],
+          payFilters: [],
+        })
       })
     })
   })

--- a/server/routes/activities/daily-attendance-summary/handlers/applyFilters.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/applyFilters.ts
@@ -35,12 +35,19 @@ export class Filters {
 
 export default class ApplyFiltersRoutes {
   APPLY = async (req: Request, res: Response): Promise<void> => {
-    const { categoryFilters, reasonFilter, searchTerm, absenceReasonFilters, payFilters } = req.body
+    const { categoryFilters, reasonFilter, searchTerm, absenceReasonFilters, payFilters, isAbsencesFilter } = req.body
+
     req.session.attendanceSummaryJourney.categoryFilters = categoryFilters ?? []
-    req.session.attendanceSummaryJourney.absenceReasonFilters = absenceReasonFilters ?? []
-    req.session.attendanceSummaryJourney.payFilters = payFilters ?? []
     req.session.attendanceSummaryJourney.reasonFilter = reasonFilter ?? 'BOTH'
     req.session.attendanceSummaryJourney.searchTerm = searchTerm ?? null
+
+    if (isAbsencesFilter) {
+      req.session.attendanceSummaryJourney.absenceReasonFilters = absenceReasonFilters ?? []
+      req.session.attendanceSummaryJourney.payFilters = payFilters ?? []
+    } else {
+      req.session.attendanceSummaryJourney.absenceReasonFilters = undefined
+      req.session.attendanceSummaryJourney.payFilters = undefined
+    }
 
     res.redirect('back')
   }

--- a/server/views/partials/activities/absencesCheckboxes.njk
+++ b/server/views/partials/activities/absencesCheckboxes.njk
@@ -38,3 +38,4 @@
     }
     ]
 }) }}
+<input type="hidden" name="isAbsencesFilter" value="true" />


### PR DESCRIPTION
If user selects some but not all categories in attendance summary view:
<img width="615" alt="image" src="https://github.com/user-attachments/assets/0f49acc4-602e-4da0-a5cf-0634ec15774d">

then ensure that the Absences and Pay checkboxes are all selected in the absences summary view:
<img width="517" alt="image" src="https://github.com/user-attachments/assets/7aab83b5-a26a-44f8-b089-0d1b9feeba47">

