### PR TITLE
SAA-4238: Content change when changing activity schedule

### DIFF
--- a/integration_tests/e2e/activities/editActivity.cy.ts
+++ b/integration_tests/e2e/activities/editActivity.cy.ts
@@ -155,6 +155,14 @@ context('Edit activity', () => {
     customTimesChangeOptionPage.continue()
 
     const daysAndSessionsPage = Page.verifyOnPage(DaysAndSessionsPage)
+    // TODO: when sameDayScheduleModificationsEnabled is enabled, use commented out assertion and remove the one below it
+    // daysAndSessionsPage
+    //   .modParagraph()
+    //   .should(
+    //     'contain.text',
+    //     'If you add a session for today, you can choose if it runs today or not. Other changes you make will take effect tomorrow.',
+    //   )
+    daysAndSessionsPage.modParagraph().should('contain.text', 'Any changes you make will take effect tomorrow.')
     daysAndSessionsPage.checkboxes().find('input[value="tuesday"]').should('be.checked')
     daysAndSessionsPage.getInputById('timeSlotsTuesday').should('be.checked')
     daysAndSessionsPage.checkboxes().find('input[value="wednesday"]').should('be.checked')

--- a/integration_tests/pages/createSchedule/daysAndSessions.ts
+++ b/integration_tests/pages/createSchedule/daysAndSessions.ts
@@ -9,6 +9,8 @@ export default class DaysAndSessionsPage extends Page {
 
   caption = (): Cypress.Chainable => cy.get('[data-qa=caption]')
 
+  modParagraph = (): Cypress.Chainable => cy.get('[data-qa=modification-time]')
+
   checkboxes = () => cy.get('[data-qa="day-session-checkboxes"]')
 
   selectDayTimeCheckboxes = (checkboxes: [string, string[]][]) =>

--- a/server/nunjucks/nunjucksSetup.ts
+++ b/server/nunjucks/nunjucksSetup.ts
@@ -256,6 +256,7 @@ export function registerNunjucks(applicationInfo?: ApplicationInfo, app?: expres
   njkEnv.addGlobal('exampleDatePickerDate', () => `29/9/${formatDate(addYears(new Date(), 1), 'yyyy')}`)
 
   njkEnv.addGlobal('prisonerExtraInformationEnabled', config.prisonerExtraInformationEnabled)
+  njkEnv.addGlobal('sameDayScheduleModificationsEnabled', config.sameDayScheduleModificationsEnabled)
 
   for (const [name, filter] of Object.entries(mojFilters())) {
     njkEnv.addFilter(name, filter as (...args: any[]) => any)

--- a/server/views/pages/activities/create-an-activity/days-and-times.njk
+++ b/server/views/pages/activities/create-an-activity/days-and-times.njk
@@ -30,7 +30,11 @@
             {% endif %}
 
             {% if session.req.routeContext.mode == 'edit' %}
-                <p class="govuk-body">Any changes you make will take effect tomorrow.</p>
+                {% if sameDayScheduleModificationsEnabled %}
+                    <p class="govuk-body" data-qa="modification-time">If you add a session for today, you can choose if it runs today or not. Other changes you make will take effect tomorrow.</p>
+                {% else %}
+                    <p class="govuk-body" data-qa="modification-time">Any changes you make will take effect tomorrow.</p>
+                {% endif %}
                 <p class="govuk-body">You should update any unlock lists that have been printed.</p>
             {% elseif createJourney.scheduleWeeks > 1 and session.req.params.weekNumber == 1 %}
                 <p class="govuk-body">Your chosen start date will fall in week 1 of your schedule, even if there are no sessions planned for the rest of the week</p>


### PR DESCRIPTION
- Changes the content in the second paragraph on the days and times page if the same day modification flag is true
- Integration test assertion set up and ready for when the flag is on
- Added the flag to the nunjucks set up so we don't have to pass it in on render on every page it's used on