### PR TITLE
BAVL-825 adding support for the capture of public and private notes for BVLS probation appointments. It is behind feature toggle.

### DIFF
--- a/integration_tests/e2e/appointments/createVideoLinkProbationMeeting.cy.ts
+++ b/integration_tests/e2e/appointments/createVideoLinkProbationMeeting.cy.ts
@@ -157,6 +157,8 @@ context('Create video link probation appointment', () => {
 
     // Extra information page
     const extraInformationPage = Page.verifyOnPage(ExtraInformationPage)
+    extraInformationPage.enterStaffNotes('some staff notes')
+    extraInformationPage.enterPrisonersNotes('some prisoners notes')
     extraInformationPage.continue()
 
     // Specific check answers page for video link probation bookings
@@ -169,6 +171,8 @@ context('Create video link probation appointment', () => {
     checkAnswersPage.assertStartDate(tomorrow)
     checkAnswersPage.assertStartTime(14, 0)
     checkAnswersPage.assertEndTime(15, 30)
+    checkAnswersPage.assertNotesForStaff('some staff notes')
+    checkAnswersPage.assertNotesForPrisoners('some prisoners notes')
     checkAnswersPage.createAppointment()
 
     // Confirmation page

--- a/integration_tests/pages/appointments/create-and-edit/video-link-booking/videoLinkProbationCheckAnswersPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/video-link-booking/videoLinkProbationCheckAnswersPage.ts
@@ -38,4 +38,12 @@ export default class VideoLinkProbationCheckAnswersPage extends Page {
     this.assertScheduleDetail('End time', `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`)
 
   createAppointment = () => cy.get('button').contains('Confirm').click()
+
+  assertExtraInformationDetail = (header: string, value: string) =>
+    this.assertSummaryListValue('extra-information', header, value)
+
+  assertNotesForStaff = (staffNotes: string) => this.assertExtraInformationDetail('Notes for prison staff', staffNotes)
+
+  assertNotesForPrisoners = (prisonersNotes: string) =>
+    this.assertExtraInformationDetail('Notes for prisoner', prisonersNotes)
 }

--- a/server/routes/appointments/video-link-booking/court/handlers/extraInformation.ts
+++ b/server/routes/appointments/video-link-booking/court/handlers/extraInformation.ts
@@ -1,23 +1,26 @@
 import { Request, Response } from 'express'
 import { Expose } from 'class-transformer'
-import { IsOptional, MaxLength } from 'class-validator'
+import { IsOptional, MaxLength, ValidateIf } from 'class-validator'
 import CourtBookingService from '../../../../../services/courtBookingService'
 import config from '../../../../../config'
 
 export class ExtraInformation {
   @Expose()
+  @ValidateIf(o => o.extraInformation && !config.bvlsMasterPublicPrivateNotesEnabled)
   @IsOptional()
-  @MaxLength(3600, { message: 'You must enter extra information which has no more than 3600 characters' })
+  @MaxLength(3600, { message: 'You must enter extra information which has no more than $constraint1 characters' })
   extraInformation: string
 
   @Expose()
+  @ValidateIf(o => o.notesForStaff && config.bvlsMasterPublicPrivateNotesEnabled)
   @IsOptional()
-  @MaxLength(400, { message: 'You must enter notes for staff which has no more than 400 characters' })
+  @MaxLength(400, { message: 'You must enter notes for staff which has no more than $constraint1 characters' })
   notesForStaff: string
 
   @Expose()
+  @ValidateIf(o => o.notesForPrisoners && config.bvlsMasterPublicPrivateNotesEnabled)
   @IsOptional()
-  @MaxLength(400, { message: 'You must enter notes for prisoner which has no more than 400 characters' })
+  @MaxLength(400, { message: 'You must enter notes for prisoner which has no more than $constraint1 characters' })
   notesForPrisoners: string
 }
 

--- a/server/routes/appointments/video-link-booking/probation/handlers/extraInformation.test.ts
+++ b/server/routes/appointments/video-link-booking/probation/handlers/extraInformation.test.ts
@@ -1,6 +1,11 @@
 import { Request, Response } from 'express'
-import ExtraInformationRoutes from './extraInformation'
+import { validate } from 'class-validator'
+import { plainToInstance } from 'class-transformer'
+import ExtraInformationRoutes, { ExtraInformation } from './extraInformation'
 import ProbationBookingService from '../../../../../services/probationBookingService'
+import config from '../../../../../config'
+import { associateErrorsWithProperty } from '../../../../../utils/utils'
+import { BookAProbationMeetingJourney } from '../journey'
 
 jest.mock('../../../../../services/probationBookingService')
 
@@ -36,7 +41,142 @@ describe('ExtraInformationRoutes', () => {
     })
   })
 
+  describe('ExtraInformation', () => {
+    it('it should validate extra information when master notes toggle is off', async () => {
+      config.bvlsMasterPublicPrivateNotesEnabled = false
+
+      const extraInformation = plainToInstance(ExtraInformation, {
+        extraInformation: 'x'.repeat(3601),
+      })
+
+      const errors = await validate(extraInformation).then(errs => errs.flatMap(associateErrorsWithProperty))
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          {
+            error: 'You must enter extra information which has no more than 3600 characters',
+            property: 'extraInformation',
+          },
+        ]),
+      )
+    })
+
+    it('it should not validate extra information when master notes toggle is off', async () => {
+      config.bvlsMasterPublicPrivateNotesEnabled = true
+
+      const extraInformation = plainToInstance(ExtraInformation, {
+        extraInformation: 'x'.repeat(3601),
+      })
+
+      const errors = await validate(extraInformation).then(errs => errs.flatMap(associateErrorsWithProperty))
+      expect(errors).toHaveLength(0)
+    })
+
+    it('it should validate staff notes when master notes toggle is on', async () => {
+      config.bvlsMasterPublicPrivateNotesEnabled = true
+
+      const extraInformation = plainToInstance(ExtraInformation, {
+        notesForStaff: 'x'.repeat(401),
+      })
+
+      const errors = await validate(extraInformation).then(errs => errs.flatMap(associateErrorsWithProperty))
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          {
+            error: 'You must enter notes for staff which has no more than 400 characters',
+            property: 'notesForStaff',
+          },
+        ]),
+      )
+    })
+
+    it('it should not validate staff notes when master notes toggle is off', async () => {
+      config.bvlsMasterPublicPrivateNotesEnabled = false
+
+      const extraInformation = plainToInstance(ExtraInformation, {
+        notesForStaff: 'x'.repeat(401),
+      })
+
+      const errors = await validate(extraInformation).then(errs => errs.flatMap(associateErrorsWithProperty))
+      expect(errors).toHaveLength(0)
+    })
+
+    it('it should validate prisoners notes when master notes toggle is on', async () => {
+      config.bvlsMasterPublicPrivateNotesEnabled = true
+
+      const extraInformation = plainToInstance(ExtraInformation, {
+        notesForPrisoners: 'x'.repeat(401),
+      })
+
+      const errors = await validate(extraInformation).then(errs => errs.flatMap(associateErrorsWithProperty))
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          {
+            error: 'You must enter notes for prisoner which has no more than 400 characters',
+            property: 'notesForPrisoners',
+          },
+        ]),
+      )
+    })
+
+    it('it should not validate prisoners notes when master notes toggle is off', async () => {
+      config.bvlsMasterPublicPrivateNotesEnabled = false
+
+      const extraInformation = plainToInstance(ExtraInformation, {
+        notesForPrisoners: 'x'.repeat(401),
+      })
+
+      const errors = await validate(extraInformation).then(errs => errs.flatMap(associateErrorsWithProperty))
+      expect(errors).toHaveLength(0)
+    })
+  })
+
   describe('POST', () => {
+    it('redirects with success message when mode is amend and master notes toggle is on', async () => {
+      config.bvlsMasterPublicPrivateNotesEnabled = true
+
+      req.body.notesForStaff = 'Notes for staff'
+      req.body.notesForPrisoners = 'Notes for prisoners'
+      req.params.mode = 'amend'
+      req.session.bookAProbationMeetingJourney.bookingId = 1
+
+      await extraInformationRoutes.POST(req as Request, res as Response)
+
+      expect(probationBookingService.amendVideoLinkBooking).toHaveBeenCalledWith(
+        {
+          bookingId: 1,
+          notesForPrisoners: 'Notes for prisoners',
+          notesForStaff: 'Notes for staff',
+        } as BookAProbationMeetingJourney,
+        res.locals.user,
+      )
+      expect(res.redirectWithSuccess).toHaveBeenCalledWith(
+        '/appointments/video-link-booking/probation/1',
+        "You've changed the extra information for this probation meeting",
+      )
+    })
+
+    it('redirects with success message when mode is amend and master notes toggle is off', async () => {
+      config.bvlsMasterPublicPrivateNotesEnabled = false
+
+      req.body.extraInformation = 'some extra information'
+      req.params.mode = 'amend'
+      req.session.bookAProbationMeetingJourney.bookingId = 2
+
+      await extraInformationRoutes.POST(req as Request, res as Response)
+
+      expect(probationBookingService.amendVideoLinkBooking).toHaveBeenCalledWith(
+        {
+          bookingId: 2,
+          comments: 'some extra information',
+        } as BookAProbationMeetingJourney,
+        res.locals.user,
+      )
+      expect(res.redirectWithSuccess).toHaveBeenCalledWith(
+        '/appointments/video-link-booking/probation/2',
+        "You've changed the extra information for this probation meeting",
+      )
+    })
+
     it('redirects with success message when mode is amend', async () => {
       req.body.comments = 'Some comments'
       req.params.mode = 'amend'
@@ -55,7 +195,6 @@ describe('ExtraInformationRoutes', () => {
     })
 
     it('redirects to check-answers when mode is create', async () => {
-      req.body.comments = 'Some comments'
       req.params.mode = 'create'
 
       await extraInformationRoutes.POST(req as Request, res as Response)

--- a/server/routes/appointments/video-link-booking/probation/handlers/extraInformation.ts
+++ b/server/routes/appointments/video-link-booking/probation/handlers/extraInformation.ts
@@ -1,13 +1,27 @@
 import { Request, Response } from 'express'
 import { Expose } from 'class-transformer'
-import { IsOptional, MaxLength } from 'class-validator'
+import { IsOptional, MaxLength, ValidateIf } from 'class-validator'
 import ProbationBookingService from '../../../../../services/probationBookingService'
+import config from '../../../../../config'
 
 export class ExtraInformation {
   @Expose()
+  @ValidateIf(o => o.extraInformation && !config.bvlsMasterPublicPrivateNotesEnabled)
   @IsOptional()
-  @MaxLength(3600, { message: 'You must enter extra information which has no more than 3600 characters' })
+  @MaxLength(3600, { message: 'You must enter extra information which has no more than $constraint1 characters' })
   extraInformation: string
+
+  @Expose()
+  @ValidateIf(o => o.notesForStaff && config.bvlsMasterPublicPrivateNotesEnabled)
+  @IsOptional()
+  @MaxLength(400, { message: 'You must enter notes for staff which has no more than $constraint1 characters' })
+  notesForStaff: string
+
+  @Expose()
+  @ValidateIf(o => o.notesForPrisoners && config.bvlsMasterPublicPrivateNotesEnabled)
+  @IsOptional()
+  @MaxLength(400, { message: 'You must enter notes for prisoner which has no more than $constraint1 characters' })
+  notesForPrisoners: string
 }
 
 export default class ExtraInformationRoutes {
@@ -18,13 +32,24 @@ export default class ExtraInformationRoutes {
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
-    const { extraInformation } = req.body
     const { mode } = req.params
     const { user } = res.locals
 
-    req.session.bookAProbationMeetingJourney = {
-      ...req.session.bookAProbationMeetingJourney,
-      comments: extraInformation,
+    if (config.bvlsMasterPublicPrivateNotesEnabled) {
+      const { notesForStaff, notesForPrisoners } = req.body
+
+      req.session.bookAProbationMeetingJourney = {
+        ...req.session.bookAProbationMeetingJourney,
+        notesForStaff,
+        notesForPrisoners,
+      }
+    } else {
+      const { extraInformation } = req.body
+
+      req.session.bookAProbationMeetingJourney = {
+        ...req.session.bookAProbationMeetingJourney,
+        comments: extraInformation,
+      }
     }
 
     if (mode === 'amend') {

--- a/server/routes/appointments/video-link-booking/probation/journey.ts
+++ b/server/routes/appointments/video-link-booking/probation/journey.ts
@@ -20,4 +20,6 @@ export type BookAProbationMeetingJourney = {
   endTime?: string
   locationCode?: string
   comments?: string
+  notesForStaff?: string
+  notesForPrisoners?: string
 }

--- a/server/routes/appointments/video-link-booking/probation/middleware/initialiseJourney.ts
+++ b/server/routes/appointments/video-link-booking/probation/middleware/initialiseJourney.ts
@@ -81,6 +81,8 @@ export default ({
       endTime: parseTimeToISOString(mainAppointment.endTime),
       locationCode: mainAppointment.prisonLocKey,
       comments: booking.comments,
+      notesForStaff: booking.notesForStaff,
+      notesForPrisoners: booking.notesForPrisoners,
     }
 
     return next()

--- a/server/services/probationBookingService.test.ts
+++ b/server/services/probationBookingService.test.ts
@@ -24,6 +24,8 @@ describe('Probation booking service', () => {
     probationTeamCode: 'BLACKPP',
     meetingTypeCode: 'PSR',
     comments: 'comments',
+    notesForStaff: 'notes for staff',
+    notesForPrisoners: 'notes for prisoners',
   } as BookAProbationMeetingJourney
 
   beforeEach(() => {
@@ -59,6 +61,8 @@ describe('Probation booking service', () => {
         probationTeamCode: 'BLACKPP',
         probationMeetingType: 'PSR',
         comments: 'comments',
+        notesForStaff: 'notes for staff',
+        notesForPrisoners: 'notes for prisoners',
       }
 
       const result = await probationBookingService.createVideoLinkBooking(journey, user)
@@ -92,6 +96,8 @@ describe('Probation booking service', () => {
         probationTeamCode: 'BLACKPP',
         probationMeetingType: 'PSR',
         comments: 'comments',
+        notesForStaff: 'notes for staff',
+        notesForPrisoners: 'notes for prisoners',
       }
 
       const result = await probationBookingService.amendVideoLinkBooking({ ...journey, bookingId: 1 }, user)

--- a/server/services/probationBookingService.ts
+++ b/server/services/probationBookingService.ts
@@ -43,6 +43,8 @@ export default class ProbationBookingService {
           }
         : undefined,
       comments: journey.comments,
+      notesForStaff: journey.notesForStaff,
+      notesForPrisoners: journey.notesForPrisoners,
     } as T
   }
 

--- a/server/views/pages/appointments/video-link-booking/court/extra-information.njk
+++ b/server/views/pages/appointments/video-link-booking/court/extra-information.njk
@@ -16,14 +16,10 @@
 
       {% if bvlsMasterPublicPrivateNotesEnabled %}
       <h1 class="govuk-heading-l">
-         <label class="govuk-label govuk-label--l">Add extra information</label>
+         <label class="govuk-label govuk-label--l">{{ pageHeading }}</label>
       </h1>
       <form method="POST" {% if session.req.params.mode == 'amend' %} data-module="form-spinner" data-loading-text="Changing extra information" {% endif %}>
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-        <span class="govuk-heading-m" for="notesForStaff">Notes for prison staff (optional)</span>
-        <p class="govuk-body" data-qa="first-paragraph">
-          This can include case number, co-defendant details if this is a multi-handler case, interpreter, or solicitor's details.
-        </p>
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
           <div class="govuk-form-group">
             {{ govukCharacterCount({
@@ -31,17 +27,15 @@
                 name: "notesForStaff",
                 errorMessage: validationErrors | findError("notesForStaff"),
                 value: formResponses.notesForStaff or session.bookACourtHearingJourney.notesForStaff,
+                label: {
+                  text: "Notes for prison staff (optional)",
+                  classes: 'govuk-fieldset__legend--s'
+                },
+                hint: { text: "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details." },
                 maxlength: "400"
             }) }}
           </div>
         </div>
-        <span class="govuk-heading-m" for="notesForPrisoner">Notes for prisoner (optional)</span>
-        <p class="govuk-body" data-qa="first-paragraph">
-          Add information the prisoner needs to know about their video link booking. This will appear on movement slips and will be seen by the prisoner.
-        </p>
-        <p class="govuk-body">
-         Do not add anything that should not be seen by or shared with a prisoner.
-        </p>
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
           <div class="govuk-form-group">
             {{ govukCharacterCount({
@@ -49,6 +43,11 @@
                 name: "notesForPrisoners",
                 errorMessage: validationErrors | findError("notesForPrisoner"),
                 value: formResponses.notesForPrisoners or session.bookACourtHearingJourney.notesForPrisoners,
+                label: {
+                  text: "Notes for prisoner (optional)",
+                  classes: 'govuk-fieldset__legend--s'
+                },
+                hint: { html: "<p class='govuk-hint'>Add information the prisoner needs to know about their video link booking. This will appear on movement slips and will be seen by the prisoner.</p><p class='govuk-hint'>Do not add anything that should not be seen by or shared with a prisoner.</p>" },
                 maxlength: "400"
             }) }}
           </div>

--- a/server/views/pages/appointments/video-link-booking/probation/check-booking.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/check-booking.njk
@@ -246,8 +246,47 @@
                                     }
                                 ]
                             }
-                        }
-                    ]
+                        } if not bvlsMasterPublicPrivateNotesEnabled,
+                        {
+                            key: {
+                                text: 'Notes for prison staff'
+                            },
+                            value: {
+                                html: '<span class="preserve-line-breaks">' + (session.bookAProbationMeetingJourney.notesForStaff | escape) + '</span>'
+                            },
+                            actions: {
+                                items: [
+                                    {
+                                        href: "extra-information?preserveHistory=true",
+                                        text: "Change",
+                                        visuallyHiddenText: "extra information",
+                                        classes: "govuk-link--no-visited-state",
+                                        attributes: { 'data-qa': 'change-extra-information' }
+                                    }
+                                ]
+                            }
+                        } if bvlsMasterPublicPrivateNotesEnabled,
+                        {
+                            key: {
+                                text: "Notes for prisoner"
+                            },
+                            value: {
+                                html: '<span class="preserve-line-breaks">' + (session.bookAProbationMeetingJourney.notesForPrisoners | escape) + '</span>'
+                            },
+                            actions: {
+                                items: [
+                                    {
+                                        href: "extra-information?preserveHistory=true",
+                                        text: "Change",
+                                        visuallyHiddenText: "extra information",
+                                        classes: "govuk-link--no-visited-state",
+                                        attributes: { 'data-qa': 'change-extra-information' }
+                                    }
+                                ]
+                            }
+                        } if bvlsMasterPublicPrivateNotesEnabled
+                    ],
+                    attributes: { 'data-qa': 'extra-information' }
                 }) }}
 
                 <div class="govuk-button-group">

--- a/server/views/pages/appointments/video-link-booking/probation/details.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/details.njk
@@ -245,11 +245,53 @@
                                 }
                             ]
                         } if isAmendable
+                    } if not bvlsMasterPublicPrivateNotesEnabled
+                ]
+            }) }}
+        </div>
+    </div>
+
+    {% if bvlsMasterPublicPrivateNotesEnabled %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            {{ govukSummaryList({
+                card: {
+                    title: {
+                        text: "Extra information"
+                    },
+                    actions: {
+                        items: [
+                            {
+                                href: 'amend/' + videoBooking.videoLinkBookingId + '/extra-information',
+                                text: "Change",
+                                classes: "govuk-link--no-visited-state"
+                            }
+                        ]
+                    } if isAmendable
+                },
+                rows: [
+                    {
+                        key: {
+                            text: 'Notes for prison staff'
+                        },
+                        value: {
+                            text: videoBooking.notesForStaff or "None provided"
+                        }
+                    },
+                    {
+                        key: {
+                            text: "Notes for prisoner"
+                        },
+                        value: {
+                            text: videoBooking.notesForPrisoners or "None provided"
+                        }
                     }
                 ]
             }) }}
         </div>
     </div>
+    {% endif %}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/server/views/pages/appointments/video-link-booking/probation/extra-information.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/extra-information.njk
@@ -13,6 +13,49 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ appointmentTypeCaption(session) }}
+      {% if bvlsMasterPublicPrivateNotesEnabled %}
+      <h1 class="govuk-heading-l">
+         <label class="govuk-label govuk-label--l">{{ pageHeading }}</label>
+      </h1>
+      <form method="POST" {% if session.req.params.mode == 'amend' %} data-module="form-spinner" data-loading-text="Changing extra information" {% endif %}>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
+          <div class="govuk-form-group">
+            {{ govukCharacterCount({
+                id: "notesForStaff",
+                name: "notesForStaff",
+                errorMessage: validationErrors | findError("notesForStaff"),
+                value: formResponses.notesForStaff or session.bookAProbationMeetingJourney.notesForStaff,
+                label: {
+                  text: "Notes for prison staff (optional)",
+                  classes: 'govuk-fieldset__legend--s'
+                },
+                hint: { text: "This can include case number, co-defendant details if this is a multi-hander case, interpreter, or solicitor's details." },
+                maxlength: "400"
+            }) }}
+          </div>
+        </div>
+        <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
+          <div class="govuk-form-group">
+            {{ govukCharacterCount({
+                id: "notesForPrisoners",
+                name: "notesForPrisoners",
+                errorMessage: validationErrors | findError("notesForPrisoner"),
+                value: formResponses.notesForPrisoners or session.bookAProbationMeetingJourney.notesForPrisoners,
+                label: {
+                  text: "Notes for prisoner (optional)",
+                  classes: 'govuk-fieldset__legend--s'
+                },
+                hint: { html: "<p class='govuk-hint'>Add information the prisoner needs to know about their video link booking. This will appear on movement slips and will be seen by the prisoner.</p><p class='govuk-hint'>Do not add anything that should not be seen by or shared with a prisoner.</p>" },
+                maxlength: "400"
+            }) }}
+          </div>
+        </div>
+        {{ govukButton({
+          text: "Continue"
+        }) }}
+      </form>
+      {% else %}
       <h1 class="govuk-heading-l">
          <label class="govuk-label govuk-label--l" for="extraInformation">Add extra information (optional)</label>
       </h1>
@@ -39,6 +82,7 @@
           text: "Continue"
         }) }}
       </form>
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Changes to the BVLS probation create/amend journey to capture notes for staff and prisoners (replacing extra info/comments). This changes sits behind a feature toggle.

![Screenshot 2025-05-27 at 10-59-30 Activities and Appointments](https://github.com/user-attachments/assets/419b0831-467a-4685-95e8-1be03fb261b1)

![Screenshot 2025-05-27 at 10-59-46 Check and confirm appointment details](https://github.com/user-attachments/assets/929b8f5b-4df2-4c69-83e7-fdbef2ec9b76)

![Screenshot 2025-05-27 at 11-00-10 Activities and Appointments](https://github.com/user-attachments/assets/04df7c9d-f3a0-4137-acbc-ecb0c6844a9c)

