### PR TITLE
SAA-4058: Refactor checkAndConfirmMultiple to use bulk allocations endpoint

### DIFF
--- a/integration_tests/e2e/activities/allocations/allocateMultipleFromCSVToActivity.cy.ts
+++ b/integration_tests/e2e/activities/allocations/allocateMultipleFromCSVToActivity.cy.ts
@@ -57,7 +57,7 @@ context('Allocate multiple via CSV to an activity', () => {
     cy.stubEndpoint('GET', '/incentive-reviews/prisoner/A5015DY', getPrisonerIepSummary)
     cy.stubEndpoint('GET', '/allocations/deallocation-reasons', getDeallocationReasons)
     cy.stubEndpoint('GET', '/prison/MDI/prison-pay-bands', getMdiPrisonPayBands)
-    cy.stubEndpoint('POST', '/schedules/2/allocations')
+    cy.stubEndpoint('POST', '/schedules/2/allocations/bulk')
     cy.stubEndpoint('GET', '/schedules/2/non-associations\\?prisonerNumber=A5015DY', getNonAssociations)
     cy.stubEndpoint('POST', '/non-associations/involving\\?prisonId=MDI', getNonAssociationsInvolving)
     cy.stubEndpoint('POST', '/prisoner-search/prisoner-numbers', getInmateDetails.content)

--- a/integration_tests/e2e/activities/allocations/allocateMultipleFromOtherActivity.cy.ts
+++ b/integration_tests/e2e/activities/allocations/allocateMultipleFromOtherActivity.cy.ts
@@ -55,7 +55,7 @@ context('Allocate multiple people to an activity by copying from another activit
     cy.stubEndpoint('GET', '/schedules/2/suitability\\?prisonerNumber=G4793VF', getCandidateSuitability)
     cy.stubEndpoint('GET', '/schedules/2/suitability\\?prisonerNumber=B1351RE', getCandidateSuitability2)
     cy.stubEndpoint('GET', '/schedules/2/suitability\\?prisonerNumber=A1351DZ', getCandidateSuitability)
-    cy.stubEndpoint('POST', '/schedules/2/allocations')
+    cy.stubEndpoint('POST', '/schedules/2/allocations/bulk')
 
     resetActivityAndScheduleStubs({
       activityStartDate: subWeeks(new Date(), 2),

--- a/integration_tests/e2e/activities/allocations/allocateMultipleToActivity.cy.ts
+++ b/integration_tests/e2e/activities/allocations/allocateMultipleToActivity.cy.ts
@@ -51,7 +51,7 @@ context('Allocate multiple one by one to an activity', () => {
     cy.stubEndpoint('GET', '/incentive-reviews/prisoner/A5015DY', getPrisonerIepSummary)
     cy.stubEndpoint('GET', '/allocations/deallocation-reasons', getDeallocationReasons)
     cy.stubEndpoint('GET', '/prison/MDI/prison-pay-bands', getMdiPrisonPayBands)
-    cy.stubEndpoint('POST', '/schedules/2/allocations')
+    cy.stubEndpoint('POST', '/schedules/2/allocations/bulk')
     cy.stubEndpoint('GET', '/schedules/2/non-associations\\?prisonerNumber=A5015DY', getNonAssociations)
     cy.stubEndpoint('GET', '/prison/MDI/prisoners\\?term=s&size=50', getInmateDetails)
     cy.stubEndpoint('POST', '/non-associations/involving\\?prisonId=MDI', getNonAssociations)

--- a/server/@types/activitiesAPI/types.ts
+++ b/server/@types/activitiesAPI/types.ts
@@ -24,6 +24,7 @@ export type PrisonerAllocations = components['schemas']['PrisonerAllocations']
 export type ActivityCreateRequest = components['schemas']['ActivityCreateRequest']
 export type ActivityUpdateRequest = components['schemas']['ActivityUpdateRequest']
 export type AllocationUpdateRequest = components['schemas']['AllocationUpdateRequest']
+export type BulkAllocationRequest = components['schemas']['BulkPrisonerAllocationRequest']
 export type SuspendPrisonerRequest = components['schemas']['SuspendPrisonerRequest']
 
 export type UnsuspendPrisonerRequest = components['schemas']['UnsuspendPrisonerRequest']

--- a/server/data/activitiesApiClient.test.ts
+++ b/server/data/activitiesApiClient.test.ts
@@ -302,6 +302,41 @@ describe('activitiesApiClient', () => {
     })
   })
 
+  describe('postBulkAllocations', () => {
+    it('should post bulk allocation data to api', async () => {
+      const allocationRequests = {
+        allocations: [
+          {
+            prisonerNumber: 'ABC123',
+            payBandId: 1,
+            startDate: '2023-01-01',
+            endDate: null,
+            exclusions: [],
+            scheduleInstanceId: null,
+          },
+          {
+            prisonerNumber: 'DEF456',
+            payBandId: 2,
+            startDate: '2023-01-01',
+            endDate: null,
+            exclusions: [],
+            scheduleInstanceId: null,
+          },
+        ],
+      }
+
+      fakeActivitiesApi
+        .post('/schedules/1/allocations/bulk', allocationRequests)
+        .matchHeader('authorization', `Bearer token`)
+        .matchHeader('Caseload-Id', 'MDI')
+        .reply(204)
+
+      await activitiesApiClient.postBulkAllocations(1, allocationRequests, user)
+
+      expect(nock.isDone()).toBe(true)
+    })
+  })
+
   describe('getPayBandsForPrison', () => {
     it('should return data from api', async () => {
       fakeActivitiesApi

--- a/server/data/activitiesApiClient.ts
+++ b/server/data/activitiesApiClient.ts
@@ -74,6 +74,7 @@ import {
   ActivityPayHistory,
   WaitingListApplicationHistory,
   LocationPrefixes,
+  BulkAllocationRequest,
 } from '../@types/activitiesAPI/types'
 import { ActivityCategoryEnum } from './activityCategoryEnum'
 import { toDateString } from '../utils/utils'
@@ -276,6 +277,21 @@ export default class ActivitiesApiClient extends RestClient {
         path: `/schedules/${scheduleId}/allocations`,
         headers: CASELOAD_HEADER(user.activeCaseLoadId),
         data: { prisonerNumber, payBandId, startDate, endDate, exclusions, scheduleInstanceId },
+      },
+      asUser(user.token),
+    )
+  }
+
+  async postBulkAllocations(
+    scheduleId: number,
+    allocationRequests: BulkAllocationRequest,
+    user: ServiceUser,
+  ): Promise<void> {
+    return this.post(
+      {
+        path: `/schedules/${scheduleId}/allocations/bulk`,
+        headers: CASELOAD_HEADER(user.activeCaseLoadId),
+        data: allocationRequests,
       },
       asUser(user.token),
     )

--- a/server/routes/activities/manage-allocations/handlers/allocateMultiplePeople/checkAndConfirmMultiple.test.ts
+++ b/server/routes/activities/manage-allocations/handlers/allocateMultiplePeople/checkAndConfirmMultiple.test.ts
@@ -111,30 +111,61 @@ describe('Allocate multiple people - check and confirm answers', () => {
     })
   })
   describe('POST', () => {
+    it('Should correctly map inmates to allocation requests with payBands', async () => {
+      req.journeyData.allocateJourney.startDateOption = StartDateOption.NEXT_SESSION
+
+      await handler.POST(req, res)
+
+      const callArgs = activitiesService.postBulkAllocations.mock.calls[0]
+      const { allocations } = callArgs[1]
+
+      expect(allocations).toHaveLength(2)
+      expect(allocations[0]).toEqual({
+        prisonerNumber: 'G3096GX',
+        payBandId: 1,
+        startDate: '2025-01-01',
+        endDate: '2026-01-01',
+        exclusions: [],
+        scheduleInstanceId: 123,
+      })
+      expect(allocations[1]).toEqual({
+        prisonerNumber: 'G4977UO',
+        payBandId: 2,
+        startDate: '2025-01-01',
+        endDate: '2026-01-01',
+        exclusions: [],
+        scheduleInstanceId: 123,
+      })
+    })
+
     it('Start date next session', async () => {
       req.journeyData.allocateJourney.startDateOption = StartDateOption.NEXT_SESSION
 
       await handler.POST(req, res)
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledTimes(2)
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledWith(
+      expect(activitiesService.postBulkAllocations).toHaveBeenCalledTimes(1)
+      expect(activitiesService.postBulkAllocations).toHaveBeenCalledWith(
         1,
-        'G3096GX',
-        1,
+        {
+          allocations: [
+            {
+              prisonerNumber: 'G3096GX',
+              payBandId: 1,
+              startDate: '2025-01-01',
+              endDate: '2026-01-01',
+              exclusions: [],
+              scheduleInstanceId: 123,
+            },
+            {
+              prisonerNumber: 'G4977UO',
+              payBandId: 2,
+              startDate: '2025-01-01',
+              endDate: '2026-01-01',
+              exclusions: [],
+              scheduleInstanceId: 123,
+            },
+          ],
+        },
         { username: 'joebloggs' },
-        '2025-01-01',
-        '2026-01-01',
-        [],
-        123,
-      )
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledWith(
-        1,
-        'G4977UO',
-        2,
-        { username: 'joebloggs' },
-        '2025-01-01',
-        '2026-01-01',
-        [],
-        123,
       )
       expect(res.redirect).toHaveBeenCalledWith('confirmation')
     })
@@ -142,26 +173,30 @@ describe('Allocate multiple people - check and confirm answers', () => {
       req.journeyData.allocateJourney.startDateOption = StartDateOption.START_DATE
 
       await handler.POST(req, res)
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledTimes(2)
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledWith(
+      expect(activitiesService.postBulkAllocations).toHaveBeenCalledTimes(1)
+      expect(activitiesService.postBulkAllocations).toHaveBeenCalledWith(
         1,
-        'G3096GX',
-        1,
+        {
+          allocations: [
+            {
+              prisonerNumber: 'G3096GX',
+              payBandId: 1,
+              startDate: '2025-01-01',
+              endDate: '2026-01-01',
+              exclusions: [],
+              scheduleInstanceId: null,
+            },
+            {
+              prisonerNumber: 'G4977UO',
+              payBandId: 2,
+              startDate: '2025-01-01',
+              endDate: '2026-01-01',
+              exclusions: [],
+              scheduleInstanceId: null,
+            },
+          ],
+        },
         { username: 'joebloggs' },
-        '2025-01-01',
-        '2026-01-01',
-        [],
-        null,
-      )
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledWith(
-        1,
-        'G4977UO',
-        2,
-        { username: 'joebloggs' },
-        '2025-01-01',
-        '2026-01-01',
-        [],
-        null,
       )
       expect(res.redirect).toHaveBeenCalledWith('confirmation')
     })
@@ -170,27 +205,32 @@ describe('Allocate multiple people - check and confirm answers', () => {
       req.journeyData.allocateJourney.endDate = null
 
       await handler.POST(req, res)
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledTimes(2)
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledWith(
+      expect(activitiesService.postBulkAllocations).toHaveBeenCalledTimes(1)
+      expect(activitiesService.postBulkAllocations).toHaveBeenCalledWith(
         1,
-        'G3096GX',
-        1,
+        {
+          allocations: [
+            {
+              prisonerNumber: 'G3096GX',
+              payBandId: 1,
+              startDate: '2025-01-01',
+              endDate: null,
+              exclusions: [],
+              scheduleInstanceId: 123,
+            },
+            {
+              prisonerNumber: 'G4977UO',
+              payBandId: 2,
+              startDate: '2025-01-01',
+              endDate: null,
+              exclusions: [],
+              scheduleInstanceId: 123,
+            },
+          ],
+        },
         { username: 'joebloggs' },
-        '2025-01-01',
-        null,
-        [],
-        123,
       )
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledWith(
-        1,
-        'G4977UO',
-        2,
-        { username: 'joebloggs' },
-        '2025-01-01',
-        null,
-        [],
-        123,
-      )
+      expect(res.redirect).toHaveBeenCalledWith('confirmation')
     })
     it('No payband id', async () => {
       req.journeyData.allocateJourney.startDateOption = StartDateOption.NEXT_SESSION
@@ -212,26 +252,30 @@ describe('Allocate multiple people - check and confirm answers', () => {
       ] as Inmate[]
 
       await handler.POST(req, res)
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledTimes(2)
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledWith(
+      expect(activitiesService.postBulkAllocations).toHaveBeenCalledTimes(1)
+      expect(activitiesService.postBulkAllocations).toHaveBeenCalledWith(
         1,
-        'G3096GX',
-        null,
+        {
+          allocations: [
+            {
+              prisonerNumber: 'G3096GX',
+              payBandId: null,
+              startDate: '2025-01-01',
+              endDate: '2026-01-01',
+              exclusions: [],
+              scheduleInstanceId: 123,
+            },
+            {
+              prisonerNumber: 'G4977UO',
+              payBandId: null,
+              startDate: '2025-01-01',
+              endDate: '2026-01-01',
+              exclusions: [],
+              scheduleInstanceId: 123,
+            },
+          ],
+        },
         { username: 'joebloggs' },
-        '2025-01-01',
-        '2026-01-01',
-        [],
-        123,
-      )
-      expect(activitiesService.allocateToSchedule).toHaveBeenCalledWith(
-        1,
-        'G4977UO',
-        null,
-        { username: 'joebloggs' },
-        '2025-01-01',
-        '2026-01-01',
-        [],
-        123,
       )
       expect(res.redirect).toHaveBeenCalledWith('confirmation')
     })

--- a/server/routes/activities/manage-allocations/handlers/allocateMultiplePeople/checkAndConfirmMultiple.ts
+++ b/server/routes/activities/manage-allocations/handlers/allocateMultiplePeople/checkAndConfirmMultiple.ts
@@ -19,20 +19,17 @@ export default class CheckAndConfirmMultipleRoutes {
       req.journeyData.allocateJourney
     const { user } = res.locals
 
-    await Promise.all(
-      inmates.map(inmate =>
-        this.activitiesService.allocateToSchedule(
-          activity.scheduleId,
-          inmate.prisonerNumber,
-          inmate.payBand?.id || null,
-          user,
-          startDate,
-          endDate,
-          [],
-          startDateOption === StartDateOption.NEXT_SESSION ? scheduledInstance?.id : null,
-        ),
-      ),
-    )
+    const allocationRequests = inmates.map(inmate => ({
+      prisonerNumber: inmate.prisonerNumber,
+      payBandId: inmate.payBand?.id || null,
+      startDate,
+      endDate,
+      exclusions: [],
+      scheduleInstanceId: startDateOption === StartDateOption.NEXT_SESSION ? scheduledInstance?.id : null,
+    }))
+
+    await this.activitiesService.postBulkAllocations(activity.scheduleId, { allocations: allocationRequests }, user)
+
     res.redirect('confirmation')
   }
 }

--- a/server/services/activitiesService.test.ts
+++ b/server/services/activitiesService.test.ts
@@ -186,6 +186,35 @@ describe('Activities Service', () => {
     })
   })
 
+  describe('postBulkAllocations', () => {
+    it('should call activities API client to post bulk allocations', async () => {
+      const allocationRequests = {
+        allocations: [
+          {
+            prisonerNumber: 'ABC123',
+            payBandId: 1,
+            startDate: '2023-01-01',
+            endDate: null,
+            exclusions: [],
+            scheduleInstanceId: 123,
+          },
+          {
+            prisonerNumber: 'DEF456',
+            payBandId: 2,
+            startDate: '2023-01-01',
+            endDate: null,
+            exclusions: [],
+            scheduleInstanceId: 123,
+          },
+        ],
+      }
+
+      await activitiesService.postBulkAllocations(1, allocationRequests, user)
+
+      expect(activitiesApiClient.postBulkAllocations).toHaveBeenCalledWith(1, allocationRequests, user)
+    })
+  })
+
   describe('getPayBandsForPrison', () => {
     it('should get the list of prison pay bands', async () => {
       const expectedResult = [{ id: 1, alias: 'High' }] as PrisonPayBand[]

--- a/server/services/activitiesService.ts
+++ b/server/services/activitiesService.ts
@@ -30,6 +30,7 @@ import {
   Attendance,
   AttendanceReason,
   AttendanceUpdateRequest,
+  BulkAllocationRequest,
   DeallocationReasonCode,
   EventAcknowledgeRequest,
   EventReviewSearchResults,
@@ -193,6 +194,10 @@ export default class ActivitiesService {
       exclusions,
       scheduleInstanceId,
     )
+  }
+
+  postBulkAllocations(scheduleId: number, allocationRequests: BulkAllocationRequest, user: ServiceUser) {
+    return this.activitiesApiClient.postBulkAllocations(scheduleId, allocationRequests, user)
   }
 
   getPayBandsForPrison(user: ServiceUser): Promise<PrisonPayBand[]> {


### PR DESCRIPTION
[SAA-4058](https://dsdmoj.atlassian.net/jira/software/c/projects/SAA/boards/4439?selectedIssue=SAA-4058&sprints=24149)

Previously we would allocate multiple prisoners with individual activitiesService.allocateToSchedule().

In this PR we are refactoring to use postBulkAllocations() which incorporates the new bulk allocate endpoint. 

[SAA-4058]: https://dsdmoj.atlassian.net/browse/SAA-4058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ