### PR TITLE
SAA-4309

### DIFF
--- a/server/routes/activities/create-an-activity/handlers/sessionTimes.test.ts
+++ b/server/routes/activities/create-an-activity/handlers/sessionTimes.test.ts
@@ -460,6 +460,13 @@ describe('Route Handlers - Create an activity schedule - session times', () => {
         },
       } as unknown as Request
 
+      const futureSameDaySlotsMock = getFutureSameDaySlots as jest.Mock
+      const allSameDaySlotsMock = getAllSameDaySlots as jest.Mock
+
+      activitiesService.getActivity.mockResolvedValueOnce(activity as unknown as Activity)
+      futureSameDaySlotsMock.mockReturnValueOnce([])
+      allSameDaySlotsMock.mockReturnValueOnce([])
+
       await handler.POST(req, res)
       expect(activitiesService.updateActivity).toHaveBeenCalledWith(1, updatedActivity, res.locals.user)
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
@@ -813,9 +820,10 @@ describe('Same-day schedule modifications (sameDayScheduleModificationsEnabled i
     config.sameDayScheduleModificationsEnabled = true
     getFutureSameDaySlotsMock = getFutureSameDaySlots as jest.Mock
     getAllSameDaySlotsMock = getAllSameDaySlots as jest.Mock
-    getFutureSameDaySlotsMock.mockClear()
-    getAllSameDaySlotsMock.mockClear()
-    activitiesService.getActivity.mockClear()
+    getFutureSameDaySlotsMock.mockReset()
+    getAllSameDaySlotsMock.mockReset()
+    activitiesService.getActivity.mockReset()
+    activitiesService.updateActivity.mockReset()
 
     handler = new SessionTimesRoutes(activitiesService)
 
@@ -996,6 +1004,73 @@ describe('Same-day schedule modifications (sameDayScheduleModificationsEnabled i
     expect(res.redirectWithSuccess).toHaveBeenCalled()
   })
 
+  it('should not treat a start time change on an existing day as a new slot', async () => {
+    const allSameDaySlots = []
+    const currentActivity = {
+      ...activity,
+      schedules: [
+        {
+          ...activity.schedules[0],
+          scheduleWeeks: 1,
+          slots: [
+            {
+              weekNumber: 1,
+              timeSlot: TimeSlot.PM,
+              mondayFlag: false,
+              tuesdayFlag: false,
+              wednesdayFlag: false,
+              thursdayFlag: false,
+              fridayFlag: true,
+              saturdayFlag: false,
+              sundayFlag: false,
+              daysOfWeek: ['Fri'],
+              startTime: '13:45',
+              endTime: '16:45',
+            },
+          ],
+        },
+      ],
+    } as unknown as Activity
+
+    activitiesService.getActivity.mockResolvedValueOnce(currentActivity)
+    activitiesService.updateActivity.mockResolvedValueOnce({} as Activity)
+    getAllSameDaySlotsMock.mockReturnValueOnce(allSameDaySlots)
+    getFutureSameDaySlotsMock.mockReturnValueOnce([])
+
+    const startMap: Map<string, SimpleTime> = new Map<string, SimpleTime>()
+    const endMap: Map<string, SimpleTime> = new Map<string, SimpleTime>()
+
+    const startTime = new SimpleTime()
+    startTime.hour = 15
+    startTime.minute = 0
+
+    startMap.set('1-FRIDAY-PM', startTime)
+
+    const endTime = new SimpleTime()
+    endTime.hour = 16
+    endTime.minute = 45
+
+    endMap.set('1-FRIDAY-PM', endTime)
+
+    req.body = {
+      startTimes: startMap,
+      endTimes: endMap,
+    }
+    req.journeyData.createJourney.slots = {
+      '1': {
+        days: ['friday'],
+        timeSlotsFriday: ['PM'],
+      },
+    }
+
+    await handler.POST(req, res)
+
+    expect(getAllSameDaySlotsMock).toHaveBeenCalledWith([], expect.anything())
+    expect(getFutureSameDaySlotsMock).not.toHaveBeenCalled()
+    expect(activitiesService.updateActivity).toHaveBeenCalled()
+    expect(res.redirectWithSuccess).toHaveBeenCalled()
+  })
+
   it('should not check for same-day slots if not in edit mode', async () => {
     req.routeContext = { mode: 'create' }
 
@@ -1029,7 +1104,7 @@ describe('Same-day schedule modifications (sameDayScheduleModificationsEnabled i
 
     expect(activitiesService.getActivity).not.toHaveBeenCalled()
     expect(getFutureSameDaySlotsMock).not.toHaveBeenCalled()
-    expect(activitiesService.updateActivity).toHaveBeenCalled()
+    expect(activitiesService.updateActivity).not.toHaveBeenCalled()
     expect(res.redirectOrReturn).toHaveBeenCalled()
   })
 

--- a/server/routes/activities/create-an-activity/handlers/sessionTimes.ts
+++ b/server/routes/activities/create-an-activity/handlers/sessionTimes.ts
@@ -18,7 +18,7 @@ import {
   SessionSlot,
   transformActivitySlotsToDailySlots,
   mapActivityScheduleSlotsToSlots,
-  calculateUniqueSlots,
+  calculateUniqueSlotsByDay,
 } from '../../../../utils/helpers/activityTimeSlotMappers'
 import { ServiceUser } from '../../../../@types/express'
 import calcCurrentWeek from '../../../../utils/helpers/currentWeekCalculator'
@@ -141,8 +141,7 @@ export default class SessionTimesRoutes {
 
         const existingSlots = mapActivityScheduleSlotsToSlots(activitySchedule?.slots || [])
         const existingSlotsAndNewSlots = req.journeyData.createJourney.customSlots
-        const newSlots = calculateUniqueSlots(existingSlotsAndNewSlots, existingSlots)
-
+        const newSlots = calculateUniqueSlotsByDay(existingSlotsAndNewSlots, existingSlots)
         req.journeyData.createJourney.allSameDaySlots = getAllSameDaySlots(newSlots, activitySchedule)
 
         if (newSlots.length > 0) {

--- a/server/utils/helpers/activityTimeSlotMappers.test.ts
+++ b/server/utils/helpers/activityTimeSlotMappers.test.ts
@@ -4,6 +4,7 @@ import activitySessionToDailyTimeSlots, {
   addNewEmptySlotsIfRequired,
   calculateExclusionSlots,
   calculateUniqueSlots,
+  calculateUniqueSlotsByDay,
   createCustomSlots,
   createSessionSlots,
   createSlot,
@@ -789,6 +790,91 @@ describe('calculateUniqueSlots', () => {
         tuesday: true,
         wednesday: true,
         weekNumber: 2,
+      },
+    ])
+  })
+})
+
+describe('calculateUniqueSlotsByDay', () => {
+  it('should not treat a time-only update as a new slot when the day already exists', () => {
+    const slotsA = [
+      {
+        weekNumber: 1,
+        timeSlot: 'PM',
+        monday: false,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: true,
+        saturday: false,
+        sunday: false,
+        customStartTime: '15:00',
+        customEndTime: '16:45',
+        daysOfWeek: ['FRIDAY'],
+      },
+    ] as Slot[]
+
+    const slotsB = [
+      {
+        weekNumber: 1,
+        timeSlot: 'PM',
+        monday: false,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: true,
+        saturday: false,
+        sunday: false,
+        daysOfWeek: ['FRIDAY'],
+      },
+    ] as Slot[]
+
+    expect(calculateUniqueSlotsByDay(slotsA, slotsB)).toEqual([])
+  })
+
+  it('should only return days that are genuinely new across split existing slots', () => {
+    const slotsA = [
+      {
+        weekNumber: 1,
+        timeSlot: 'PM',
+        monday: true,
+        tuesday: true,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+        daysOfWeek: ['MONDAY', 'TUESDAY'],
+      },
+    ] as Slot[]
+
+    const slotsB = [
+      {
+        weekNumber: 1,
+        timeSlot: 'PM',
+        monday: true,
+        tuesday: false,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+        daysOfWeek: ['MONDAY'],
+      },
+    ] as Slot[]
+
+    expect(calculateUniqueSlotsByDay(slotsA, slotsB)).toEqual([
+      {
+        weekNumber: 1,
+        timeSlot: 'PM',
+        monday: false,
+        tuesday: true,
+        wednesday: false,
+        thursday: false,
+        friday: false,
+        saturday: false,
+        sunday: false,
+        daysOfWeek: ['TUESDAY'],
       },
     ])
   })

--- a/server/utils/helpers/activityTimeSlotMappers.ts
+++ b/server/utils/helpers/activityTimeSlotMappers.ts
@@ -341,6 +341,42 @@ export function calculateUniqueSlots(slotsA: Slot[], slotsB: Slot[]): Slot[] {
     .filter(s => s.daysOfWeek.length > 0)
 }
 
+export function calculateUniqueSlotsByDay(slotsA: Slot[], slotsB: Slot[]): Slot[] {
+  return slotsA
+    .map(slot => {
+      const existingDays = new Set(
+        slotsB
+          .filter(
+            existingSlot => existingSlot.weekNumber === slot.weekNumber && existingSlot.timeSlot === slot.timeSlot,
+          )
+          .flatMap(existingSlot => existingSlot.daysOfWeek),
+      )
+
+      if (existingDays.size === 0) {
+        return slot
+      }
+
+      const daysOfWeek = slot.daysOfWeek.filter(day => !existingDays.has(day))
+
+      if (daysOfWeek.length === 0) {
+        return null
+      }
+
+      return {
+        ...slot,
+        monday: daysOfWeek.includes(DayOfWeekEnum.MONDAY),
+        tuesday: daysOfWeek.includes(DayOfWeekEnum.TUESDAY),
+        wednesday: daysOfWeek.includes(DayOfWeekEnum.WEDNESDAY),
+        thursday: daysOfWeek.includes(DayOfWeekEnum.THURSDAY),
+        friday: daysOfWeek.includes(DayOfWeekEnum.FRIDAY),
+        saturday: daysOfWeek.includes(DayOfWeekEnum.SATURDAY),
+        sunday: daysOfWeek.includes(DayOfWeekEnum.SUNDAY),
+        daysOfWeek,
+      }
+    })
+    .filter(Boolean)
+}
+
 export function calculateExclusionSlots(exclusions: Slot[], updatedExclusions: Slot[]): Slot[] {
   const addedSlots: Slot[] = []
 


### PR DESCRIPTION
calculateUniqueSlots - For each new slot, it looks for only one existing slot with the same week + AM/PM/ED.
If there are multiple existing slots for that same week + AM/PM/ED (for different days), it ignores the others.
So it can accidentally think a day is “new” when it is not.

New approach: For each new slot, it collects all existing slots with the same week + AM/PM/ED and then builds one combined list of all days already present. It removes those days from the new slot. If no days are left, that slot is not new - if some days are left, only those days are treated as new.