### PR TITLE
BAVL-792 removing prisoner names from the video link page titles but still including in the headers.

### DIFF
--- a/server/views/pages/appointments/video-link-booking/court/confirm-cancel.njk
+++ b/server/views/pages/appointments/video-link-booking/court/confirm-cancel.njk
@@ -3,12 +3,13 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Are you sure you want to cancel " + (session.bookACourtHearingJourney.prisoner.name | toTitleCase) + "'s booking?" %}
+{% set pageTitle = "Are you sure you want to cancel this booking?" %}
+{% set pageHeading = "Are you sure you want to cancel " + (session.bookACourtHearingJourney.prisoner.name | toTitleCase) + "'s booking?" %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
             {{ govukInsetText({
                 html: "The cancellation of a booking cannot be reversed."
             }) }}

--- a/server/views/pages/appointments/video-link-booking/probation/confirm-cancel.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/confirm-cancel.njk
@@ -3,12 +3,13 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitle = "Are you sure you want to cancel " + (session.bookAProbationMeetingJourney.prisoner.name | toTitleCase) + "'s booking?" %}
+{% set pageTitle = "Are you sure you want to cancel this booking?" %}
+{% set pageHeading = "Are you sure you want to cancel " + (session.bookAProbationMeetingJourney.prisoner.name | toTitleCase) + "'s booking?" %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+            <h1 class="govuk-heading-l">{{ pageHeading }}</h1>
             {{ govukInsetText({
                 html: "The cancellation of a booking cannot be reversed."
             }) }}


### PR DESCRIPTION
This change removes the prisoner name from the video link page title(s) but still includes in the header(s).

I have made this change to prevent the name bing included in any page analytics.
