### PR TITLE
BAVL-899 content sweep changes for the BVLS court and probation appointment journeys.

### DIFF
--- a/integration_tests/e2e/activities/suspensions.cy.ts
+++ b/integration_tests/e2e/activities/suspensions.cy.ts
@@ -595,8 +595,8 @@ context('Suspensions', () => {
     confirmationPage.title().should('contain.text', 'Suspension ended')
   })
   it('should unsuspend a prisoner from an activity - end of today', () => {
-    const today = format(startOfToday(), 'dd MMMM yyyy')
-    const tomorrow = format(addDays(startOfToday(), 1), 'dd MMMM yyyy')
+    const today = format(startOfToday(), 'd MMMM yyyy')
+    const tomorrow = format(addDays(startOfToday(), 1), 'd MMMM yyyy')
     cy.visit('/activities/suspensions/prisoner/G0995GW')
     const page = Page.verifyOnPage(ViewAllocationsPage)
     page.caption().should('contain.text', 'Manage suspensions')

--- a/server/views/pages/appointments/video-link-booking/court/check-booking.njk
+++ b/server/views/pages/appointments/video-link-booking/court/check-booking.njk
@@ -280,45 +280,30 @@
                     attributes: { 'data-qa': 'post-scheduling-information' }
                 }) }}
 
-                <h2 class="govuk-heading-m">Extra information</h2>
                 {{ govukSummaryList({
+                    card: {
+                        title: {
+                            text: "Extra information"
+                        },
+                        actions: {
+                            items: [
+                                {
+                                    href: "extra-information?preserveHistory=true",
+                                    text: "Change",
+                                    visuallyHiddenText: "extra information",
+                                    classes: "govuk-link--no-visited-state",
+                                    attributes: { 'data-qa': 'change-extra-information' }
+                                }
+                            ]
+                        }
+                    },
                     rows: [
-                        {
-                            key: {
-                                text: "Extra information"
-                            },
-                            value: {
-                                html: '<span class="preserve-line-breaks">' + (session.bookACourtHearingJourney.comments | escape) + '</span>'
-                            },
-                            actions: {
-                                items: [
-                                    {
-                                        href: "extra-information?preserveHistory=true",
-                                        text: "Change",
-                                        visuallyHiddenText: "extra information",
-                                        classes: "govuk-link--no-visited-state",
-                                        attributes: { 'data-qa': 'change-extra-information' }
-                                    }
-                                ]
-                            }
-                        } if not bvlsMasterPublicPrivateNotesEnabled,
                         {
                             key: {
                                 text: 'Notes for prison staff'
                             },
                             value: {
-                                html: '<span class="preserve-line-breaks">' + (session.bookACourtHearingJourney.notesForStaff | escape) + '</span>'
-                            },
-                            actions: {
-                                items: [
-                                    {
-                                        href: "extra-information?preserveHistory=true",
-                                        text: "Change",
-                                        visuallyHiddenText: "extra information",
-                                        classes: "govuk-link--no-visited-state",
-                                        attributes: { 'data-qa': 'change-extra-information' }
-                                    }
-                                ]
+                                html: '<span class="preserve-line-breaks">' + (session.bookACourtHearingJourney.notesForStaff or 'None entered' | escape) + '</span>'
                             }
                         } if bvlsMasterPublicPrivateNotesEnabled,
                         {
@@ -326,18 +311,7 @@
                                 text: "Notes for prisoner"
                             },
                             value: {
-                                html: '<span class="preserve-line-breaks">' + (session.bookACourtHearingJourney.notesForPrisoners | escape) + '</span>'
-                            },
-                            actions: {
-                                items: [
-                                    {
-                                        href: "extra-information?preserveHistory=true",
-                                        text: "Change",
-                                        visuallyHiddenText: "extra information",
-                                        classes: "govuk-link--no-visited-state",
-                                        attributes: { 'data-qa': 'change-extra-information' }
-                                    }
-                                ]
+                                html: '<span class="preserve-line-breaks">' + (session.bookACourtHearingJourney.notesForPrisoners or 'None entered' | escape) + '</span>'
                             }
                         } if bvlsMasterPublicPrivateNotesEnabled
                     ],

--- a/server/views/pages/appointments/video-link-booking/court/details.njk
+++ b/server/views/pages/appointments/video-link-booking/court/details.njk
@@ -209,48 +209,6 @@
         </div>
     </div>
 
-    {% if bvlsMasterPublicPrivateNotesEnabled %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-
-            {{ govukSummaryList({
-                card: {
-                    title: {
-                        text: "Extra information"
-                    },
-                    actions: {
-                        items: [
-                            {
-                                href: 'amend/' + videoBooking.videoLinkBookingId + '/extra-information',
-                                text: "Change",
-                                classes: "govuk-link--no-visited-state"
-                            }
-                        ]
-                    } if isAmendable
-                },
-                rows: [
-                    {
-                        key: {
-                            text: 'Notes for prison staff'
-                        },
-                        value: {
-                            text: videoBooking.notesForStaff or "None provided"
-                        }
-                    },
-                    {
-                        key: {
-                            text: "Notes for prisoner"
-                        },
-                        value: {
-                            text: videoBooking.notesForPrisoners or "None provided"
-                        }
-                    }
-                ]
-            }) }}
-        </div>
-    </div>
-    {% endif %}
-
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
@@ -343,6 +301,48 @@
             }) }}
         </div>
     </div>
+
+    {% if bvlsMasterPublicPrivateNotesEnabled %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+            {{ govukSummaryList({
+                card: {
+                    title: {
+                        text: "Extra information"
+                    },
+                    actions: {
+                        items: [
+                            {
+                                href: 'amend/' + videoBooking.videoLinkBookingId + '/extra-information',
+                                text: "Change",
+                                classes: "govuk-link--no-visited-state"
+                            }
+                        ]
+                    } if isAmendable
+                },
+                rows: [
+                    {
+                        key: {
+                            text: 'Notes for prison staff'
+                        },
+                        value: {
+                            text: videoBooking.notesForStaff or "None entered"
+                        }
+                    },
+                    {
+                        key: {
+                            text: "Notes for prisoner"
+                        },
+                        value: {
+                            text: videoBooking.notesForPrisoners or "None entered"
+                        }
+                    }
+                ]
+            }) }}
+        </div>
+    </div>
+    {% endif %}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/server/views/pages/appointments/video-link-booking/probation/check-booking.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/check-booking.njk
@@ -226,44 +226,30 @@
                     attributes: { 'data-qa': 'scheduling-information' }
                 }) }}
 
-                <h2 class="govuk-heading-m">Extra information</h2>
                 {{ govukSummaryList({
+                    card: {
+                        title: {
+                            text: "Extra information"
+                        },
+                        actions: {
+                            items: [
+                                {
+                                    href: "extra-information?preserveHistory=true",
+                                    text: "Change",
+                                    visuallyHiddenText: "extra information",
+                                    classes: "govuk-link--no-visited-state",
+                                    attributes: { 'data-qa': 'change-extra-information' }
+                                }
+                            ]
+                        }
+                    },
                     rows: [
-                        {
-                            key: {
-                                text: "Extra information"
-                            },
-                            value: {
-                                html: '<span class="preserve-line-breaks">' + (session.bookAProbationMeetingJourney.comments | escape) + '</span>'
-                            },
-                            actions: {
-                                items: [
-                                    {
-                                        href: "extra-information?preserveHistory=true",
-                                        text: "Change",
-                                        visuallyHiddenText: "extra information",
-                                        classes: "govuk-link--no-visited-state"
-                                    }
-                                ]
-                            }
-                        } if not bvlsMasterPublicPrivateNotesEnabled,
                         {
                             key: {
                                 text: 'Notes for prison staff'
                             },
                             value: {
-                                html: '<span class="preserve-line-breaks">' + (session.bookAProbationMeetingJourney.notesForStaff | escape) + '</span>'
-                            },
-                            actions: {
-                                items: [
-                                    {
-                                        href: "extra-information?preserveHistory=true",
-                                        text: "Change",
-                                        visuallyHiddenText: "extra information",
-                                        classes: "govuk-link--no-visited-state",
-                                        attributes: { 'data-qa': 'change-extra-information' }
-                                    }
-                                ]
+                                html: '<span class="preserve-line-breaks">' + (session.bookAProbationMeetingJourney.notesForStaff or 'None entered' | escape) + '</span>'
                             }
                         } if bvlsMasterPublicPrivateNotesEnabled,
                         {
@@ -271,18 +257,7 @@
                                 text: "Notes for prisoner"
                             },
                             value: {
-                                html: '<span class="preserve-line-breaks">' + (session.bookAProbationMeetingJourney.notesForPrisoners | escape) + '</span>'
-                            },
-                            actions: {
-                                items: [
-                                    {
-                                        href: "extra-information?preserveHistory=true",
-                                        text: "Change",
-                                        visuallyHiddenText: "extra information",
-                                        classes: "govuk-link--no-visited-state",
-                                        attributes: { 'data-qa': 'change-extra-information' }
-                                    }
-                                ]
+                                html: '<span class="preserve-line-breaks">' + (session.bookAProbationMeetingJourney.notesForPrisoners or 'None entered' | escape) + '</span>'
                             }
                         } if bvlsMasterPublicPrivateNotesEnabled
                     ],

--- a/server/views/pages/appointments/video-link-booking/probation/details.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/details.njk
@@ -276,7 +276,7 @@
                             text: 'Notes for prison staff'
                         },
                         value: {
-                            text: videoBooking.notesForStaff or "None provided"
+                            text: videoBooking.notesForStaff or "None entered"
                         }
                     },
                     {
@@ -284,7 +284,7 @@
                             text: "Notes for prisoner"
                         },
                         value: {
-                            text: videoBooking.notesForPrisoners or "None provided"
+                            text: videoBooking.notesForPrisoners or "None entered"
                         }
                     }
                 ]


### PR DESCRIPTION
Content sweep for the BVLS court and probation appointment journeys to provide a consistent look for the staff and prisoner note.

![court-check-details](https://github.com/user-attachments/assets/416a93b9-3ec0-44e3-a202-099701b04aa1)

![court-details](https://github.com/user-attachments/assets/892ef52c-08c0-4f5d-a8a8-cb554a54dc53)

![probation-check-details](https://github.com/user-attachments/assets/eda4fff4-48ef-4439-ae76-f3fd28e0011c)

![probation-details](https://github.com/user-attachments/assets/0c484adc-618d-4aa6-a9fa-5873cb668a67)

