### PR TITLE
BAVL-1257 show the probation team name during the BVLS probation amend journey.

### DIFF
--- a/server/views/pages/appointments/video-link-booking/probation/probation-meeting-details.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/probation-meeting-details.njk
@@ -80,6 +80,8 @@
                     ]
                   }) }}
                 {% else %}
+                    <span class="govuk-label govuk-label--s">Probation Team</span>
+                    <p class="govuk-body govuk-!-margin-bottom-6">{{ (probationTeams | find('code', session.bookAProbationMeetingJourney.probationTeamCode)).description }}</p>
                     <input type="hidden" name="probationTeamRequired" value="{{ 'YES' if session.bookAProbationMeetingJourney.probationTeamRequired == true else 'NO' }}">
                     <input type="hidden" name="probationTeamCode" value="{{ session.bookAProbationMeetingJourney.probationTeamCode }}">
                 {% endif %}


### PR DESCRIPTION
**What does this PR do?**

It now shows the name of probation team name (as non-editable text, it cannot be changed) during the probation amend journey.

**Why is this change being made?**

For user clarity and consistency with the related parent BVLS service.

**What has changed?**

A small content change to the meeting details nunjucks template (when editing).

This has been tested running locally.

**The appointment to be changed:**
<img width="1564" height="1374" alt="image" src="https://github.com/user-attachments/assets/21c0a815-00aa-480d-891a-a565d35d7fdd" />

**The amend screen before:**
<img width="1414" height="1484" alt="image" src="https://github.com/user-attachments/assets/291400d7-07ea-41cc-a756-68694e564b26" />

**The amend screen after:**
<img width="1424" height="1630" alt="image" src="https://github.com/user-attachments/assets/91a0dcb7-59de-4f3e-a1f0-d54102664d32" />

