### PR TITLE
SAA-2327 update circle ci alerts channels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: activities-and-appointments-alerts
+    default: activities-and-appointments-alerts-security
 
   releases-slack-channel:
     type: string
-    default: activities-and-appointments-alerts
+    default: activities-and-appointments-dev
 
   node-version:
     type: string


### PR DESCRIPTION
Created new [activities-and-appointments-alerts-security](https://moj.enterprise.slack.com/archives/C08BVFF9TFG) channel for security alerts
Moved release alerts to dev channel as per guidance https://tech-docs.hmpps.service.justice.gov.uk/creating-new-services/prerequisites/ 