### PR TITLE
BAVL-696 make the confirmation text for probation teams not yet using BVLS to be team agnostic to allow for 'Team not listed'.

### DIFF
--- a/server/views/pages/appointments/video-link-booking/probation/booking-cancelled.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/booking-cancelled.njk
@@ -14,9 +14,9 @@
                 <p class='govuk-body'>We have emailed you confirming the cancellation. An email has also been sent to {{ probationTeam.description }}.</p>
             {% else %}
                 <p class='govuk-body'>We have emailed you confirming the cancellation.</p>
-                <h2 class="govuk-heading-m">Email {{ probationTeam.description }} to confirm the cancellation</h2>
+                <h2 class="govuk-heading-m">Email the probation team to confirm the cancellation</h2>
                 <p class="govuk-body">
-                    You must email {{ probationTeam.description }} to confirm the cancellation. This is because they do not yet have access to the Book a video link service.
+                    The probation team will not automatically receive confirmation of this cancellation. You must email them to confirm the cancellation.
                 </p>
             {% endif %}
 

--- a/server/views/pages/appointments/video-link-booking/probation/confirmation.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/confirmation.njk
@@ -19,9 +19,9 @@
             </p>
 
             {% if not probationTeam.enabled %}
-                <h2 class="govuk-heading-m">Email {{ probationTeam.description }} to confirm the booking</h2>
+                <h2 class="govuk-heading-m">Email the probation team this booking is for to confirm</h2>
                 <p class="govuk-body">
-                    You must email {{ probationTeam.description }} to confirm the booking. This is because they do not yet have access to the Book a video link service.
+                    The probation team will not automatically receive confirmation of this booking. You must email them to confirm.
                 </p>
             {% endif %}
 


### PR DESCRIPTION
Small textual change to message shown to prison users if choose a probation team that is not able to use BVLS directly.  

This is to allow it to be more generic e.g. if they choose 'Team not listed' which is available as probation team choice.