### PR TITLE
add packages to renovate ignore config to avoid breaking changes in non major upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
   "overrides": {
     "rollup": "~4.28.1",
     "cookie": "~1.0.2",
-    "path-to-regexp": "=0.1.12",
+    "path-to-regexp": "~0.1.12",
     "cross-spawn": "~7.0.6"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ministryofjustice/hmpps-renovate-config:node"],
   "reviewers": ["natclamp-moj", "Kristian-Gregory", "davidthomas22", "dafhoustonmoj", "munslowl", "angela-pan-moj"],
+  "ignoreDeps": ["@ministryofjustice/hmpps-digital-prison-reporting-frontend", "path-to-regexp", "cross-spawn"],
   "packageRules": [
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
There's jira tickets to resolve these upgrades properly, this is just a temp solution to avoid breaking changes every time it tries to create a non major dependency update PR.