### PR TITLE
SAA-4316: Fix unsuspended confirmation banner text

### DIFF
--- a/server/views/pages/activities/suspensions/confirmation.njk
+++ b/server/views/pages/activities/suspensions/confirmation.njk
@@ -9,6 +9,10 @@
 {% set sessionIsPaid = session.suspendJourney.paid == YesNo.YES %}
 {% set allocationCount = session.suspendJourney.allocations | length %}
 
+{% set unsuspendedWarningText %}
+  Unlock and movement lists may need to be printed again if they're due to attend {{ 'this activity' if allocationCount == 1 else 'any of these activities' }} later today.
+{% endset %}
+
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -19,7 +23,7 @@
                         {% if allocationCount == 1 %}
                             {{ session.suspendJourney.allocations[0].activityName | safe }}
                         {% else %}
-                            {{ allocationCount }} activities 
+                            {{ allocationCount }} activities
                         {% endif %}
                         {{ ' with pay' if sessionIsPaid else ' without pay' }}
                     {% endset %}
@@ -46,7 +50,7 @@
                     {% set subText %}
                         {{ session.suspendJourney.inmate.prisonerName | safe }} ({{ session.suspendJourney.inmate.prisonerNumber }}) will be suspended from
                         {% if allocationCount == 1 %}
-                            {{ session.suspendJourney.allocations[0].activityName | safe }} 
+                            {{ session.suspendJourney.allocations[0].activityName | safe }}
                         {% else %}
                             {{ allocationCount }} activities
                         {% endif %}
@@ -81,7 +85,7 @@
                     }) }}
 
                     {{ govukWarningText({
-                        text: "Unlock and movement lists may need to be printed again if they're due to attend {{ 'this activity' if allocationCount == 1 else 'any of these activities' }} later today.",
+                        text: unsuspendedWarningText,
                         iconFallbackText: "Warning"
                     }) }}
                 {% else %}
@@ -114,7 +118,7 @@
                         <li>
                             <a href="/activities/prisoner-allocations/{{ session.suspendJourney.inmate.prisonerNumber }}" class='govuk-link govuk-link--no-visited-state'>check and manage {{ session.suspendJourney.inmate.prisonerName | safe }}'s allocations</a>
                         </li>
-                        <li> 
+                        <li>
                             <a href="/activities/suspensions/prisoner/{{ session.suspendJourney.inmate.prisonerNumber }}" class='govuk-link govuk-link--no-visited-state'>manage {{ session.suspendJourney.inmate.prisonerName | safe }}'s suspensions</a>
                         </li>
                         <li>


### PR DESCRIPTION
Tweaked nunjucks file to set the conditional check as a variable at the start of the template as it was being rendered verbatim

| Before | After |
| -------- | ------- |
| <img width="300" height="150" alt="Screenshot 2026-05-11 at 18 19 59" src="https://github.com/user-attachments/assets/fb619d9c-713f-43fc-bc30-87448e7c27e7" />  | <img width="300" height="150" alt="Screenshot 2026-05-11 at 18 19 20" src="https://github.com/user-attachments/assets/d5786d85-f43a-4636-96d6-4bbfc987cf94" /> |




