### PR TITLE
SAA-3472: Redirect user back to reason page if the data isn't present…

### DIFF
--- a/server/routes/activities/record-attendance/handlers/cancel-session/confirmation.test.ts
+++ b/server/routes/activities/record-attendance/handlers/cancel-session/confirmation.test.ts
@@ -86,6 +86,25 @@ describe('Route Handlers - Cancel Session Confirmation', () => {
       expect(activitiesService.cancelScheduledActivity).toHaveBeenCalledTimes(0)
       expect(res.redirect).toHaveBeenCalledWith('../../1/attendance-list')
     })
+
+    it("should redirect the user back if the reason isn't present on the session", async () => {
+      confirmRequest = {
+        ...req,
+        body: {
+          confirm: 'yes',
+        },
+        session: {
+          recordAttendanceJourney: {
+            sessionCancellation: {},
+          },
+        },
+      } as unknown as Request
+
+      await handler.POST(confirmRequest, res)
+
+      expect(activitiesService.cancelScheduledActivity).not.toHaveBeenCalledWith()
+      expect(res.redirect).toHaveBeenCalledWith('../../1/cancel')
+    })
   })
 
   describe('Validation', () => {

--- a/server/routes/activities/record-attendance/handlers/cancel-session/confirmation.ts
+++ b/server/routes/activities/record-attendance/handlers/cancel-session/confirmation.ts
@@ -21,9 +21,11 @@ export default class CancelSessionRoutes {
 
     if (confirm === 'yes') {
       const sessionCancellationRequest = req.session.recordAttendanceJourney.sessionCancellation
+      // if the reason isn't present on the request, send the user back to recollect the data
+      if (!sessionCancellationRequest?.reason) return res.redirect(`../../${instanceId}/cancel`)
       await this.activitiesService.cancelScheduledActivity(instanceId, sessionCancellationRequest, user)
     }
 
-    res.redirect(`../../${instanceId}/attendance-list`)
+    return res.redirect(`../../${instanceId}/attendance-list`)
   }
 }


### PR DESCRIPTION
… before endpoint call