### PR TITLE
Use canonical Maven host for WireMock download

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Get wiremock
         shell: bash
         run: |
-          curl --fail --retry 2 -o wiremock.jar https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
+          curl --fail --retry 2 -o wiremock.jar https://repo.maven.apache.org/maven2/org/wiremock/wiremock-standalone/3.9.1/wiremock-standalone-3.9.1.jar
 
       - name: Prepare and run integration tests
         id: integration-tests


### PR DESCRIPTION
I noticed intermittent issues downloading wiremock with 404 errors returned, using the canonical form of the URL may help reduce this noise. 
