### PR TITLE
SAA-3622: Remove extraneous calls to setup journey data for remove allocation

### DIFF
--- a/server/routes/activities/manage-allocations/createRoutes.ts
+++ b/server/routes/activities/manage-allocations/createRoutes.ts
@@ -28,20 +28,18 @@ import CheckAndConfirmMultipleRoutes from './handlers/allocateMultiplePeople/che
 import PayBandMultipleRoutes, { PayBandMultipleForm } from './handlers/allocateMultiplePeople/payBandMultiple'
 import ConfirmMultipleAllocationsRoutes from './handlers/allocateMultiplePeople/confirmation'
 import FromActivityListRoutes from './handlers/allocateMultiplePeople/fromActivityList'
-import setUpJourneyData from '../../../middleware/setUpJourneyData'
 
 export default function Index({
   activitiesService,
   prisonService,
   metricsService,
   nonAssociationsService,
-  tokenStore,
 }: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string, handler: RequestHandler, stepRequiresSession = false) =>
-    router.get(path, setUpJourneyData(tokenStore), emptyJourneyHandler('allocateJourney', stepRequiresSession), handler)
+    router.get(path, emptyJourneyHandler('allocateJourney', stepRequiresSession), handler)
   const post = (path: string, handler: RequestHandler, type?: new () => object) =>
-    router.post(path, setUpJourneyData(tokenStore), validationMiddleware(type), handler)
+    router.post(path, validationMiddleware(type), handler)
 
   const startJourneyHandler = new StartJourneyRoutes(prisonService, activitiesService, metricsService)
   const beforeYouAllocateHandler = new BeforeYouAllocateRoutes(activitiesService)

--- a/server/routes/activities/manage-allocations/editRoutes.ts
+++ b/server/routes/activities/manage-allocations/editRoutes.ts
@@ -7,14 +7,13 @@ import StartDateRoutes, { StartDate } from './handlers/startDate'
 import RemoveDateOptionRoutes, { RemoveDateOption } from './handlers/removeDateOption'
 import ExclusionRoutes, { Schedule } from './handlers/exclusions'
 import ConfirmExclusionsRoutes from './handlers/confirmExclusions'
-import setUpJourneyData from '../../../middleware/setUpJourneyData'
 
-export default function Index({ activitiesService, tokenStore }: Services): Router {
+export default function Index({ activitiesService }: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string, handler: RequestHandler, stepRequiresSession = false) =>
-    router.get(path, setUpJourneyData(tokenStore), emptyJourneyHandler('allocateJourney', stepRequiresSession), handler)
+    router.get(path, emptyJourneyHandler('allocateJourney', stepRequiresSession), handler)
   const post = (path: string, handler: RequestHandler, type?: new () => object) =>
-    router.post(path, setUpJourneyData(tokenStore), validationMiddleware(type), handler)
+    router.post(path, validationMiddleware(type), handler)
 
   const startDateHandler = new StartDateRoutes(activitiesService)
   const removeDateOptionHandler = new RemoveDateOptionRoutes(activitiesService)

--- a/server/routes/activities/manage-allocations/excludeRoutes.ts
+++ b/server/routes/activities/manage-allocations/excludeRoutes.ts
@@ -4,14 +4,13 @@ import validationMiddleware from '../../../middleware/validationMiddleware'
 import emptyJourneyHandler from '../../../middleware/emptyJourneyHandler'
 import ExclusionRoutes, { Schedule } from './handlers/exclusions'
 import ConfirmExclusionsRoutes from './handlers/confirmExclusions'
-import setUpJourneyData from '../../../middleware/setUpJourneyData'
 
-export default function Index({ activitiesService, tokenStore }: Services): Router {
+export default function Index({ activitiesService }: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string, handler: RequestHandler, stepRequiresSession = false) =>
-    router.get(path, setUpJourneyData(tokenStore), emptyJourneyHandler('allocateJourney', stepRequiresSession), handler)
+    router.get(path, emptyJourneyHandler('allocateJourney', stepRequiresSession), handler)
   const post = (path: string, handler: RequestHandler, type?: new () => object) =>
-    router.post(path, setUpJourneyData(tokenStore), validationMiddleware(type), handler)
+    router.post(path, validationMiddleware(type), handler)
 
   const exclusionsHandler = new ExclusionRoutes(activitiesService)
   const confirmExclusionsHandler = new ConfirmExclusionsRoutes(activitiesService)

--- a/server/routes/activities/manage-allocations/removeRoutes.ts
+++ b/server/routes/activities/manage-allocations/removeRoutes.ts
@@ -19,14 +19,13 @@ import DeallocationSelectActivities, {
   DeallocationSelect,
 } from './handlers/deallocationAfterAllocation/deallocationSelectActivities'
 import ConfirmDeallocationIfExistingRoutes, { ConfirmDeallocateOptions } from './handlers/confirmDeallocationIfExisting'
-import setUpJourneyData from '../../../middleware/setUpJourneyData'
 
-export default function Index({ activitiesService, metricsService, tokenStore }: Services): Router {
+export default function Index({ activitiesService, metricsService }: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string, handler: RequestHandler, stepRequiresSession = false) =>
-    router.get(path, setUpJourneyData(tokenStore), emptyJourneyHandler('allocateJourney', stepRequiresSession), handler)
+    router.get(path, emptyJourneyHandler('allocateJourney', stepRequiresSession), handler)
   const post = (path: string, handler: RequestHandler, type?: new () => object) =>
-    router.post(path, setUpJourneyData(tokenStore), validationMiddleware(type), handler)
+    router.post(path, validationMiddleware(type), handler)
 
   const cancelHandler = new CancelRoutes()
   const deallocationEndDecisionHandler = new EndDecisionRoutes()


### PR DESCRIPTION
Remove calls to [setUpJourneyData](https://github.com/ministryofjustice/hmpps-activities-management/blob/1514471978cb0e2f09c42b4868fcfbca9820b2b7/server/middleware/setUpJourneyData.ts) in routes as they are called in [index.ts](https://github.com/ministryofjustice/hmpps-activities-management/blob/3d4e9e2b486822969eddb10ab4d55c7636a64e0b/server/routes/activities/manage-allocations/index.ts) anyway and this meant journey data was being saved twice.