### PR TITLE
SAA-3429: Movement list cancelled events filter

### DIFF
--- a/integration_tests/e2e/activities/movementList.cy.ts
+++ b/integration_tests/e2e/activities/movementList.cy.ts
@@ -55,6 +55,7 @@ context('Create activity', () => {
     const locationEventsPage = Page.verifyOnPage(LocationEventsPage)
     locationEventsPage.assertBadges(0, CONTROLLED_UNLOCK_BADGE, PEEP_BADGE)
     locationEventsPage.assertBadges(1, CAT_A_BADGE, CONTROLLED_UNLOCK_BADGE)
+    locationEventsPage.cancelledBadge().should('have.lengthOf', 1)
 
     locationEventsPage.getButton('Show filter').click()
     locationEventsPage.acctAlertCheckbox().should('be.checked')
@@ -71,6 +72,7 @@ context('Create activity', () => {
 
     locationEventsPage.assertBadges(0, PEEP_BADGE)
     locationEventsPage.assertBadges(1, CAT_A_BADGE)
+    locationEventsPage.cancelledBadge().should('have.lengthOf', 1)
 
     locationEventsPage.getButton('Show filter').click()
     locationEventsPage.acctAlertCheckbox().should('be.checked')
@@ -81,11 +83,13 @@ context('Create activity', () => {
     locationEventsPage.catAAlertCheckbox().should('be.checked')
     locationEventsPage.catAHigherAlertCheckbox().should('be.checked')
     locationEventsPage.catAProvisionalAlertCheckbox().should('be.checked')
+    locationEventsPage.cancelledFilter().should('be.checked')
 
     locationEventsPage.selectAllAlerts().click()
     locationEventsPage.getButton('Apply filters').eq(0).click()
     locationEventsPage.assertBadges(0, CONTROLLED_UNLOCK_BADGE, PEEP_BADGE)
     locationEventsPage.assertBadges(1, CAT_A_BADGE, CONTROLLED_UNLOCK_BADGE)
+    locationEventsPage.cancelledBadge().should('have.lengthOf', 1)
 
     locationEventsPage.getButton('Show filter').click()
     locationEventsPage.selectAllAlerts().click()
@@ -97,9 +101,45 @@ context('Create activity', () => {
     locationEventsPage.catAAlertCheckbox().should('not.be.checked')
     locationEventsPage.catAHigherAlertCheckbox().should('not.be.checked')
     locationEventsPage.catAProvisionalAlertCheckbox().should('not.be.checked')
-
     locationEventsPage.getButton('Apply filters').eq(0).click()
-
     locationEventsPage.relevantAlertColumn().should('not.exist')
+  })
+
+  it('should filter out cancelled sessions', () => {
+    const indexPage = Page.verifyOnPage(IndexPage)
+    indexPage.activitiesCard().click()
+
+    const activitiesIndexPage = Page.verifyOnPage(ActivitiesIndexPage)
+    activitiesIndexPage.unlockAndMovementCard().click()
+
+    const manageActivitiesPage = Page.verifyOnPage(UnlockAndMovementIndexPage)
+    manageActivitiesPage.createMovementListsCard().should('contain.text', 'Create movement lists')
+    manageActivitiesPage.createMovementListsCard().click()
+
+    const chooseMovementListDetailsPage = Page.verifyOnPage(ChooseDetailsPage)
+    chooseMovementListDetailsPage.selectToday()
+    chooseMovementListDetailsPage.selectAM()
+    chooseMovementListDetailsPage.continue()
+
+    const locationsPage = Page.verifyOnPage(LocationsPage)
+    locationsPage.selectLocation('Workshop 1').click()
+
+    const locationEventsPage = Page.verifyOnPage(LocationEventsPage)
+    locationEventsPage.assertBadges(0, CONTROLLED_UNLOCK_BADGE, PEEP_BADGE)
+    locationEventsPage.assertBadges(1, CAT_A_BADGE, CONTROLLED_UNLOCK_BADGE)
+    locationEventsPage.cancelledBadge().should('have.lengthOf', 1)
+
+    locationEventsPage.getButton('Show filter').click()
+    locationEventsPage.acctAlertCheckbox().should('be.checked')
+    locationEventsPage.controlledUnlockAlertCheckbox().should('be.checked')
+    locationEventsPage.eListAlertCheckbox().should('be.checked')
+    locationEventsPage.peepAlertCheckbox().should('be.checked')
+    locationEventsPage.tactAlertCheckbox().should('be.checked')
+    locationEventsPage.catAAlertCheckbox().should('be.checked')
+    locationEventsPage.catAHigherAlertCheckbox().should('be.checked')
+    locationEventsPage.catAProvisionalAlertCheckbox().should('be.checked')
+    locationEventsPage.selectNoCancelledEvents().click()
+    locationEventsPage.getButton('Apply filters').eq(0).click()
+    cy.get('tbody>tr').should('have.length', 1)
   })
 })

--- a/integration_tests/fixtures/activitiesApi/getScheduledEventLocations.json
+++ b/integration_tests/fixtures/activitiesApi/getScheduledEventLocations.json
@@ -61,7 +61,7 @@
         "onWing": false,
         "offWing": false,
         "outsidePrison": false,
-        "cancelled": false,
+        "cancelled": true,
         "suspended": false,
         "autoSuspended": false,
         "prisonerNumber": "G4572UO",

--- a/integration_tests/pages/unlockAndMovements/abstractEventsPage.ts
+++ b/integration_tests/pages/unlockAndMovements/abstractEventsPage.ts
@@ -40,5 +40,11 @@ export default abstract class AbstractEventsPage extends Page {
 
   selectAllAlerts = () => cy.get('a[data-checkbox-name="alertFilters"]')
 
+  selectNoCancelledEvents = () => cy.get(`[name="cancelledEventsFilter"][value="NO"]`)
+
   relevantAlertColumn = () => cy.get('th').contains('Relevant alerts')
+
+  cancelledBadge = (): Cypress.Chainable => cy.get('[data-qa=cancelled-badge]')
+
+  cancelledFilter = () => cy.get(`[name="cancelledEventsFilter"][value="YES"]`)
 }

--- a/server/@types/activities.ts
+++ b/server/@types/activities.ts
@@ -44,6 +44,7 @@ export type MovementListPrisonerEvents = {
   alerts?: PrisonerAlert[]
   events?: ScheduledEvent[]
   clashingEvents?: ScheduledEvent[]
+  cancelledEvents?: ScheduledEvent[]
 }
 
 export type SubLocationCellPattern = {

--- a/server/routes/activities/movement-list/handlers/applyFilters.test.ts
+++ b/server/routes/activities/movement-list/handlers/applyFilters.test.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express'
 import ApplyFiltersRoutes from './applyFilters'
+import { YesNo } from '../../../../@types/activities'
 
 describe('Route Handlers - Apply Filters', () => {
   const handler = new ApplyFiltersRoutes()
@@ -18,10 +19,12 @@ describe('Route Handlers - Apply Filters', () => {
       get: jest.fn(),
       body: {
         alertFilters: ['ALERT_PEEP', 'CAT_A_PROVISIONAL'],
+        cancelledEventsFilter: YesNo.YES,
       },
       journeyData: {
         movementListJourney: {
           alertFilters: null,
+          cancelledEventsFilter: null,
         },
       },
     } as unknown as Request
@@ -32,6 +35,7 @@ describe('Route Handlers - Apply Filters', () => {
       await handler.APPLY(req, res)
       expect(req.journeyData.movementListJourney).toStrictEqual({
         alertFilters: ['ALERT_PEEP', 'CAT_A_PROVISIONAL'],
+        cancelledEventsFilter: 'YES',
       })
     })
 
@@ -40,6 +44,7 @@ describe('Route Handlers - Apply Filters', () => {
       await handler.APPLY(req, res)
       expect(req.journeyData.movementListJourney).toStrictEqual({
         alertFilters: [],
+        cancelledEventsFilter: 'YES',
       })
     })
   })

--- a/server/routes/activities/movement-list/handlers/applyFilters.ts
+++ b/server/routes/activities/movement-list/handlers/applyFilters.ts
@@ -9,7 +9,9 @@ export class Filters {
 
 export default class ApplyFiltersRoutes {
   APPLY = async (req: Request, res: Response): Promise<void> => {
-    const { alertFilters } = req.body
+    const { alertFilters, cancelledEventsFilter } = req.body
+
+    req.journeyData.movementListJourney.cancelledEventsFilter = cancelledEventsFilter
 
     req.journeyData.movementListJourney.alertFilters = alertFilters ?? []
 

--- a/server/routes/activities/movement-list/handlers/locationEvents.ts
+++ b/server/routes/activities/movement-list/handlers/locationEvents.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express'
 import { isValid } from 'date-fns'
 import DateOption from '../../../../enum/dateOption'
-import { EventType, MovementListLocation, MovementListPrisonerEvents } from '../../../../@types/activities'
+import { EventType, MovementListLocation, MovementListPrisonerEvents, YesNo } from '../../../../@types/activities'
 import ActivitiesService from '../../../../services/activitiesService'
 import PrisonService from '../../../../services/prisonService'
 import { eventClashes, scheduledEventSort } from '../../../../utils/utils'
@@ -64,6 +64,8 @@ export default class LocationEventsRoutes {
 
     movementListJourney.alertFilters ??= alertOptions.map(a => a.key)
 
+    movementListJourney.cancelledEventsFilter ??= YesNo.YES
+
     const selectedAlerts = movementListJourney.alertFilters
 
     const locations = internalLocationEvents.map(
@@ -122,11 +124,16 @@ export default class LocationEventsRoutes {
                 e => e.eventType !== EventType.APPOINTMENT || applyCancellationDisplayRule(e),
               )
 
+              const pageFilterCheck =
+                movementListJourney.cancelledEventsFilter === YesNo.NO
+                  ? filteredEvents.filter(event => !event.cancelled)
+                  : filteredEvents
+
               return {
                 ...p,
                 alerts: this.alertsFilterService.getFilteredAlerts(selectedAlerts, p?.alerts),
                 category: this.alertsFilterService.getFilteredCategory(selectedAlerts, p?.category),
-                events: filteredEvents,
+                events: pageFilterCheck,
                 clashingEvents,
               } as MovementListPrisonerEvents
             })

--- a/server/routes/activities/movement-list/journey.ts
+++ b/server/routes/activities/movement-list/journey.ts
@@ -1,6 +1,9 @@
+import { YesNo } from '../../../@types/activities'
+
 export type MovementListJourney = {
   dateOption?: string
   date?: string
   timeSlot?: string
   alertFilters?: string[]
+  cancelledEventsFilter?: YesNo
 }

--- a/server/views/pages/activities/movement-list/location-events.njk
+++ b/server/views/pages/activities/movement-list/location-events.njk
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "moj/components/filter/macro.njk" import mojFilter %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "components/alertsList.njk" import alertsList %}
@@ -45,7 +46,7 @@
                 {% endif %}
 
                 {% if event.cancelled %}
-                    <div class='govuk-!-margin-top-1 govuk-!-margin-bottom-1'>{{ govukTag({ text: 'Cancelled', classes: 'govuk-tag--small govuk-tag--red' }) }}</div>
+                    <div class='govuk-!-margin-top-1 govuk-!-margin-bottom-1'>{{ govukTag({ text: 'Cancelled', classes: 'govuk-tag--small govuk-tag--red', attributes: { "data-qa": "cancelled-badge" } }) }}</div>
                 {% endif %}
 
                 {% if event.suspended %}
@@ -94,7 +95,7 @@
             {% endif %}
 
             {% if event.cancelled %}
-                <div class='govuk-!-margin-top-1 govuk-!-margin-bottom-1'>{{ govukTag({ text: 'Cancelled', classes: 'govuk-tag--small govuk-tag--red' }) }}</div>
+                <div class='govuk-!-margin-top-1 govuk-!-margin-bottom-1'>{{ govukTag({ text: 'Cancelled', classes: 'govuk-tag--small govuk-tag--red', attributes: { "data-qa": "cancelled-badge" } }) }}</div>
             {% endif %}
 
             {% if event.suspended %}
@@ -121,8 +122,32 @@
 {% block content %}
 
     {% set filterOptionsHtml %}
-
         {{ alertFilters(alertOptions, movementListJourney.alertFilters) }}
+
+        {{ govukRadios({
+            idPrefix: 'cancelledEventsFilter',
+            name: 'cancelledEventsFilter',
+            classes: "govuk-radios--small",
+            fieldset: {
+                legend: {
+                    text: 'Show cancelled events',
+                    isPageHeading: true,
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+            items:[
+                {
+                    value: YesNo.YES,
+                    text: 'Yes',
+                    checked: movementListJourney.cancelledEventsFilter == YesNo.YES
+                },
+                {
+                    value: YesNo.NO,
+                    text: 'No',
+                    checked: movementListJourney.cancelledEventsFilter == YesNo.NO
+                }
+            ]
+        }) }}   
 
         <button class="govuk-button govuk-!-margin-top-3" data-module="govuk-button">
             Apply filters


### PR DESCRIPTION
Added show cancelled events filter to the movement list and added cypress tests to check filter behaviour 

<img width="386" height="299" alt="Screenshot 2025-09-19 at 16 58 35" src="https://github.com/user-attachments/assets/e0888480-8cf4-4fae-a7cd-1002575a9e86" />
