### PR TITLE
SAA-2197: Fix mark appointment attendances UI issues

### DIFF
--- a/server/routes/appointments/attendance/handlers/attendees.test.ts
+++ b/server/routes/appointments/attendance/handlers/attendees.test.ts
@@ -512,7 +512,7 @@ describe('Route Handlers - Record Appointment Attendance', () => {
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
         '../attendees',
         'Attendance recorded',
-        "You've saved attendance details for 1 attendee",
+        "You've saved attendance details for 1 attendee.",
       )
     })
 
@@ -545,7 +545,7 @@ describe('Route Handlers - Record Appointment Attendance', () => {
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
         '../attendees',
         'Attendance recorded',
-        "You've saved attendance details for 4 attendees",
+        "You've saved attendance details for 4 attendees.",
       )
     })
   })
@@ -571,8 +571,8 @@ describe('Route Handlers - Record Appointment Attendance', () => {
 
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
         '../attendees',
-        'Attendance recorded',
-        "You've saved attendance details for 1 attendee",
+        'Non-attendance recorded',
+        "You've saved attendance details for 1 attendee.",
       )
     })
 
@@ -604,8 +604,8 @@ describe('Route Handlers - Record Appointment Attendance', () => {
 
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
         '../attendees',
-        'Attendance recorded',
-        "You've saved attendance details for 4 attendees",
+        'Non-attendance recorded',
+        "You've saved attendance details for 4 attendees.",
       )
     })
   })

--- a/server/routes/appointments/attendance/handlers/attendees.ts
+++ b/server/routes/appointments/attendance/handlers/attendees.ts
@@ -126,10 +126,11 @@ export default class AttendeesRoutes {
 
     await this.activitiesService.updateMultipleAppointmentAttendances(action, requests, user)
 
+    const successHeader = action === AttendanceAction.ATTENDED ? 'Attendance recorded' : 'Non-attendance recorded'
     const successMessage = `You've saved attendance details for ${attendanceIds.length} ${
-      attendanceIds.length === 1 ? 'attendee' : 'attendees'
+      attendanceIds.length === 1 ? 'attendee.' : 'attendees.'
     }`
 
-    return res.redirectWithSuccess('../attendees', 'Attendance recorded', successMessage)
+    return res.redirectWithSuccess('../attendees', successHeader, successMessage)
   }
 }

--- a/server/routes/appointments/attendance/handlers/editAttendance.test.ts
+++ b/server/routes/appointments/attendance/handlers/editAttendance.test.ts
@@ -107,7 +107,7 @@ describe('Route Handlers - Edit Appointment Attendance', () => {
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
         '../../../attendees',
         'Attendance recorded',
-        "You've saved details for Joe Bloggs",
+        "You've saved details for Joe Bloggs.",
       )
     })
 
@@ -125,7 +125,7 @@ describe('Route Handlers - Edit Appointment Attendance', () => {
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
         '../../../attendees',
         'Non-attendance recorded',
-        "You've saved details for Joe Bloggs",
+        "You've saved details for Joe Bloggs.",
       )
     })
 
@@ -143,7 +143,7 @@ describe('Route Handlers - Edit Appointment Attendance', () => {
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
         '../../../attendees',
         'Attendance reset',
-        'Attendance for Joe Bloggs has been reset',
+        'Attendance for Joe Bloggs has been reset.',
       )
     })
   })

--- a/server/routes/appointments/attendance/handlers/editAttendance.ts
+++ b/server/routes/appointments/attendance/handlers/editAttendance.ts
@@ -51,7 +51,7 @@ export default class EditAttendanceRoutes {
     const prisonerName = convertToTitleCase(`${attendee.prisoner.firstName} ${attendee.prisoner.lastName}`)
 
     let successHeader = 'Attendance recorded'
-    let successMessage = `You've saved details for ${prisonerName}`
+    let successMessage = `You've saved details for ${prisonerName}.`
     let action = AttendanceAction.ATTENDED
 
     if (req.body.attendanceOption === EditAttendanceOptions.NO) {
@@ -59,7 +59,7 @@ export default class EditAttendanceRoutes {
       action = AttendanceAction.NOT_ATTENDED
     } else if (req.body.attendanceOption === EditAttendanceOptions.RESET) {
       successHeader = 'Attendance reset'
-      successMessage = `Attendance for ${prisonerName} has been reset`
+      successMessage = `Attendance for ${prisonerName} has been reset.`
       action = AttendanceAction.RESET
     }
 

--- a/server/views/pages/appointments/attendance/attendees.njk
+++ b/server/views/pages/appointments/attendance/attendees.njk
@@ -28,7 +28,7 @@
 
 {% macro attendanceTag(attendee) %}
     {% if attendee.attended === null %}
-        Not recorded
+        Not recorded yet
     {% else %}
         {% if attendee.attended === true %}
             {{ govukTag({ text: 'Attended', classes: 'govuk-tag--green' }) }}
@@ -47,7 +47,7 @@
 {% macro renderViewLink(attendee) %}
     {% if attendee.attended !== null %}
         <a href="attendees/{{ attendee.appointment.id }}/{{ attendee.prisoner.prisonerNumber }}" class="govuk-link govuk-link--no-visited-state">
-            View or Edit
+            View or edit
         </a>
     {% endif %}
 {% endmacro %}
@@ -60,55 +60,65 @@
 {% endmacro %}
 
 {% block content %}
-    <form method='POST'>
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+<form method='POST'>
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
-        <div class="govuk-grid-column-two-thirds">
-            <span class="govuk-caption-l" data-qa="caption">Record appointment attendance</span>
-            {% if singleAppointment %}
-                <h1 class="govuk-heading-l govuk-!-margin-0" data-qa='heading'>{{ singleAppointment.appointmentName }}</h1>
-                <span class="govuk-caption-l" data-qa="date-caption">{{ singleAppointment.startTime + (" to " + singleAppointment.endTime if singleAppointment.endTime) }}</span>
-                <span class="govuk-caption-l" data-qa="date-caption">{{ singleAppointment.startDate | toDate | formatDate }}</span>
-                <span class="govuk-caption-l govuk-!-margin-bottom-4">{{ showLocation(singleAppointment) }}</span>
-            {% else %}
-                <h1 class="govuk-heading-l govuk-!-margin-0" data-qa='heading'>Record attendance at {{ numAppointments }} appointments</h1>
-                <span class="govuk-caption-l" data-qa="date-caption">{{ session.recordAppointmentAttendanceJourney.date | toDate | formatDate }}</span>
-            {% endif %}
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <span class="govuk-caption-l" data-qa="caption">Record appointment attendance</span>
+                {% if singleAppointment %}
+                    <h1 class="govuk-heading-l govuk-!-margin-0">{{ singleAppointment.appointmentName }}</h1>
+                    <span class="govuk-caption-l" data-qa="date-caption">{{ singleAppointment.startTime + (" to " + singleAppointment.endTime if singleAppointment.endTime) }}</span>
+                    <span class="govuk-caption-l" data-qa="date-caption">{{ singleAppointment.startDate | toDate | formatDate }}</span>
+                    <span class="govuk-caption-l govuk-!-margin-bottom-4">{{ showLocation(singleAppointment) }}</span>
+                {% else %}
+                    <h1 class="govuk-heading-l govuk-!-margin-0">Record attendance at {{ numAppointments }} appointments</h1>
+                    <span class="govuk-caption-l govuk-!-margin-bottom-4" data-qa="date-caption">{{ session.recordAppointmentAttendanceJourney.date | toDate | formatDate }}</span>
+                {% endif %}
 
-            <h2 class="govuk-heading-m">{{ attendanceSummary.attendeeCount }} attendee{{ "s" if attendanceSummary.attendeeCount != 1 }}</h2>
+                <h2 class="govuk-heading-m">{{ attendanceSummary.attendeeCount }} attendee{{ "s" if attendanceSummary.attendeeCount != 1 }}</h2>
+            </div>
+        </div>
 
-            {% if attendanceSummary.attendeeCount > 1 %}
-                <ul class="govuk-list govuk-!-margin-bottom-4">
-                    <li>
-                        <span>Attended:</span>
-                        <span class="govuk-!-font-weight-bold">{{ attendanceSummary.attended }}</span> ({{ attendanceSummary.attendedPercentage }}%)
-                    </li>
-                    <li>
-                        <span>Did not attend:</span>
-                        <span class="govuk-!-font-weight-bold">{{ attendanceSummary.notAttended }}</span> ({{ attendanceSummary.notAttendedPercentage }}%)
-                    </li>
-                    <li>
-                        <span>Not recorded yet:</span>
-                        <span class="govuk-!-font-weight-bold">{{ attendanceSummary.notRecorded }}</span> ({{ attendanceSummary.notRecordedPercentage }}%)
-                    </li>
-                </ul>
-            {% endif %}
+        <div class="govuk-grid-row govuk-!-margin-bottom-4">
+            <div class="govuk-grid-column-two-thirds">
+                {% if attendanceSummary.attendeeCount > 1 %}
+                    <ul class="govuk-list">
+                        <li>
+                            <span>Attended:</span>
+                            <span class="govuk-!-font-weight-bold">{{ attendanceSummary.attended }}</span> ({{ attendanceSummary.attendedPercentage }}%)
+                        </li>
+                        <li>
+                            <span>Did not attend:</span>
+                            <span class="govuk-!-font-weight-bold">{{ attendanceSummary.notAttended }}</span> ({{ attendanceSummary.notAttendedPercentage }}%)
+                        </li>
+                        <li>
+                            <span>Not recorded yet:</span>
+                            <span class="govuk-!-font-weight-bold">{{ attendanceSummary.notRecorded }}</span> ({{ attendanceSummary.notRecordedPercentage }}%)
+                        </li>
+                    </ul>
+                {% endif %}
+            </div>
+        </div>
 
-            {{ searchBar({
-                inputParams: {
-                    id: 'searchTerm',
-                    name: 'searchTerm',
-                    label: {
-                        text: 'Search by prisoner name or prison number',
-                        classes: 'govuk-label--s'
+        <div class="govuk-grid-row govuk-!-margin-bottom-4">
+            <div class="govuk-grid-column-two-thirds">
+                {{ searchBar({
+                    inputParams: {
+                        id: 'searchTerm',
+                        name: 'searchTerm',
+                        label: {
+                            text: 'Search by prisoner name or prison number',
+                            classes: 'govuk-label--s'
+                        },
+                        type: 'search',
+                        value: session.req.query.searchTerm
                     },
-                    type: 'search',
-                    value: session.req.query.searchTerm
-                },
-                buttonParams: {
-                    text: 'Search'
-                }
-            }) }}
+                    buttonParams: {
+                        text: 'Search'
+                    }
+                }) }}
+            </div>
         </div>
 
         {% set attendeeListRows = [] %}
@@ -216,8 +226,8 @@
                     formAction: 'attendees/non-attend'
                 }
             ],
-            itemsDescription: 'person',
-            itemsDescriptionPlural: 'people'
+            itemsDescription: 'attendee',
+            itemsDescriptionPlural: 'attendees'
         }) }}
     </form>
 {% endblock %}

--- a/server/views/pages/appointments/attendance/summaries-multi-select.njk
+++ b/server/views/pages/appointments/attendance/summaries-multi-select.njk
@@ -97,7 +97,7 @@
             <div class="govuk-grid-column-full">
                 <span class="govuk-caption-l">Record appointment attendance</span>
                 <h1 class="govuk-heading-l govuk-!-margin-0">Find an appointment to record or edit attendance</h1>
-                <span class="govuk-caption-m govuk-!-margin-bottom-4" data-qa="date-caption">{{ date | formatDate }}</span>
+                <span class="govuk-caption-l govuk-!-margin-bottom-4" data-qa="date-caption">{{ date | formatDate }}</span>
             </div>
         </div>
 
@@ -141,6 +141,11 @@
                         text: 'Search'
                     }
                 }) }}
+            </div>
+        </div>
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
 
                 {% set filterOptionsHtml %}
 


### PR DESCRIPTION
### [SAA-2294](https://dsdmoj.atlassian.net/browse/SAA-2294): 'Find an appt' page: change content width when filters removed
<img width="958" alt="image" src="https://github.com/user-attachments/assets/6ce06742-b706-4350-8824-c9f5a08f31f6" />

### [SAA-2295](https://dsdmoj.atlassian.net/browse/SAA-2295): Placeholder text for 'Not recorded' should be 'Not recorded yet'
<img width="205" alt="image" src="https://github.com/user-attachments/assets/170bccac-c28b-4c25-b3a1-28f7d6917f42" />

### [SAA-2296](https://dsdmoj.atlassian.net/browse/SAA-2296): Action bar text change
<img width="254" alt="image" src="https://github.com/user-attachments/assets/5e3c9e80-8641-48ed-b50a-45ed1ecb9e40" />

### [SAA-2297](https://dsdmoj.atlassian.net/browse/SAA-2297): Spacing around 'n attendees' content on record attendance page
<img width="165" alt="image" src="https://github.com/user-attachments/assets/a6aa97bb-71b2-40c9-af5c-1294e8e6214f" />

### [SAA-2298](https://dsdmoj.atlassian.net/browse/SAA-2298): Full stops in notification banners
<img width="625" alt="image" src="https://github.com/user-attachments/assets/01704797-7a7d-4170-a65e-69df8ad6237a" />
<img width="626" alt="image" src="https://github.com/user-attachments/assets/3a40f795-c153-451f-bea1-2c9717156883" />
<img width="625" alt="image" src="https://github.com/user-attachments/assets/964d6639-3c04-4edb-9e1d-7593232a9642" />

### [SAA-2299](https://dsdmoj.atlassian.net/browse/SAA-2299): Notification banner for non-attendance
<img width="623" alt="image" src="https://github.com/user-attachments/assets/e9f7d394-877d-498d-b77b-ae115e5b4bcd" />

### [SAA-2300](https://dsdmoj.atlassian.net/browse/SAA-2300): Left-hand alignment looks off on 'Record attendance' page
<img width="61" alt="image" src="https://github.com/user-attachments/assets/770596e3-f8ba-46bc-adf4-cfe2da8d9d9a" />

### [SAA-2301](https://dsdmoj.atlassian.net/browse/SAA-2301): 'View or Edit' link change to lower case 'e': View or edit
<img width="137" alt="image" src="https://github.com/user-attachments/assets/a136b83c-71cf-449d-8d38-96354103c269" />




[SAA-2294]: https://dsdmoj.atlassian.net/browse/SAA-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAA-2295]: https://dsdmoj.atlassian.net/browse/SAA-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAA-2296]: https://dsdmoj.atlassian.net/browse/SAA-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAA-2297]: https://dsdmoj.atlassian.net/browse/SAA-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAA-2298]: https://dsdmoj.atlassian.net/browse/SAA-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SAA-2299]: https://dsdmoj.atlassian.net/browse/SAA-2299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ