### PR TITLE
SAA-4300: Add renderPayHistory macro for attendance history to account for outside work

### DIFF
--- a/integration_tests/e2e/activities/attendance/attendanceNotRequired.cy.ts
+++ b/integration_tests/e2e/activities/attendance/attendanceNotRequired.cy.ts
@@ -70,7 +70,13 @@ context('Attendance not required', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.selectActivityWithName('Football')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)

--- a/integration_tests/e2e/activities/attendance/attendanceNotRequired.cy.ts
+++ b/integration_tests/e2e/activities/attendance/attendanceNotRequired.cy.ts
@@ -70,7 +70,7 @@ context('Attendance not required', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1')
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
     activitiesPage.selectActivityWithName('Football')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)

--- a/integration_tests/e2e/activities/attendance/multipleActivities.cy.ts
+++ b/integration_tests/e2e/activities/attendance/multipleActivities.cy.ts
@@ -86,7 +86,14 @@ context('Record attendance', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Gym', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Gym',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.selectActivitiesWithNames('English level 1', 'English level 2')
     activitiesPage.getButton('Record or edit attendance').click()
 
@@ -292,7 +299,13 @@ context('Record attendance', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.selectActivitiesWithNames('English level 1')
     activitiesPage.getButton('Record or edit attendance').click()
 

--- a/integration_tests/e2e/activities/attendance/multipleActivities.cy.ts
+++ b/integration_tests/e2e/activities/attendance/multipleActivities.cy.ts
@@ -86,7 +86,7 @@ context('Record attendance', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Gym', 'Maths level 1')
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Gym', 'Maths level 1', 'Outside Prison Shop')
     activitiesPage.selectActivitiesWithNames('English level 1', 'English level 2')
     activitiesPage.getButton('Record or edit attendance').click()
 
@@ -292,7 +292,7 @@ context('Record attendance', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1')
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
     activitiesPage.selectActivitiesWithNames('English level 1')
     activitiesPage.getButton('Record or edit attendance').click()
 

--- a/integration_tests/e2e/activities/attendance/recordAttendance_activityHubUsers.cy.ts
+++ b/integration_tests/e2e/activities/attendance/recordAttendance_activityHubUsers.cy.ts
@@ -142,7 +142,13 @@ context('Record attendance for activity hub users', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.back()
 
     Page.verifyOnPage(SelectPeriodPage)

--- a/integration_tests/e2e/activities/attendance/recordAttendance_activityHubUsers.cy.ts
+++ b/integration_tests/e2e/activities/attendance/recordAttendance_activityHubUsers.cy.ts
@@ -156,7 +156,14 @@ context('Record attendance for activity hub users', () => {
     selectPeriodPage.selectPM()
     selectPeriodPage.continue()
 
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Gym', 'Maths level 1')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Gym',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.selectActivityWithName('English level 1')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)

--- a/integration_tests/e2e/activities/attendance/recordAttendance_activityHubUsers.cy.ts
+++ b/integration_tests/e2e/activities/attendance/recordAttendance_activityHubUsers.cy.ts
@@ -142,7 +142,7 @@ context('Record attendance for activity hub users', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1')
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
     activitiesPage.back()
 
     Page.verifyOnPage(SelectPeriodPage)

--- a/integration_tests/e2e/activities/attendance/recordNonAttendance.cy.ts
+++ b/integration_tests/e2e/activities/attendance/recordNonAttendance.cy.ts
@@ -50,7 +50,7 @@ context('Record non attendance', () => {
     )
   })
 
-  it('should click through record non attendance journey', () => {
+  it('should click through record non attendance journey and SHOULD display sick pay radios for prison work', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.activitiesCard().click()
 
@@ -70,7 +70,7 @@ context('Record non attendance', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1')
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
     activitiesPage.selectActivityWithName('English level 1')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)
@@ -88,7 +88,7 @@ context('Record non attendance', () => {
     Page.verifyOnPage(AttendanceListPage)
   })
 
-  it.only('should click through record non attendance journey', () => {
+  it('should click through record non attendance journey and should NOT display sick pay options for outside work ', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.activitiesCard().click()
 
@@ -134,7 +134,6 @@ context('Record non attendance', () => {
     notAttendedReasonPage.selectRadio('notAttendedData[0][notAttendedReason]')
     cy.get(`#notAttendedData-0-sickPay`).should('not.exist')
     cy.get(`#notAttendedData-0-notAttendedReason-4`).click()
-
     cy.get(`#notAttendedData-0-restPay`).should('not.exist')
     cy.get(`#notAttendedData-0-category-4`).should('not.exist')
     notAttendedReasonPage.submit()

--- a/integration_tests/e2e/activities/attendance/recordNonAttendance.cy.ts
+++ b/integration_tests/e2e/activities/attendance/recordNonAttendance.cy.ts
@@ -70,7 +70,13 @@ context('Record non attendance', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.selectActivityWithName('English level 1')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)
@@ -92,7 +98,6 @@ context('Record non attendance', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.activitiesCard().click()
 
-
     const activitiesIndexPage = Page.verifyOnPage(ActivitiesIndexPage)
     activitiesIndexPage.recordAttendanceCard().click()
 
@@ -109,7 +114,13 @@ context('Record non attendance', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.selectActivityWithName('Outside Prison Shop')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)
@@ -124,11 +135,7 @@ context('Record non attendance', () => {
       })),
     }
 
-    cy.stubEndpoint(
-      'GET',
-      '/scheduled-instances/100',
-      outsideWorkInstance,
-    )
+    cy.stubEndpoint('GET', '/scheduled-instances/100', outsideWorkInstance)
 
     const notAttendedReasonPage = Page.verifyOnPage(NotAttendedReasonPage)
     notAttendedReasonPage.selectRadio('notAttendedData[0][notAttendedReason]')

--- a/integration_tests/e2e/activities/attendance/recordNonAttendance.cy.ts
+++ b/integration_tests/e2e/activities/attendance/recordNonAttendance.cy.ts
@@ -5,6 +5,7 @@ import ActivitiesPage from '../../../pages/recordAttendance/activitiesPage'
 import AttendanceListPage from '../../../pages/recordAttendance/attendanceList'
 import getAttendanceReasons from '../../../fixtures/activitiesApi/getAttendanceReasons.json'
 import getScheduledInstance from '../../../fixtures/activitiesApi/getScheduledInstance93.json'
+import getScheduledOutsideWorkInstance from '../../../fixtures/activitiesApi/getScheduledInstance100.json'
 import getAttendeesForScheduledInstance from '../../../fixtures/activitiesApi/getAttendeesScheduledInstance93.json'
 import getScheduledEvents from '../../../fixtures/activitiesApi/getScheduledEventsMdi20230202.json'
 import getInmateDetails from '../../../fixtures/prisonerSearchApi/getInmateDetailsForNonAttendance.json'
@@ -27,9 +28,17 @@ context('Record non attendance', () => {
       `/scheduled-instances/attendance-summary\\?prisonCode=MDI&date=2023-02-02`,
       getAttendanceSummary,
     )
+    cy.stubEndpoint(
+      'GET',
+      `/scheduled-instances/attendance-summary\\?prisonCode=MDI&date=2023-04-04`,
+      getAttendanceSummary,
+    )
     cy.stubEndpoint('GET', '/scheduled-instances/93', getScheduledInstance)
+    cy.stubEndpoint('GET', '/scheduled-instances/100', getScheduledOutsideWorkInstance)
     cy.stubEndpoint('GET', '/scheduled-instances/93/scheduled-attendees', getAttendeesForScheduledInstance)
+    cy.stubEndpoint('GET', '/scheduled-instances/100/scheduled-attendees', getAttendeesForScheduledInstance)
     cy.stubEndpoint('POST', '/scheduled-events/prison/MDI\\?date=2023-02-02', getScheduledEvents)
+    cy.stubEndpoint('POST', '/scheduled-events/prison/MDI\\?date=2023-04-04', getScheduledEvents)
     cy.stubEndpoint('POST', '/prisoner-search/prisoner-numbers', getInmateDetails)
     cy.stubEndpoint('PUT', '/attendances')
     cy.stubEndpoint('GET', '/attendance-reasons', getAttendanceReasons)
@@ -77,5 +86,60 @@ context('Record non attendance', () => {
     notAttendedReasonPage.submit()
 
     Page.verifyOnPage(AttendanceListPage)
+  })
+
+  it.only('should click through record non attendance journey', () => {
+    const indexPage = Page.verifyOnPage(IndexPage)
+    indexPage.activitiesCard().click()
+
+
+    const activitiesIndexPage = Page.verifyOnPage(ActivitiesIndexPage)
+    activitiesIndexPage.recordAttendanceCard().click()
+
+    const recordAttendancePage = Page.verifyOnPage(AttendanceDashboardPage)
+    recordAttendancePage.recordAttendanceCard().click()
+
+    const howToRecordAttendancePage = Page.verifyOnPage(HowToRecordAttendancePage)
+    howToRecordAttendancePage.radioActivityClick().click()
+    howToRecordAttendancePage.continue()
+
+    const selectPeriodPage = Page.verifyOnPage(SelectPeriodPage)
+    selectPeriodPage.enterDate(new Date(2023, 1, 2))
+    selectPeriodPage.selectAM()
+    selectPeriodPage.continue()
+
+    const activitiesPage = Page.verifyOnPage(ActivitiesPage)
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.selectActivityWithName('Outside Prison Shop')
+
+    const attendanceListPage = Page.verifyOnPage(AttendanceListPage)
+    attendanceListPage.selectPrisoner('Arianniver, Eeteljan')
+    attendanceListPage.markAsNotAttended()
+
+    const outsideWorkInstance = {
+      ...getScheduledOutsideWorkInstance,
+      attendances: getScheduledOutsideWorkInstance.attendances.map(attendance => ({
+        ...attendance,
+        status: 'COMPLETED',
+      })),
+    }
+
+    cy.stubEndpoint(
+      'GET',
+      '/scheduled-instances/100',
+      outsideWorkInstance,
+    )
+
+    const notAttendedReasonPage = Page.verifyOnPage(NotAttendedReasonPage)
+    notAttendedReasonPage.selectRadio('notAttendedData[0][notAttendedReason]')
+    cy.get(`#notAttendedData-0-sickPay`).should('not.exist')
+    cy.get(`#notAttendedData-0-notAttendedReason-4`).click()
+
+    cy.get(`#notAttendedData-0-restPay`).should('not.exist')
+    cy.get(`#notAttendedData-0-category-4`).should('not.exist')
+    notAttendedReasonPage.submit()
+
+    Page.verifyOnPage(AttendanceListPage)
+    attendanceListPage.checkAttendanceStatuses('Arianniver, Eeteljan', 'Sick', 'Employer-paid')
   })
 })

--- a/integration_tests/e2e/activities/attendance/recordNonAttendance.cy.ts
+++ b/integration_tests/e2e/activities/attendance/recordNonAttendance.cy.ts
@@ -28,11 +28,6 @@ context('Record non attendance', () => {
       `/scheduled-instances/attendance-summary\\?prisonCode=MDI&date=2023-02-02`,
       getAttendanceSummary,
     )
-    cy.stubEndpoint(
-      'GET',
-      `/scheduled-instances/attendance-summary\\?prisonCode=MDI&date=2023-04-04`,
-      getAttendanceSummary,
-    )
     cy.stubEndpoint('GET', '/scheduled-instances/93', getScheduledInstance)
     cy.stubEndpoint('GET', '/scheduled-instances/100', getScheduledOutsideWorkInstance)
     cy.stubEndpoint('GET', '/scheduled-instances/93/scheduled-attendees', getAttendeesForScheduledInstance)
@@ -94,7 +89,7 @@ context('Record non attendance', () => {
     Page.verifyOnPage(AttendanceListPage)
   })
 
-  it('should click through record non attendance journey and should NOT display sick pay options for outside work ', () => {
+  it('should click through record non attendance journey and should NOT display sick pay options for outside work', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
     indexPage.activitiesCard().click()
 

--- a/integration_tests/e2e/activities/attendance/setPrisonersToNotRequired.cy.ts
+++ b/integration_tests/e2e/activities/attendance/setPrisonersToNotRequired.cy.ts
@@ -85,7 +85,13 @@ context('Exclude multiple prisoners from an activity', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.selectActivityWithName('English level 2')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)
@@ -133,7 +139,13 @@ context('Exclude multiple prisoners from an activity', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
+    activitiesPage.containsActivities(
+      'English level 1',
+      'English level 2',
+      'Football',
+      'Maths level 1',
+      'Outside Prison Shop',
+    )
     activitiesPage.selectActivityWithName('English level 2')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)

--- a/integration_tests/e2e/activities/attendance/setPrisonersToNotRequired.cy.ts
+++ b/integration_tests/e2e/activities/attendance/setPrisonersToNotRequired.cy.ts
@@ -85,7 +85,7 @@ context('Exclude multiple prisoners from an activity', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1')
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
     activitiesPage.selectActivityWithName('English level 2')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)
@@ -133,7 +133,7 @@ context('Exclude multiple prisoners from an activity', () => {
     selectPeriodPage.continue()
 
     const activitiesPage = Page.verifyOnPage(ActivitiesPage)
-    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1')
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Football', 'Maths level 1', 'Outside Prison Shop')
     activitiesPage.selectActivityWithName('English level 2')
 
     const attendanceListPage = Page.verifyOnPage(AttendanceListPage)

--- a/integration_tests/fixtures/activitiesApi/getAttendanceSummary.json
+++ b/integration_tests/fixtures/activitiesApi/getAttendanceSummary.json
@@ -139,5 +139,30 @@
       "absences": 1,
       "paid": 2
     }
+  },
+  {
+    "scheduledInstanceId": 100,
+    "activityId": 100,
+    "activityScheduleId": 100,
+    "summary": "Outside Prison Shop",
+    "categoryId": 2,
+    "sessionDate": "2024-04-04",
+    "startTime": "09:00",
+    "endTime": "10:00",
+    "timeSlot": "AM",
+    "inCell": false,
+    "onWing": false,
+    "offWing": false,
+    "outsideWork": true,
+    "attendanceRequired": true,
+    "cancelled": false,
+    "attendanceSummary": {
+      "allocations": 5,
+      "attendees": 4,
+      "notRecorded": 0,
+      "attended": 2,
+      "absences": 1,
+      "paid": 2
+    }
   }
 ]

--- a/integration_tests/fixtures/activitiesApi/getScheduledEventsMdi20230202.json
+++ b/integration_tests/fixtures/activitiesApi/getScheduledEventsMdi20230202.json
@@ -217,7 +217,7 @@
       "categoryCode": "OUTSIDE_WORK",
       "categoryDescription": "Outside Work",
       "summary": "Outside work",
-      "date": "2023-04-04",
+      "date": "2023-02-02",
       "startTime": "19:00",
       "endTime": "20:00",
       "priority": 5,

--- a/integration_tests/fixtures/activitiesApi/getScheduledEventsMdi20230202.json
+++ b/integration_tests/fixtures/activitiesApi/getScheduledEventsMdi20230202.json
@@ -206,6 +206,23 @@
       "startTime": "19:00",
       "endTime": "20:00",
       "priority": 5
+    },
+    {
+      "eventSource": "SAA",
+      "eventType": "ACTIVITY",
+      "prisonCode": "MDI",
+      "scheduledInstanceId": 100,
+      "bookingId": 1151729,
+      "prisonerNumber": "G7218GI",
+      "categoryCode": "OUTSIDE_WORK",
+      "categoryDescription": "Outside Work",
+      "summary": "Outside work",
+      "date": "2023-04-04",
+      "startTime": "19:00",
+      "endTime": "20:00",
+      "priority": 5,
+      "paidActivity": false,
+      "issuePayment": null
     }
   ],
   "externalTransfers": [],

--- a/integration_tests/fixtures/activitiesApi/getScheduledInstance100.json
+++ b/integration_tests/fixtures/activitiesApi/getScheduledInstance100.json
@@ -1,0 +1,76 @@
+{
+  "id": 100,
+  "date": "2023-04-04",
+  "startTime": "14:00",
+  "endTime": "15:00",
+  "timeSlot": "PM",
+  "cancelled": false,
+  "cancelledTime": null,
+  "cancelledBy": null,
+  "attendances": [
+    {
+      "id": 2,
+      "prisonerNumber": "G5897GP",
+      "attendanceReason": { "code": "SICK" },
+      "comment": null,
+      "posted": false,
+      "recordedTime": null,
+      "recordedBy": null,
+      "status": "WAITING",
+      "payAmount": null,
+      "bonusAmount": null,
+      "pieces": null,
+      "issuePayment": true,
+      "editable": true
+    },
+    {
+      "id": 5,
+      "prisonerNumber": "G7218GI",
+      "attendanceReason": { "code": "SICK" },
+      "comment": null,
+      "posted": false,
+      "recordedTime": null,
+      "recordedBy": null,
+      "status": "WAITING",
+      "payAmount": null,
+      "bonusAmount": null,
+      "pieces": null,
+      "issuePayment": true,
+      "editable": true
+    }
+  ],
+  "activitySchedule": {
+    "id": 8,
+    "description": "Outside Prison Shop",
+    "capacity": 10,
+    "activity": {
+      "id": 3,
+      "prisonCode": "MDI",
+      "attendanceRequired": true,
+      "inCell": false,
+      "pieceWork": false,
+      "outsideWork": true,
+      "summary": "Outside Prison Shop",
+      "description": "An externally run activity where prisoners work outside a prison boundary. Not paid by Prison",
+      "category": {
+        "id": 1,
+        "code": "Work",
+        "name": "Work",
+        "description": "Outside Work"
+      },
+      "riskLevel": null,
+      "paid": false
+    },
+    "slots": [
+      {
+        "id": 10,
+        "startTime": "14:00",
+        "endTime": "15:00",
+        "daysOfWeek": ["Thu"],
+        "timeSlot": "PM"
+      }
+    ],
+    "startDate": "2023-04-04",
+    "endDate": null
+  }
+}

--- a/server/views/pages/activities/record-attendance/attendance-details.njk
+++ b/server/views/pages/activities/record-attendance/attendance-details.njk
@@ -9,7 +9,7 @@
 {% set jsBackLink = true %}
 
 {% set outsideWork = instance.activitySchedule.activity.outsideWork %}
-{% set caseNoteHref %} 
+{% set caseNoteHref %}
     <p>
         <a href='{{ dpsUrl }}/prisoner/{{ attendee.prisonerNumber }}/case-notes' class='govuk-link govuk-link--no-visited-state' target='_blank' rel='noopener noreferrer'>
             Go to {{ attendee.name | toTitleCase | possessive }} case notes to add more details (opens in new tab)
@@ -28,6 +28,16 @@
         {% else %}
             Unpaid
         {% endif %}
+    {% endif %}
+{% endmacro %}
+
+{% macro renderPayHistory(attendance, payable, history) %}
+    {% if outsideWork and not payable %}
+      Managed by an external employer
+    {% elseif history.issuePayment %}
+      ('£' + (attendance.payAmount / 100) | toFixed)
+    {% else %}
+      None
     {% endif %}
 {% endmacro %}
 
@@ -156,7 +166,7 @@
                 <h1 class="govuk-heading-l">Attendance record for {{ attendee.name | toTitleCase }}</h1>
                 <div class="govuk-inset-text">
                     <a href="../attendance-list" class="govuk-link govuk-link--no-visited-state">{{ instance.activitySchedule.activity.summary }}</a>
-                    on {{ instance.date | toDate | formatDate('d MMMM yyyy') }} ({{ instance.timeSlot }}) 
+                    on {{ instance.date | toDate | formatDate('d MMMM yyyy') }} ({{ instance.timeSlot }})
                </div>
                {% if attendance.status === 'WAITING' %}
                    <h2 class="govuk-heading-m">Attendance record reset</h2>
@@ -226,7 +236,7 @@
                                 key: {
                                     text: "Pay"
                                 },
-                                value: { text: ('£' + (attendance.payAmount / 100) | toFixed) if attendanceHistory.issuePayment else 'None' }
+                                value: { text: renderPay(attendance, activity.paid, attendanceHistory) }
                             }
                         ), historyListRows) %}
 

--- a/server/views/pages/activities/record-attendance/attendance-details.njk
+++ b/server/views/pages/activities/record-attendance/attendance-details.njk
@@ -31,13 +31,15 @@
     {% endif %}
 {% endmacro %}
 
-{% macro renderPayHistory(attendance, payable, history) %}
+{% macro renderPayHistory(attendance, payable, attendanceHistory) %}
     {% if outsideWork and not payable %}
       Managed by an external employer
-    {% elseif history.issuePayment %}
-      ('£' + (attendance.payAmount / 100) | toFixed)
     {% else %}
-      None
+        {% if attendanceHistory.issuePayment %}
+            {{ '£' + (attendance.payAmount / 100) | toFixed }}
+        {% else %}
+            None
+        {% endif %}
     {% endif %}
 {% endmacro %}
 
@@ -187,6 +189,13 @@
                     </div>
                 {% endif %}
 
+              {% if attendance.issuePayment and attendance.attendanceReason.code == 'ATTENDED' and attendance.editable %}
+                {{ govukButton({
+                  text: "Remove pay and add case note",
+                  classes: "govuk-button--warning"
+                }) }}
+              {% endif %}
+
                 {% if attendance.attendanceHistory | length %}
                     <h2 class="govuk-heading-m" data-qa="history-heading">Change history for this attendance record</h2>
                     {% set changeNo = attendance.attendanceHistory | length %}
@@ -236,7 +245,7 @@
                                 key: {
                                     text: "Pay"
                                 },
-                                value: { text: renderPay(attendance, activity.paid, attendanceHistory) }
+                                value: { text: renderPayHistory(attendance, activity.paid, attendanceHistory) }
                             }
                         ), historyListRows) %}
 
@@ -301,13 +310,6 @@
 
                         {% set changeNo = changeNo - 1 %}
                     {% endfor %}
-                {% endif %}
-
-                {% if attendance.issuePayment and attendance.attendanceReason.code == 'ATTENDED' and attendance.editable %}
-                    {{ govukButton({
-                        text: "Remove pay and add case note",
-                        classes: "govuk-button--warning"
-                    }) }}
                 {% endif %}
 
                 {% if attendee.prisonId == user.activeCaseLoadId %}

--- a/server/views/pages/activities/record-attendance/attendance-list-single.njk
+++ b/server/views/pages/activities/record-attendance/attendance-list-single.njk
@@ -45,7 +45,7 @@
                     <p class="govuk-body govuk-!-margin-top-4">
                         <a href='../cancel-multiple/view-edit-details/{{instance.id}}' class="govuk-link">View or edit cancellation</a>
                         {% if instance.isAmendable %}
-                        or 
+                        or
                         <a href="uncancel" class="govuk-link">uncancel this session</a>
                         {% endif %}
                     </p>
@@ -182,8 +182,8 @@
         {% set attendanceTagDetails %}
             {% if attendee.advancedAttendance %}
                 {{ attendanceTag('COMPLETED', 'NOT_REQUIRED', instance.activitySchedule.activity.attendanceRequired) }}
-                {{ payStatus( 
-                    { 
+                {{ payStatus(
+                    {
                         dataPresentCheck: attendee.advancedAttendance,
                         status: 'COMPLETED',
                         payable: isPayable,
@@ -193,8 +193,8 @@
                     }) }}
             {% else %}
                 {{ attendanceTag(attendee.attendance.status, attendee.attendance.attendanceReason.code, instance.activitySchedule.activity.attendanceRequired) }}
-                {{ payStatus( 
-                    { 
+                {{ payStatus(
+                    {
                         dataPresentCheck: attendee.attendance,
                         status: attendee.attendance.status,
                         payable: isPayable,


### PR DESCRIPTION
**Logic**
- Adding the `renderPayHistory` macro for rendering different text depending on outside work / payment issued / anything else. 

**Tests**
- Outside prison shop added to cypress fixtures
- Checking that we do NOT display sick pay options when marking outside work as not attended 

**Other**
- Moved the remove pay button further up the attendance details page. 