### PR TITLE
BAVL-919 small error message change to be consistent with BVLS and DPS services for notes.

### DIFF
--- a/server/routes/appointments/video-link-booking/court/handlers/extraInformation.test.ts
+++ b/server/routes/appointments/video-link-booking/court/handlers/extraInformation.test.ts
@@ -82,7 +82,7 @@ describe('ExtraInformationRoutes', () => {
       expect(errors).toEqual(
         expect.arrayContaining([
           {
-            error: 'You must enter notes for staff which has no more than 400 characters',
+            error: 'Notes for prison staff must be 400 characters or less',
             property: 'notesForStaff',
           },
         ]),
@@ -111,7 +111,7 @@ describe('ExtraInformationRoutes', () => {
       expect(errors).toEqual(
         expect.arrayContaining([
           {
-            error: 'You must enter notes for prisoner which has no more than 400 characters',
+            error: 'Notes for prisoner must be 400 characters or less',
             property: 'notesForPrisoners',
           },
         ]),

--- a/server/routes/appointments/video-link-booking/court/handlers/extraInformation.ts
+++ b/server/routes/appointments/video-link-booking/court/handlers/extraInformation.ts
@@ -14,13 +14,13 @@ export class ExtraInformation {
   @Expose()
   @ValidateIf(o => o.notesForStaff && config.bvlsMasterPublicPrivateNotesEnabled)
   @IsOptional()
-  @MaxLength(400, { message: 'You must enter notes for staff which has no more than $constraint1 characters' })
+  @MaxLength(400, { message: 'Notes for prison staff must be $constraint1 characters or less' })
   notesForStaff: string
 
   @Expose()
   @ValidateIf(o => o.notesForPrisoners && config.bvlsMasterPublicPrivateNotesEnabled)
   @IsOptional()
-  @MaxLength(400, { message: 'You must enter notes for prisoner which has no more than $constraint1 characters' })
+  @MaxLength(400, { message: 'Notes for prisoner must be $constraint1 characters or less' })
   notesForPrisoners: string
 }
 

--- a/server/routes/appointments/video-link-booking/probation/handlers/extraInformation.test.ts
+++ b/server/routes/appointments/video-link-booking/probation/handlers/extraInformation.test.ts
@@ -82,7 +82,7 @@ describe('ExtraInformationRoutes', () => {
       expect(errors).toEqual(
         expect.arrayContaining([
           {
-            error: 'You must enter notes for staff which has no more than 400 characters',
+            error: 'Notes for prison staff must be 400 characters or less',
             property: 'notesForStaff',
           },
         ]),
@@ -111,7 +111,7 @@ describe('ExtraInformationRoutes', () => {
       expect(errors).toEqual(
         expect.arrayContaining([
           {
-            error: 'You must enter notes for prisoner which has no more than 400 characters',
+            error: 'Notes for prisoner must be 400 characters or less',
             property: 'notesForPrisoners',
           },
         ]),

--- a/server/routes/appointments/video-link-booking/probation/handlers/extraInformation.ts
+++ b/server/routes/appointments/video-link-booking/probation/handlers/extraInformation.ts
@@ -14,13 +14,13 @@ export class ExtraInformation {
   @Expose()
   @ValidateIf(o => o.notesForStaff && config.bvlsMasterPublicPrivateNotesEnabled)
   @IsOptional()
-  @MaxLength(400, { message: 'You must enter notes for staff which has no more than $constraint1 characters' })
+  @MaxLength(400, { message: 'Notes for prison staff must be $constraint1 characters or less' })
   notesForStaff: string
 
   @Expose()
   @ValidateIf(o => o.notesForPrisoners && config.bvlsMasterPublicPrivateNotesEnabled)
   @IsOptional()
-  @MaxLength(400, { message: 'You must enter notes for prisoner which has no more than $constraint1 characters' })
+  @MaxLength(400, { message: 'Notes for prisoner must be $constraint1 characters or less' })
   notesForPrisoners: string
 }
 

--- a/server/views/pages/appointments/video-link-booking/court/extra-information.njk
+++ b/server/views/pages/appointments/video-link-booking/court/extra-information.njk
@@ -41,7 +41,7 @@
             {{ govukCharacterCount({
                 id: "notesForPrisoners",
                 name: "notesForPrisoners",
-                errorMessage: validationErrors | findError("notesForPrisoner"),
+                errorMessage: validationErrors | findError("notesForPrisoners"),
                 value: formResponses.notesForPrisoners or session.bookACourtHearingJourney.notesForPrisoners,
                 label: {
                   text: "Notes for prisoner (optional)",

--- a/server/views/pages/appointments/video-link-booking/probation/extra-information.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/extra-information.njk
@@ -40,7 +40,7 @@
             {{ govukCharacterCount({
                 id: "notesForPrisoners",
                 name: "notesForPrisoners",
-                errorMessage: validationErrors | findError("notesForPrisoner"),
+                errorMessage: validationErrors | findError("notesForPrisoners"),
                 value: formResponses.notesForPrisoners or session.bookAProbationMeetingJourney.notesForPrisoners,
                 label: {
                   text: "Notes for prisoner (optional)",


### PR DESCRIPTION
Small error message tidy up for consistency across services where BVLS bookings can be created.

**Court journey:**
![court](https://github.com/user-attachments/assets/7746916b-a49f-4a77-accd-7d59e22127ef)

**Probation journey:**
![probation](https://github.com/user-attachments/assets/bc0f294f-09b2-4faf-b4c3-c472606cc294)
