### PR TITLE
SAA-2197: Add summary link to appointments attendance summary view

### DIFF
--- a/server/views/pages/appointments/attendance/summaries-multi-select.njk
+++ b/server/views/pages/appointments/attendance/summaries-multi-select.njk
@@ -86,6 +86,10 @@
             </div>
         </div>
 
+        <p class="govuk-body">
+            <a href="/appointments/attendance-summary/dashboard?date={{ date | toDateString }}" data-qa="summary-link" target='_blank'>Go to daily attendance summary</a>
+        </p>
+
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <h2 class="govuk-heading-s">Showing {{ summaries | length }} appointment{{ "s" if summaries | length != 1 }}</h2>


### PR DESCRIPTION
Add a link to allow users to go to the appointment attendance summary view.
<img width="346" alt="image" src="https://github.com/user-attachments/assets/3d9232c5-591f-4d2a-86a3-e671496e608e" />
