### PR TITLE
BAVL-1257 show the probation team not listed label for team during the BVLS probation amend journey when no team selected.

### DIFF
--- a/server/views/pages/appointments/video-link-booking/probation/probation-meeting-details.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/probation-meeting-details.njk
@@ -81,7 +81,7 @@
                   }) }}
                 {% else %}
                     <span class="govuk-label govuk-label--s">Probation Team</span>
-                    <p class="govuk-body govuk-!-margin-bottom-6">{{ (probationTeams | find('code', session.bookAProbationMeetingJourney.probationTeamCode)).description }}</p>
+                    <p class="govuk-body govuk-!-margin-bottom-6">{{ (probationTeams | find('code', session.bookAProbationMeetingJourney.probationTeamCode)).description or 'Team not listed'}}</p>
                     <input type="hidden" name="probationTeamRequired" value="{{ 'YES' if session.bookAProbationMeetingJourney.probationTeamRequired == true else 'NO' }}">
                     <input type="hidden" name="probationTeamCode" value="{{ session.bookAProbationMeetingJourney.probationTeamCode }}">
                 {% endif %}


### PR DESCRIPTION
Small addition to previous content change [here](https://github.com/ministryofjustice/hmpps-activities-management/pull/2130).  Handle 'Team not listed' probation team choice.

<img width="1600" height="1796" alt="image" src="https://github.com/user-attachments/assets/464da794-cc22-4fe2-b4f3-93433a4b00d3" />

<img width="1234" height="1528" alt="image" src="https://github.com/user-attachments/assets/f6163810-1da8-49ca-9683-78f7c43dd549" />
