### PR TITLE
SAA-2290: Back link fix and refactor

### DIFF
--- a/server/routes/activities/change-of-circumstances/handlers/selectPeriodForChanges.ts
+++ b/server/routes/activities/change-of-circumstances/handlers/selectPeriodForChanges.ts
@@ -5,15 +5,15 @@ import { startOfToday, subDays } from 'date-fns'
 import { formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
-import { PresetDateOptionsWithYesterday } from '../../../../utils/utils'
+import DateOption from '../../../../enum/dateOption'
 
 export class TimePeriodForChanges {
   @Expose()
-  @IsIn(Object.values(PresetDateOptionsWithYesterday), { message: 'Select a date to query changes in the prison' })
+  @IsIn(Object.values(DateOption), { message: 'Select a date to query changes in the prison' })
   datePresetOption: string
 
   @Expose()
-  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithYesterday.OTHER)
+  @ValidateIf(o => o.datePresetOption === DateOption.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(date => date <= startOfToday(), { message: 'Enter a date on or before today' })
   @IsValidDate({ message: 'Enter a valid date' })
@@ -29,8 +29,8 @@ export default class SelectPeriodForChangesRoutes {
   }
 
   private selectedDate(form: TimePeriodForChanges) {
-    if (form.datePresetOption === PresetDateOptionsWithYesterday.TODAY) return startOfToday()
-    if (form.datePresetOption === PresetDateOptionsWithYesterday.YESTERDAY) return subDays(startOfToday(), 1)
+    if (form.datePresetOption === DateOption.TODAY) return startOfToday()
+    if (form.datePresetOption === DateOption.YESTERDAY) return subDays(startOfToday(), 1)
     return form.date
   }
 }

--- a/server/routes/activities/change-of-circumstances/handlers/selectPeriodForChanges.ts
+++ b/server/routes/activities/change-of-circumstances/handlers/selectPeriodForChanges.ts
@@ -5,20 +5,15 @@ import { startOfToday, subDays } from 'date-fns'
 import { formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
-
-enum PresetDateOptions {
-  TODAY = 'today',
-  YESTERDAY = 'yesterday',
-  OTHER = 'other',
-}
+import { PresetDateOptionsWithYesterday } from '../../../../utils/utils'
 
 export class TimePeriodForChanges {
   @Expose()
-  @IsIn(Object.values(PresetDateOptions), { message: 'Select a date to query changes in the prison' })
+  @IsIn(Object.values(PresetDateOptionsWithYesterday), { message: 'Select a date to query changes in the prison' })
   datePresetOption: string
 
   @Expose()
-  @ValidateIf(o => o.datePresetOption === PresetDateOptions.OTHER)
+  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithYesterday.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(date => date <= startOfToday(), { message: 'Enter a date on or before today' })
   @IsValidDate({ message: 'Enter a valid date' })
@@ -34,8 +29,8 @@ export default class SelectPeriodForChangesRoutes {
   }
 
   private selectedDate(form: TimePeriodForChanges) {
-    if (form.datePresetOption === PresetDateOptions.TODAY) return startOfToday()
-    if (form.datePresetOption === PresetDateOptions.YESTERDAY) return subDays(startOfToday(), 1)
+    if (form.datePresetOption === PresetDateOptionsWithYesterday.TODAY) return startOfToday()
+    if (form.datePresetOption === PresetDateOptionsWithYesterday.YESTERDAY) return subDays(startOfToday(), 1)
     return form.date
   }
 }

--- a/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.test.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.test.ts
@@ -2,8 +2,8 @@ import { Request, Response } from 'express'
 import { addDays } from 'date-fns'
 import { plainToInstance } from 'class-transformer'
 import { validate } from 'class-validator'
-import SelectDateRoutes, { DateOptions, NotAttendedDate } from './notAttendedSelectDate'
-import { associateErrorsWithProperty } from '../../../../utils/utils'
+import SelectDateRoutes, { NotAttendedDate } from './notAttendedSelectDate'
+import { associateErrorsWithProperty, PresetDateOptionsWithYesterday } from '../../../../utils/utils'
 import { formatDatePickerDate, formatIsoDate } from '../../../../utils/datePickerUtils'
 
 describe('Not attended routes - select date', () => {
@@ -52,7 +52,7 @@ describe('Not attended routes - select date', () => {
       const today = new Date()
 
       req.body = {
-        datePresetOption: DateOptions.TODAY,
+        datePresetOption: PresetDateOptionsWithYesterday.TODAY,
       }
 
       await handler.POST(req, res)
@@ -66,7 +66,7 @@ describe('Not attended routes - select date', () => {
       const yesterday = addDays(new Date(), -1)
 
       req.body = {
-        datePresetOption: DateOptions.YESTERDAY,
+        datePresetOption: PresetDateOptionsWithYesterday.YESTERDAY,
       }
 
       await handler.POST(req, res)
@@ -80,7 +80,7 @@ describe('Not attended routes - select date', () => {
       const selectedDate = addDays(new Date(), 2)
 
       req.body = {
-        datePresetOption: DateOptions.OTHER,
+        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
         date: selectedDate,
       }
 
@@ -115,7 +115,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation fails if date option is other and a date is not provided', async () => {
       const body = {
-        datePresetOption: DateOptions.OTHER,
+        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
         date: '',
       }
 
@@ -127,7 +127,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation fails if preset option is other and a bad date is provided', async () => {
       const body = {
-        datePresetOption: DateOptions.OTHER,
+        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
         date: '',
       }
 
@@ -141,7 +141,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation fails if date is more than 60 days into the future', async () => {
       const body = {
-        datePresetOption: DateOptions.OTHER,
+        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
         date: formatDatePickerDate(addDays(new Date(), 61)),
       }
 
@@ -153,7 +153,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation fails if date is more than 14 days into the past', async () => {
       const body = {
-        datePresetOption: DateOptions.OTHER,
+        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
         date: formatDatePickerDate(addDays(new Date(), -15)),
       }
 
@@ -165,7 +165,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation passes if validate date option selected', async () => {
       const body = {
-        datePresetOption: DateOptions.TODAY,
+        datePresetOption: PresetDateOptionsWithYesterday.TODAY,
       }
 
       const requestObject = plainToInstance(NotAttendedDate, body)
@@ -176,7 +176,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation passes if validate date option is other and valid date entered', async () => {
       const body = {
-        datePresetOption: DateOptions.OTHER,
+        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
         date: formatDatePickerDate(addDays(new Date(), -14)),
       }
 

--- a/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.test.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.test.ts
@@ -3,8 +3,9 @@ import { addDays } from 'date-fns'
 import { plainToInstance } from 'class-transformer'
 import { validate } from 'class-validator'
 import SelectDateRoutes, { NotAttendedDate } from './notAttendedSelectDate'
-import { associateErrorsWithProperty, PresetDateOptionsWithYesterday } from '../../../../utils/utils'
+import { associateErrorsWithProperty } from '../../../../utils/utils'
 import { formatDatePickerDate, formatIsoDate } from '../../../../utils/datePickerUtils'
+import DateOption from '../../../../enum/dateOption'
 
 describe('Not attended routes - select date', () => {
   const handler = new SelectDateRoutes()
@@ -52,7 +53,7 @@ describe('Not attended routes - select date', () => {
       const today = new Date()
 
       req.body = {
-        datePresetOption: PresetDateOptionsWithYesterday.TODAY,
+        datePresetOption: DateOption.TODAY,
       }
 
       await handler.POST(req, res)
@@ -66,7 +67,7 @@ describe('Not attended routes - select date', () => {
       const yesterday = addDays(new Date(), -1)
 
       req.body = {
-        datePresetOption: PresetDateOptionsWithYesterday.YESTERDAY,
+        datePresetOption: DateOption.YESTERDAY,
       }
 
       await handler.POST(req, res)
@@ -80,7 +81,7 @@ describe('Not attended routes - select date', () => {
       const selectedDate = addDays(new Date(), 2)
 
       req.body = {
-        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
+        datePresetOption: DateOption.OTHER,
         date: selectedDate,
       }
 
@@ -115,7 +116,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation fails if date option is other and a date is not provided', async () => {
       const body = {
-        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
+        datePresetOption: DateOption.OTHER,
         date: '',
       }
 
@@ -127,7 +128,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation fails if preset option is other and a bad date is provided', async () => {
       const body = {
-        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
+        datePresetOption: DateOption.OTHER,
         date: '',
       }
 
@@ -141,7 +142,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation fails if date is more than 60 days into the future', async () => {
       const body = {
-        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
+        datePresetOption: DateOption.OTHER,
         date: formatDatePickerDate(addDays(new Date(), 61)),
       }
 
@@ -153,7 +154,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation fails if date is more than 14 days into the past', async () => {
       const body = {
-        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
+        datePresetOption: DateOption.OTHER,
         date: formatDatePickerDate(addDays(new Date(), -15)),
       }
 
@@ -165,7 +166,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation passes if validate date option selected', async () => {
       const body = {
-        datePresetOption: PresetDateOptionsWithYesterday.TODAY,
+        datePresetOption: DateOption.TODAY,
       }
 
       const requestObject = plainToInstance(NotAttendedDate, body)
@@ -176,7 +177,7 @@ describe('Not attended routes - select date', () => {
 
     it('validation passes if validate date option is other and valid date entered', async () => {
       const body = {
-        datePresetOption: PresetDateOptionsWithYesterday.OTHER,
+        datePresetOption: DateOption.OTHER,
         date: formatDatePickerDate(addDays(new Date(), -14)),
       }
 

--- a/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.ts
@@ -5,13 +5,14 @@ import { addDays, startOfToday, subDays } from 'date-fns'
 import { formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
-import { getSelectedDate, PresetDateOptionsWithYesterday } from '../../../../utils/utils'
+import { getSelectedDate } from '../../../../utils/utils'
+import DateOption from '../../../../enum/dateOption'
 
 export class NotAttendedDate {
-  @IsEnum(PresetDateOptionsWithYesterday, { message: 'Select a date' })
-  datePresetOption: PresetDateOptionsWithYesterday
+  @IsEnum(DateOption, { message: 'Select a date' })
+  datePresetOption: DateOption
 
-  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithYesterday.OTHER)
+  @ValidateIf(o => o.datePresetOption === DateOption.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(thisDate => thisDate >= subDays(startOfToday(), 14), {
     message: 'Enter a date within the last 14 days',

--- a/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/notAttendedSelectDate.ts
@@ -5,18 +5,13 @@ import { addDays, startOfToday, subDays } from 'date-fns'
 import { formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
-
-export enum DateOptions {
-  TODAY = 'today',
-  YESTERDAY = 'yesterday',
-  OTHER = 'other',
-}
+import { getSelectedDate, PresetDateOptionsWithYesterday } from '../../../../utils/utils'
 
 export class NotAttendedDate {
-  @IsEnum(DateOptions, { message: 'Select a date' })
-  datePresetOption: DateOptions
+  @IsEnum(PresetDateOptionsWithYesterday, { message: 'Select a date' })
+  datePresetOption: PresetDateOptionsWithYesterday
 
-  @ValidateIf(o => o.datePresetOption === DateOptions.OTHER)
+  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithYesterday.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(thisDate => thisDate >= subDays(startOfToday(), 14), {
     message: 'Enter a date within the last 14 days',
@@ -37,13 +32,7 @@ export default class SelectDateRoutes {
 
   POST = async (req: Request, res: Response): Promise<void> => {
     req.session.attendanceSummaryJourney = null
-    const selectedDate = this.selectedDate(req.body)
+    const selectedDate = getSelectedDate(req.body)
     res.redirect(`attendance?date=${formatIsoDate(selectedDate)}&status=NotAttended&preserveHistory=true`)
-  }
-
-  private selectedDate(form: NotAttendedDate) {
-    if (form.datePresetOption === DateOptions.TODAY) return new Date()
-    if (form.datePresetOption === DateOptions.YESTERDAY) return subDays(new Date(), 1)
-    return form.date
   }
 }

--- a/server/routes/activities/daily-attendance-summary/handlers/selectPeriod.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/selectPeriod.ts
@@ -2,22 +2,19 @@ import { Request, Response } from 'express'
 import { Expose, Transform } from 'class-transformer'
 import { IsIn, ValidateIf } from 'class-validator'
 import { addDays, startOfToday, subDays } from 'date-fns'
-import {
-  getDatePresetOptionWithYesterday,
-  getSelectedDate,
-  PresetDateOptionsWithYesterday,
-} from '../../../../utils/utils'
+import { getDatePresetOptionWithYesterday, getSelectedDate } from '../../../../utils/utils'
 import { formatDatePickerDate, formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
+import DateOption from '../../../../enum/dateOption'
 
 export class TimePeriod {
   @Expose()
-  @IsIn(Object.values(PresetDateOptionsWithYesterday), { message: 'Select a date' })
+  @IsIn(Object.values(DateOption), { message: 'Select a date' })
   datePresetOption: string
 
   @Expose()
-  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithYesterday.OTHER)
+  @ValidateIf(o => o.datePresetOption === DateOption.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(thisDate => thisDate >= subDays(startOfToday(), 14), {
     message: 'Enter a date within the last 14 days',
@@ -37,10 +34,7 @@ export default class SelectPeriodRoutes {
     res.render('pages/activities/daily-attendance-summary/select-period', {
       title: 'What date do you want to see the daily attendance summary for?',
       datePresetOption,
-      date:
-        date && datePresetOption === PresetDateOptionsWithYesterday.OTHER
-          ? formatDatePickerDate(new Date(date as string))
-          : null,
+      date: date && datePresetOption === DateOption.OTHER ? formatDatePickerDate(new Date(date as string)) : null,
     })
   }
 

--- a/server/routes/activities/daily-attendance-summary/handlers/selectPeriod.ts
+++ b/server/routes/activities/daily-attendance-summary/handlers/selectPeriod.ts
@@ -2,23 +2,22 @@ import { Request, Response } from 'express'
 import { Expose, Transform } from 'class-transformer'
 import { IsIn, ValidateIf } from 'class-validator'
 import { addDays, startOfToday, subDays } from 'date-fns'
+import {
+  getDatePresetOptionWithYesterday,
+  getSelectedDate,
+  PresetDateOptionsWithYesterday,
+} from '../../../../utils/utils'
 import { formatDatePickerDate, formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
 
-enum PresetDateOptions {
-  TODAY = 'today',
-  YESTERDAY = 'yesterday',
-  OTHER = 'other',
-}
-
 export class TimePeriod {
   @Expose()
-  @IsIn(Object.values(PresetDateOptions), { message: 'Select a date' })
+  @IsIn(Object.values(PresetDateOptionsWithYesterday), { message: 'Select a date' })
   datePresetOption: string
 
   @Expose()
-  @ValidateIf(o => o.datePresetOption === PresetDateOptions.OTHER)
+  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithYesterday.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(thisDate => thisDate >= subDays(startOfToday(), 14), {
     message: 'Enter a date within the last 14 days',
@@ -33,37 +32,22 @@ export class TimePeriod {
 export default class SelectPeriodRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
     const { date } = req.query
-    const datePresetOption = this.getDatePresetOption(date as string)
+    const datePresetOption = getDatePresetOptionWithYesterday(date as string)
 
     res.render('pages/activities/daily-attendance-summary/select-period', {
       title: 'What date do you want to see the daily attendance summary for?',
       datePresetOption,
       date:
-        date && datePresetOption === PresetDateOptions.OTHER ? formatDatePickerDate(new Date(date as string)) : null,
+        date && datePresetOption === PresetDateOptionsWithYesterday.OTHER
+          ? formatDatePickerDate(new Date(date as string))
+          : null,
     })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
     req.session.attendanceSummaryJourney = null
 
-    const selectedDate = this.selectedDate(req.body)
+    const selectedDate = getSelectedDate(req.body)
     return res.redirect(`summary?date=${formatIsoDate(selectedDate)}`)
-  }
-
-  private selectedDate(form: TimePeriod) {
-    if (form.datePresetOption === PresetDateOptions.TODAY) return new Date()
-    if (form.datePresetOption === PresetDateOptions.YESTERDAY) return subDays(new Date(), 1)
-    return form.date
-  }
-
-  private getDatePresetOption = (date: string): PresetDateOptions => {
-    if (date === undefined) return null
-    if (date === this.getDate(new Date())) return PresetDateOptions.TODAY
-    if (date === this.getDate(subDays(new Date(), 1))) return PresetDateOptions.YESTERDAY
-    return PresetDateOptions.OTHER
-  }
-
-  private getDate = (date: Date): string => {
-    return date.toISOString().split('T')[0]
   }
 }

--- a/server/routes/activities/record-attendance/handlers/selectPeriod.test.ts
+++ b/server/routes/activities/record-attendance/handlers/selectPeriod.test.ts
@@ -20,13 +20,19 @@ describe('Route Handlers - Select period', () => {
       redirect: jest.fn(),
     } as unknown as Response
 
-    req = {} as unknown as Request
+    req = {
+      query: {},
+    } as unknown as Request
   })
 
   describe('GET', () => {
     it('should render the expected view', async () => {
       await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/activities/record-attendance/select-period')
+      expect(res.render).toHaveBeenCalledWith('pages/activities/record-attendance/select-period', {
+        date: null,
+        datePresetOption: null,
+        sessions: null,
+      })
     })
   })
 

--- a/server/routes/activities/record-attendance/handlers/selectPeriod.ts
+++ b/server/routes/activities/record-attendance/handlers/selectPeriod.ts
@@ -6,20 +6,16 @@ import { formatDatePickerDate, formatIsoDate, parseDatePickerDate } from '../../
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
 import TimeSlot from '../../../../enum/timeSlot'
-import {
-  convertToArray,
-  getDatePresetOptionWithYesterday,
-  getSelectedDate,
-  PresetDateOptionsWithYesterday,
-} from '../../../../utils/utils'
+import { convertToArray, getDatePresetOptionWithYesterday, getSelectedDate } from '../../../../utils/utils'
+import DateOption from '../../../../enum/dateOption'
 
 export class TimePeriod {
   @Expose()
-  @IsIn(Object.values(PresetDateOptionsWithYesterday), { message: 'Select a date' })
+  @IsIn(Object.values(DateOption), { message: 'Select a date' })
   datePresetOption: string
 
   @Expose()
-  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithYesterday.OTHER)
+  @ValidateIf(o => o.datePresetOption === DateOption.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(thisDate => thisDate <= addDays(startOfToday(), 60), {
     message: 'Enter a date up to 60 days in the future',
@@ -39,10 +35,7 @@ export default class SelectPeriodRoutes {
     return res.render('pages/activities/record-attendance/select-period', {
       sessions: sessions || null,
       datePresetOption,
-      date:
-        date && datePresetOption === PresetDateOptionsWithYesterday.OTHER
-          ? formatDatePickerDate(new Date(date as string))
-          : null,
+      date: date && datePresetOption === DateOption.OTHER ? formatDatePickerDate(new Date(date as string)) : null,
     })
   }
 

--- a/server/routes/activities/record-attendance/handlers/selectPeriod.ts
+++ b/server/routes/activities/record-attendance/handlers/selectPeriod.ts
@@ -37,7 +37,7 @@ export default class SelectPeriodRoutes {
     const { date, sessions } = req.query
     const datePresetOption = getDatePresetOptionWithYesterday(date as string)
     return res.render('pages/activities/record-attendance/select-period', {
-      sessions,
+      sessions: sessions || null,
       datePresetOption,
       date:
         date && datePresetOption === PresetDateOptionsWithYesterday.OTHER

--- a/server/routes/activities/record-attendance/handlers/selectPeriod.ts
+++ b/server/routes/activities/record-attendance/handlers/selectPeriod.ts
@@ -1,26 +1,25 @@
 import { Request, Response } from 'express'
 import { Expose, Transform } from 'class-transformer'
 import { IsIn, IsNotEmpty, ValidateIf } from 'class-validator'
-import { addDays, startOfToday, subDays } from 'date-fns'
-import { formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
+import { addDays, startOfToday } from 'date-fns'
+import { formatDatePickerDate, formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
 import TimeSlot from '../../../../enum/timeSlot'
-import { convertToArray } from '../../../../utils/utils'
-
-enum PresetDateOptions {
-  TODAY = 'today',
-  YESTERDAY = 'yesterday',
-  OTHER = 'other',
-}
+import {
+  convertToArray,
+  getDatePresetOptionWithYesterday,
+  getSelectedDate,
+  PresetDateOptionsWithYesterday,
+} from '../../../../utils/utils'
 
 export class TimePeriod {
   @Expose()
-  @IsIn(Object.values(PresetDateOptions), { message: 'Select a date' })
+  @IsIn(Object.values(PresetDateOptionsWithYesterday), { message: 'Select a date' })
   datePresetOption: string
 
   @Expose()
-  @ValidateIf(o => o.datePresetOption === PresetDateOptions.OTHER)
+  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithYesterday.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(thisDate => thisDate <= addDays(startOfToday(), 60), {
     message: 'Enter a date up to 60 days in the future',
@@ -35,18 +34,21 @@ export class TimePeriod {
 
 export default class SelectPeriodRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
-    return res.render('pages/activities/record-attendance/select-period')
+    const { date, sessions } = req.query
+    const datePresetOption = getDatePresetOptionWithYesterday(date as string)
+    return res.render('pages/activities/record-attendance/select-period', {
+      sessions,
+      datePresetOption,
+      date:
+        date && datePresetOption === PresetDateOptionsWithYesterday.OTHER
+          ? formatDatePickerDate(new Date(date as string))
+          : null,
+    })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
-    const selectedDate = this.selectedDate(req.body)
+    const selectedDate = getSelectedDate(req.body)
     const sessions = req.body.sessions ? convertToArray(req.body.sessions).join(',') : ''
     res.redirect(`activities?date=${formatIsoDate(selectedDate)}${sessions ? `&sessionFilters=${sessions}` : ''}`)
-  }
-
-  private selectedDate(form: TimePeriod) {
-    if (form.datePresetOption === PresetDateOptions.TODAY) return new Date()
-    if (form.datePresetOption === PresetDateOptions.YESTERDAY) return subDays(new Date(), 1)
-    return form.date
   }
 }

--- a/server/routes/activities/unlock-list/handlers/selectDateAndLocation.ts
+++ b/server/routes/activities/unlock-list/handlers/selectDateAndLocation.ts
@@ -6,16 +6,17 @@ import ActivitiesService from '../../../../services/activitiesService'
 import { formatDatePickerDate, formatIsoDate, parseDatePickerDate } from '../../../../utils/datePickerUtils'
 import IsValidDate from '../../../../validators/isValidDate'
 import Validator from '../../../../validators/validator'
-import { getDatePresetOptionWithTomorrow, PresetDateOptionsWithTomorrow } from '../../../../utils/utils'
+import { getDatePresetOptionWithTomorrow } from '../../../../utils/utils'
 import TimeSlot from '../../../../enum/timeSlot'
+import DateOption from '../../../../enum/dateOption'
 
 export class DateAndLocation {
   @Expose()
-  @IsIn(Object.values(PresetDateOptionsWithTomorrow), { message: 'Select a date' })
+  @IsIn(Object.values(DateOption), { message: 'Select a date' })
   datePresetOption: string
 
   @Expose()
-  @ValidateIf(o => o.datePresetOption === PresetDateOptionsWithTomorrow.OTHER)
+  @ValidateIf(o => o.datePresetOption === DateOption.OTHER)
   @Transform(({ value }) => parseDatePickerDate(value))
   @Validator(thisDate => thisDate <= addDays(startOfToday(), 60), {
     message: 'Enter a date up to 60 days in the future',
@@ -45,10 +46,7 @@ export default class SelectDateAndLocationRoutes {
     res.render('pages/activities/unlock-list/select-date-and-location', {
       locationGroups,
       datePresetOption,
-      date:
-        date && datePresetOption === PresetDateOptionsWithTomorrow.OTHER
-          ? formatDatePickerDate(new Date(date as string))
-          : null,
+      date: date && datePresetOption === DateOption.OTHER ? formatDatePickerDate(new Date(date as string)) : null,
       locationKey: locationKey || null,
       activitySlot: activitySlot || null,
     })
@@ -67,8 +65,8 @@ export default class SelectDateAndLocationRoutes {
   }
 
   private getDateValue = (datePresetOption: string, date: Date): Date => {
-    if (datePresetOption === PresetDateOptionsWithTomorrow.TODAY) return new Date()
-    if (datePresetOption === PresetDateOptionsWithTomorrow.TOMORROW) return addDays(new Date(), 1)
+    if (datePresetOption === DateOption.TODAY) return new Date()
+    if (datePresetOption === DateOption.TOMORROW) return addDays(new Date(), 1)
     return date
   }
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -20,18 +20,7 @@ import { FieldValidationError } from '../middleware/validationMiddleware'
 import { Activity, ActivitySchedule, Attendance, ScheduledEvent, Slot } from '../@types/activitiesAPI/types'
 import { CreateAnActivityJourney, Slots } from '../routes/activities/create-an-activity/journey'
 import { NameFormatStyle } from './helpers/nameFormatStyle'
-
-export enum PresetDateOptionsWithYesterday {
-  TODAY = 'today',
-  YESTERDAY = 'yesterday',
-  OTHER = 'other',
-}
-
-export enum PresetDateOptionsWithTomorrow {
-  TODAY = 'today',
-  TOMORROW = 'tomorrow',
-  OTHER = 'other',
-}
+import DateOption from '../enum/dateOption'
 
 const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
 
@@ -406,8 +395,8 @@ export const getSplitTime = (time: string) => {
 }
 
 export const getSelectedDate = form => {
-  if (form.datePresetOption === PresetDateOptionsWithYesterday.TODAY) return new Date()
-  if (form.datePresetOption === PresetDateOptionsWithYesterday.YESTERDAY) return subDays(new Date(), 1)
+  if (form.datePresetOption === DateOption.TODAY) return new Date()
+  if (form.datePresetOption === DateOption.YESTERDAY) return subDays(new Date(), 1)
   return form.date
 }
 
@@ -415,16 +404,16 @@ export const getDateFromDateAndTimeFormat = (date: Date): string => {
   return date.toISOString().split('T')[0]
 }
 
-export const getDatePresetOptionWithYesterday = (date: string): PresetDateOptionsWithYesterday => {
+export const getDatePresetOptionWithYesterday = (date: string): DateOption => {
   if (date === undefined) return null
-  if (date === getDateFromDateAndTimeFormat(new Date())) return PresetDateOptionsWithYesterday.TODAY
-  if (date === getDateFromDateAndTimeFormat(subDays(new Date(), 1))) return PresetDateOptionsWithYesterday.YESTERDAY
-  return PresetDateOptionsWithYesterday.OTHER
+  if (date === getDateFromDateAndTimeFormat(new Date())) return DateOption.TODAY
+  if (date === getDateFromDateAndTimeFormat(subDays(new Date(), 1))) return DateOption.YESTERDAY
+  return DateOption.OTHER
 }
 
-export const getDatePresetOptionWithTomorrow = (date: string): PresetDateOptionsWithTomorrow => {
+export const getDatePresetOptionWithTomorrow = (date: string): DateOption => {
   if (date === undefined) return null
-  if (date === getDateFromDateAndTimeFormat(new Date())) return PresetDateOptionsWithTomorrow.TODAY
-  if (date === getDateFromDateAndTimeFormat(addDays(new Date(), 1))) return PresetDateOptionsWithTomorrow.TOMORROW
-  return PresetDateOptionsWithTomorrow.OTHER
+  if (date === getDateFromDateAndTimeFormat(new Date())) return DateOption.TODAY
+  if (date === getDateFromDateAndTimeFormat(addDays(new Date(), 1))) return DateOption.TOMORROW
+  return DateOption.OTHER
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any,dot-notation */
 import {
+  addDays,
   areIntervalsOverlapping,
   endOfDay,
   format,
@@ -10,15 +11,27 @@ import {
   parse,
   parseISO,
   set,
+  subDays,
 } from 'date-fns'
 import { enGB } from 'date-fns/locale/en-GB'
 import { ValidationError } from 'class-validator'
 import _ from 'lodash'
 import { FieldValidationError } from '../middleware/validationMiddleware'
 import { Activity, ActivitySchedule, Attendance, ScheduledEvent, Slot } from '../@types/activitiesAPI/types'
-// eslint-disable-next-line import/no-cycle
 import { CreateAnActivityJourney, Slots } from '../routes/activities/create-an-activity/journey'
 import { NameFormatStyle } from './helpers/nameFormatStyle'
+
+export enum PresetDateOptionsWithYesterday {
+  TODAY = 'today',
+  YESTERDAY = 'yesterday',
+  OTHER = 'other',
+}
+
+export enum PresetDateOptionsWithTomorrow {
+  TODAY = 'today',
+  TOMORROW = 'tomorrow',
+  OTHER = 'other',
+}
 
 const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
 
@@ -390,4 +403,28 @@ export const getSplitTime = (time: string) => {
     hour: splitTime[0][0] === '0' ? splitTime[0][1] : splitTime[0],
     minute: splitTime[1][0] === '0' ? splitTime[1][1] : splitTime[1],
   }
+}
+
+export const getSelectedDate = form => {
+  if (form.datePresetOption === PresetDateOptionsWithYesterday.TODAY) return new Date()
+  if (form.datePresetOption === PresetDateOptionsWithYesterday.YESTERDAY) return subDays(new Date(), 1)
+  return form.date
+}
+
+export const getDateFromDateAndTimeFormat = (date: Date): string => {
+  return date.toISOString().split('T')[0]
+}
+
+export const getDatePresetOptionWithYesterday = (date: string): PresetDateOptionsWithYesterday => {
+  if (date === undefined) return null
+  if (date === getDateFromDateAndTimeFormat(new Date())) return PresetDateOptionsWithYesterday.TODAY
+  if (date === getDateFromDateAndTimeFormat(subDays(new Date(), 1))) return PresetDateOptionsWithYesterday.YESTERDAY
+  return PresetDateOptionsWithYesterday.OTHER
+}
+
+export const getDatePresetOptionWithTomorrow = (date: string): PresetDateOptionsWithTomorrow => {
+  if (date === undefined) return null
+  if (date === getDateFromDateAndTimeFormat(new Date())) return PresetDateOptionsWithTomorrow.TODAY
+  if (date === getDateFromDateAndTimeFormat(addDays(new Date(), 1))) return PresetDateOptionsWithTomorrow.TOMORROW
+  return PresetDateOptionsWithTomorrow.OTHER
 }

--- a/server/views/pages/activities/change-of-circumstances/select-period.njk
+++ b/server/views/pages/activities/change-of-circumstances/select-period.njk
@@ -6,7 +6,8 @@
 
 {% set pageTitle = applicationName + " - Change of circumstances" %}
 {% set pageId = 'select-period-for-changes-page' %}
-{% set jsBackLink = true %}
+{% set hardBackLinkHref = "/activities/allocations" %}
+{% set hardBackLinkText = "Back" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/pages/activities/record-attendance/activities.njk
+++ b/server/views/pages/activities/record-attendance/activities.njk
@@ -14,7 +14,8 @@
 
 {% set pageTitle = applicationName + " - Record attendance" %}
 {% set pageId = 'activities-page' %}
-{% set jsBackLink = true %}
+{% set hardBackLinkHref = "/activities/attendance/select-period?date="+(activityDate | toDateString or '')+"&sessions="+(session.req.query.sessionFilters or '') %}
+{% set hardBackLinkText = "Back" %}
 
 {% set filterParams = (('&searchTerm=' + session.req.query.searchTerm) if session.req.query.searchTerm else '') +
     (('&sessionFilters=' + session.req.query.sessionFilters) if session.req.query.sessionFilters else '') +

--- a/server/views/pages/activities/record-attendance/select-period.njk
+++ b/server/views/pages/activities/record-attendance/select-period.njk
@@ -32,17 +32,17 @@
                         {
                             value: "today",
                             text: "Today - " + now | formatDate('d MMMM yyyy', false),
-                            checked: formResponses.datePresetOption == 'today'
+                            checked: formResponses.datePresetOption == 'today' or datePresetOption == 'today'
                         },
                         {
                             value: "yesterday",
                             text: "Yesterday - " + now | addDays(-1) | formatDate('d MMMM yyyy', false),
-                            checked: formResponses.datePresetOption == 'yesterday'
+                            checked: formResponses.datePresetOption == 'yesterday' or datePresetOption == 'yesterday'
                         },
                         {
                             value: "other",
                             text: "A different date",
-                            checked: formResponses.datePresetOption == 'other',
+                            checked: formResponses.datePresetOption == 'other' or datePresetOption == 'other',
                             conditional: { 
                                 html: mojDatePicker({
                                     id: 'date',


### PR DESCRIPTION
Fixes the back link on the 'find an activity to record...' page to go back to the select-period page, and make sure it renders the datePresetOption and the sessions that were previously selected.

Includes a refactor to amalgamate related enums and functions to ensure that the datePresetOptions are pre-selected on various pages.