### PR TITLE
SAA-3504: Unlock list activity cat filter change

### DIFF
--- a/integration_tests/pages/unlockAndMovements/unlock/plannedEventsPage.ts
+++ b/integration_tests/pages/unlockAndMovements/unlock/plannedEventsPage.ts
@@ -4,4 +4,10 @@ export default class PlannedEventsPage extends AbstractEventsPage {
   constructor() {
     super('planned-events-page')
   }
+
+  categoryCheckbox = (cat: string) => cy.get(`[name=activityCategoriesFilters][value="${cat}"]`)
+
+  selectAllCategories = () => cy.get('a[data-checkbox-name="activityCategoriesFilters"]')
+
+  table = (): Cypress.Chainable => cy.get('#unlock-list-table')
 }

--- a/server/routes/activities/unlock-list/handlers/plannedEvents.test.ts
+++ b/server/routes/activities/unlock-list/handlers/plannedEvents.test.ts
@@ -121,6 +121,7 @@ describe('Unlock list routes - planned events', () => {
         ['ALERT_HA'],
         '',
         YesNo.YES,
+        false,
         res.locals.user,
       )
 
@@ -206,6 +207,7 @@ describe('Unlock list routes - planned events', () => {
         ['CAT_A'],
         'search term',
         YesNo.YES,
+        false,
         res.locals.user,
       )
 
@@ -233,6 +235,61 @@ describe('Unlock list routes - planned events', () => {
         },
         alertOptions: alertFilterOptions,
       })
+    })
+    it('should pass true into function call if the user has selected/removed any activity category filters', async () => {
+      req = {
+        query: {
+          date: '2022-01-01',
+        },
+        session: {
+          unlockListJourney: {
+            locationKey: 'A',
+            timeSlot: 'AM',
+            stayingOrLeavingFilter: 'Leaving',
+            activityFilter: 'With',
+            subLocationFilters: ['A'],
+            searchTerm: 'search term',
+            alertFilters: ['CAT_A'],
+            cancelledEventsFilter: YesNo.YES,
+            activityCategoriesFilters: ['SAA_EDUCATION'],
+          },
+        },
+      } as unknown as Request
+
+      const unlockListItems = [
+        {
+          prisonerNumber: 'A1111AA',
+          isLeavingWing: true,
+        },
+        {
+          prisonerNumber: 'B2222BB',
+          isLeavingWing: true,
+        },
+      ] as UnlockListItem[]
+
+      when(activitiesService.getLocationGroups).mockResolvedValue(locationsAtPrison)
+      when(unlockListService.getFilteredUnlockList).mockResolvedValue(unlockListItems)
+      when(alertsFilterService.getAllAlertFilterOptions).mockReturnValue([
+        { key: 'CAT_A', description: 'CAT A', codes: ['A', 'E'] },
+      ])
+      when(activitiesService.getActivityCategories).mockResolvedValue(activityCategories as ActivityCategory[])
+
+      await handler.GET(req, res)
+
+      expect(unlockListService.getFilteredUnlockList).toHaveBeenCalledWith(
+        new Date('2022-01-01'),
+        'AM',
+        'A',
+        ['A'],
+        'With',
+        ['SAA_EDUCATION'],
+        'Leaving',
+        ['CAT_A'],
+        'search term',
+        YesNo.YES,
+        true,
+        res.locals.user,
+      )
     })
   })
 })

--- a/server/routes/activities/unlock-list/handlers/plannedEvents.ts
+++ b/server/routes/activities/unlock-list/handlers/plannedEvents.ts
@@ -41,7 +41,7 @@ export default class PlannedEventsRoutes {
 
     // we need to know if the user is filtering on activity category, if they are we will only return activities and ignore other event types
     const activityCategoryFilterBeingUsed =
-      req.session.unlockListJourney.activityCategoriesFilters.length !== activityCategories.map(c => c.code).length
+      req.session.unlockListJourney.activityCategoriesFilters.length !== activityCategories.length
 
     const {
       subLocationFilters,

--- a/server/routes/activities/unlock-list/handlers/plannedEvents.ts
+++ b/server/routes/activities/unlock-list/handlers/plannedEvents.ts
@@ -39,6 +39,10 @@ export default class PlannedEventsRoutes {
 
     const unlockDate = date ? toDate(asString(date)) : new Date()
 
+    // we need to know if the user is filtering on activity category, if they are we will only return activities and ignore other event types
+    const activityCategoryFilterBeingUsed =
+      req.session.unlockListJourney.activityCategoriesFilters.length !== activityCategories.map(c => c.code).length
+
     const {
       subLocationFilters,
       activityFilter,
@@ -60,6 +64,7 @@ export default class PlannedEventsRoutes {
       alertFilters,
       searchTerm,
       cancelledEventsFilter,
+      activityCategoryFilterBeingUsed,
       user,
     )
 

--- a/server/services/unlockListService.test.ts
+++ b/server/services/unlockListService.test.ts
@@ -237,6 +237,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -281,6 +282,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -314,6 +316,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -336,6 +339,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -359,6 +363,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -381,6 +386,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -403,6 +409,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -425,6 +432,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -453,6 +461,7 @@ describe('Unlock list service', () => {
         ['CAT_A'],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -478,11 +487,13 @@ describe('Unlock list service', () => {
         ['CAT_A'],
         null,
         YesNo.YES,
+        true,
         user,
       )
 
-      expect(unlockListItems).toHaveLength(3)
-      expect(unlockListItems.map(i => i.prisonerNumber)).toEqual(['A1111AA', 'A2222AA', 'A3333AA'])
+      expect(unlockListItems).toHaveLength(2)
+      expect(unlockListItems.map(i => i.prisonerNumber)).toEqual(['A2222AA', 'A3333AA'])
+      unlockListItems.forEach(prisoner => prisoner.events.forEach(event => expect(event.eventType).toBe('ACTIVITY')))
     })
 
     it('should filter activity category and include when event category not selected, but the prisoner has another event which is selected', async () => {
@@ -524,11 +535,12 @@ describe('Unlock list service', () => {
         ['CAT_A'],
         null,
         YesNo.YES,
+        true,
         user,
       )
 
-      expect(unlockListItems).toHaveLength(4)
-      expect(unlockListItems.map(i => i.prisonerNumber)).toEqual(['A1111AA', 'A2222AA', 'A3333AA', 'A4444AA'])
+      expect(unlockListItems).toHaveLength(3)
+      expect(unlockListItems.map(i => i.prisonerNumber)).toEqual(['A2222AA', 'A3333AA', 'A4444AA'])
       const multiplePrisonerEvents = unlockListItems.find(item => item.prisonerNumber === 'A4444AA').events
       expect(multiplePrisonerEvents).toEqual([
         {
@@ -613,11 +625,12 @@ describe('Unlock list service', () => {
         ['CAT_A'],
         null,
         YesNo.YES,
+        true,
         user,
       )
 
-      expect(unlockListItems).toHaveLength(3)
-      expect(unlockListItems.map(i => i.prisonerNumber)).toEqual(['A1111AA', 'A2222AA', 'A3333AA'])
+      expect(unlockListItems).toHaveLength(2)
+      expect(unlockListItems.map(i => i.prisonerNumber)).toEqual(['A2222AA', 'A3333AA'])
     })
 
     it('should filter alerts', async () => {
@@ -645,6 +658,7 @@ describe('Unlock list service', () => {
         alertFilters,
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -718,6 +732,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.YES,
+        false,
         user,
       )
 
@@ -862,6 +877,7 @@ describe('Unlock list service', () => {
         [],
         null,
         YesNo.NO,
+        false,
         user,
       )
       expect(unlockListItems).toEqual([


### PR DESCRIPTION
If the user uses the activity category filter, then **only** activities are shown on the page
If the user doesn't engage with the activity category filter, all event types are shown (filtered as before)