### PR TITLE
BAVL-1339 changed capture of probation officer details from checkbox to conditional radio.

### DIFF
--- a/integration_tests/e2e/appointments/createVideoLinkProbationMeeting.cy.ts
+++ b/integration_tests/e2e/appointments/createVideoLinkProbationMeeting.cy.ts
@@ -144,7 +144,7 @@ context('Create video link probation appointment', () => {
     meetingDetailsPage.selectYesToProbationTeamKnown()
     meetingDetailsPage.selectProbationTeam('Barking - Probation')
     meetingDetailsPage.selectRadioFirstMeetingType()
-    meetingDetailsPage.checkOfficerDetailsNotKnown()
+    meetingDetailsPage.selectNoToProbationOfficerDetailsKnown()
     meetingDetailsPage.continue()
 
     // Date and time of meeting page
@@ -237,7 +237,7 @@ context('Create video link probation appointment', () => {
     meetingDetailsPage.selectYesToProbationTeamKnown()
     meetingDetailsPage.selectProbationTeam('Barking - Probation')
     meetingDetailsPage.selectMeetingType('Other')
-    meetingDetailsPage.checkOfficerDetailsNotKnown()
+    meetingDetailsPage.selectNoToProbationOfficerDetailsKnown()
     meetingDetailsPage.continue()
 
     // Date and time of meeting page

--- a/integration_tests/pages/appointments/create-and-edit/video-link-booking/probationMeetingDetailsPage.ts
+++ b/integration_tests/pages/appointments/create-and-edit/video-link-booking/probationMeetingDetailsPage.ts
@@ -13,5 +13,5 @@ export default class ProbationMeetingDetailsPage extends Page {
 
   selectRadioFirstMeetingType = () => this.getInputById('meetingTypeCode').click()
 
-  checkOfficerDetailsNotKnown = () => this.getInputByName('officerDetailsNotKnown').check()
+  selectNoToProbationOfficerDetailsKnown = () => this.getInputById('probationOfficerDetailsKnown-2').click()
 }

--- a/server/routes/appointments/video-link-booking/probation/handlers/probationMeetingDetails.test.ts
+++ b/server/routes/appointments/video-link-booking/probation/handlers/probationMeetingDetails.test.ts
@@ -91,7 +91,7 @@ describe('MeetingDetailsRoutes', () => {
       const body = {
         probationTeamCode: '',
         meetingTypeCode: '',
-        officerDetailsNotKnown: '',
+        probationOfficerDetailsKnown: '',
         officerFullName: '',
         officerEmail: '',
         officerTelephone: '',
@@ -112,8 +112,8 @@ describe('MeetingDetailsRoutes', () => {
           property: 'meetingTypeCode',
         },
         {
-          error: "Enter the probation officer's details",
-          property: 'officerDetailsOrUnknown',
+          error: 'Select if you know the details of the probation officer',
+          property: 'probationOfficerDetailsKnown',
         },
       ])
     })
@@ -122,10 +122,7 @@ describe('MeetingDetailsRoutes', () => {
       const body = {
         probationTeamRequired: 'YES',
         meetingTypeCode: 'code',
-        officerDetailsNotKnown: 'true',
-        officerFullName: '',
-        officerEmail: '',
-        officerTelephone: '',
+        probationOfficerDetailsKnown: 'NO',
       }
 
       const requestObject = plainToInstance(ProbationMeetingDetails, body)
@@ -141,15 +138,12 @@ describe('MeetingDetailsRoutes', () => {
       ])
     })
 
-    it('validation fails for an empty email', async () => {
+    it('validation fails for an empty probation officer details', async () => {
       const body = {
         probationTeamRequired: 'NO',
         probationTeamCode: 'code',
         meetingTypeCode: 'code',
-        officerDetailsNotKnown: '',
-        officerFullName: 'Joe Bloggs',
-        officerEmail: '',
-        officerTelephone: '',
+        probationOfficerDetailsKnown: 'YES',
       }
 
       const requestObject = plainToInstance(ProbationMeetingDetails, body)
@@ -158,6 +152,10 @@ describe('MeetingDetailsRoutes', () => {
       )
 
       expect(errors).toEqual([
+        {
+          error: "Enter the probation officer's full name",
+          property: 'officerFullName',
+        },
         {
           error: "Enter the probation officer's email address",
           property: 'officerEmail',
@@ -170,10 +168,9 @@ describe('MeetingDetailsRoutes', () => {
         probationTeamRequired: 'NO',
         probationTeamCode: 'code',
         meetingTypeCode: 'code',
-        officerDetailsNotKnown: '',
+        probationOfficerDetailsKnown: 'YES',
         officerFullName: 'Joe Bloggs',
         officerEmail: 'invalid',
-        officerTelephone: '',
       }
 
       const requestObject = plainToInstance(ProbationMeetingDetails, body)
@@ -194,7 +191,7 @@ describe('MeetingDetailsRoutes', () => {
         probationTeamRequired: 'NO',
         probationTeamCode: 'code',
         meetingTypeCode: 'code',
-        officerDetailsNotKnown: '',
+        probationOfficerDetailsKnown: 'YES',
         officerFullName: 'Joe Bloggs',
         officerEmail: 'test@gmail.com',
         officerTelephone: 'invalid',
@@ -209,30 +206,6 @@ describe('MeetingDetailsRoutes', () => {
         {
           error: 'Enter a valid UK phone number',
           property: 'officerTelephone',
-        },
-      ])
-    })
-
-    it('validation fails for both details entered and not known selected', async () => {
-      const body = {
-        probationTeamRequired: 'NO',
-        probationTeamCode: 'code',
-        meetingTypeCode: 'code',
-        officerDetailsNotKnown: 'true',
-        officerFullName: 'Joe Bloggs',
-        officerEmail: 'test@gmail.com',
-        officerTelephone: '',
-      }
-
-      const requestObject = plainToInstance(ProbationMeetingDetails, body)
-      const errors = await validate(requestObject, { stopAtFirstError: true }).then(errs =>
-        errs.flatMap(associateErrorsWithProperty),
-      )
-
-      expect(errors).toEqual([
-        {
-          error: "Enter either the probation officer's details, or select 'Not yet known'",
-          property: 'officerDetailsOrUnknown',
         },
       ])
     })

--- a/server/routes/appointments/video-link-booking/probation/handlers/probationMeetingDetails.ts
+++ b/server/routes/appointments/video-link-booking/probation/handlers/probationMeetingDetails.ts
@@ -1,10 +1,11 @@
 import { Request, Response } from 'express'
 import { Expose, Transform } from 'class-transformer'
-import { Equals, IsEmail, IsEnum, IsNotEmpty, IsOptional, IsPhoneNumber, ValidateIf } from 'class-validator'
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, ValidateIf } from 'class-validator'
 import { parsePhoneNumberWithError } from 'libphonenumber-js'
 import BookAVideoLinkService from '../../../../../services/bookAVideoLinkService'
 import ProbationBookingService from '../../../../../services/probationBookingService'
 import { YesNo } from '../../../../../@types/activities'
+import IsValidUkPhoneNumber from '../../../../../validators/isValidUkPhoneNumber'
 
 export class ProbationMeetingDetails {
   @Expose()
@@ -22,35 +23,29 @@ export class ProbationMeetingDetails {
   meetingTypeCode: string
 
   @Expose()
-  @Transform(({ obj }) =>
-    !obj.officerDetailsNotKnown && !obj.officerFullName && !obj.officerEmail && !obj.officerTelephone
-      ? null
-      : !!obj.officerDetailsNotKnown !== !!(obj.officerFullName || obj.officerEmail || obj.officerTelephone),
-  )
-  @Equals(true, { message: `Enter either the probation officer's details, or select 'Not yet known'` })
-  @IsNotEmpty({ message: "Enter the probation officer's details" })
-  officerDetailsOrUnknown: boolean
+  @IsEnum(YesNo, { message: 'Select if you know the details of the probation officer' })
+  probationOfficerDetailsKnown: string
 
   @Expose()
-  @Transform(({ value }) => value === 'true')
-  officerDetailsNotKnown: boolean
-
-  @Expose()
-  @ValidateIf(o => o.officerDetailsOrUnknown && !o.officerDetailsNotKnown)
+  @Transform(({ value, obj }) => (obj.probationOfficerDetailsKnown === YesNo.YES ? value : undefined))
+  @ValidateIf(o => o.probationOfficerDetailsKnown === YesNo.YES)
   @IsNotEmpty({ message: `Enter the probation officer's full name` })
   officerFullName: string
 
   @Expose()
-  @ValidateIf(o => o.officerDetailsOrUnknown && !o.officerDetailsNotKnown)
+  @Transform(({ value, obj }) => (obj.probationOfficerDetailsKnown === YesNo.YES ? value : undefined))
+  @ValidateIf(o => o.probationOfficerDetailsKnown === YesNo.YES)
   @IsEmail({}, { message: 'Enter a valid email address' })
   @IsNotEmpty({ message: `Enter the probation officer's email address` })
   officerEmail: string
 
   @Expose()
-  @Transform(({ value }) => (value.trim() === '' ? undefined : value))
-  @ValidateIf(o => o.officerDetailsOrUnknown && !o.officerDetailsNotKnown)
+  @Transform(({ value, obj }) =>
+    value && value.trim() !== '' && obj.probationOfficerDetailsKnown === YesNo.YES ? value : undefined,
+  )
+  @ValidateIf(o => o.probationOfficerDetailsKnown === YesNo.YES)
   @IsOptional()
-  @IsPhoneNumber('GB', { message: 'Enter a valid UK phone number' })
+  @IsValidUkPhoneNumber({ message: 'Enter a valid UK phone number' })
   officerTelephone: string
 }
 
@@ -80,7 +75,7 @@ export default class ProbationMeetingDetailsRoutes {
       probationTeamRequired,
       probationTeamCode,
       meetingTypeCode,
-      officerDetailsNotKnown,
+      probationOfficerDetailsKnown,
       officerFullName,
       officerEmail,
       officerTelephone,
@@ -93,16 +88,17 @@ export default class ProbationMeetingDetailsRoutes {
       probationTeamRequired: probationTeamRequired === YesNo.YES,
       probationTeamCode: probationTeamRequired === YesNo.YES ? probationTeamCode : 'TEAM_NOT_LISTED',
       meetingTypeCode,
-      officerDetailsNotKnown,
-      officer: officerDetailsNotKnown
-        ? undefined
-        : {
-            fullName: officerFullName,
-            email: officerEmail,
-            telephone: officerTelephone
-              ? parsePhoneNumberWithError(officerTelephone, 'GB').formatNational()
-              : undefined,
-          },
+      probationOfficerDetailsKnown: probationOfficerDetailsKnown === YesNo.YES,
+      officer:
+        probationOfficerDetailsKnown === YesNo.YES
+          ? {
+              fullName: officerFullName,
+              email: officerEmail,
+              telephone: officerTelephone
+                ? parsePhoneNumberWithError(officerTelephone, 'GB').formatNational()
+                : undefined,
+            }
+          : undefined,
     }
 
     if (mode === 'amend') {

--- a/server/routes/appointments/video-link-booking/probation/journey.ts
+++ b/server/routes/appointments/video-link-booking/probation/journey.ts
@@ -10,7 +10,6 @@ export type BookAProbationMeetingJourney = {
   probationTeamRequired?: boolean
   probationTeamCode?: string
   meetingTypeCode?: string
-  officerDetailsNotKnown?: boolean
   probationOfficerDetailsKnown?: boolean
   officer?: {
     fullName: string

--- a/server/routes/appointments/video-link-booking/probation/journey.ts
+++ b/server/routes/appointments/video-link-booking/probation/journey.ts
@@ -11,6 +11,7 @@ export type BookAProbationMeetingJourney = {
   probationTeamCode?: string
   meetingTypeCode?: string
   officerDetailsNotKnown?: boolean
+  probationOfficerDetailsKnown?: boolean
   officer?: {
     fullName: string
     email: string

--- a/server/routes/appointments/video-link-booking/probation/middleware/initialiseJourney.ts
+++ b/server/routes/appointments/video-link-booking/probation/middleware/initialiseJourney.ts
@@ -69,13 +69,15 @@ export default ({
       probationTeamCode: booking.probationTeamCode,
       meetingTypeCode: booking.probationMeetingType,
       officerDetailsNotKnown: booking.additionalBookingDetails?.contactName === undefined,
-      officer: booking.additionalBookingDetails?.contactName
-        ? {
-            fullName: booking.additionalBookingDetails?.contactName,
-            email: booking.additionalBookingDetails?.contactEmail,
-            telephone: booking.additionalBookingDetails?.contactNumber,
-          }
-        : undefined,
+      probationOfficerDetailsKnown: booking.additionalBookingDetails?.contactName === undefined,
+      officer:
+        booking.additionalBookingDetails?.contactName !== undefined
+          ? {
+              fullName: booking.additionalBookingDetails?.contactName,
+              email: booking.additionalBookingDetails?.contactEmail,
+              telephone: booking.additionalBookingDetails?.contactNumber,
+            }
+          : undefined,
       date: parseDateToISOString(mainAppointment.appointmentDate),
       startTime: parseTimeToISOString(mainAppointment.startTime),
       endTime: parseTimeToISOString(mainAppointment.endTime),

--- a/server/routes/appointments/video-link-booking/probation/middleware/initialiseJourney.ts
+++ b/server/routes/appointments/video-link-booking/probation/middleware/initialiseJourney.ts
@@ -68,8 +68,7 @@ export default ({
       probationTeamRequired: booking.probationTeamCode !== 'TEAM_NOT_LISTED',
       probationTeamCode: booking.probationTeamCode,
       meetingTypeCode: booking.probationMeetingType,
-      officerDetailsNotKnown: booking.additionalBookingDetails?.contactName === undefined,
-      probationOfficerDetailsKnown: booking.additionalBookingDetails?.contactName === undefined,
+      probationOfficerDetailsKnown: booking.additionalBookingDetails?.contactName !== undefined,
       officer:
         booking.additionalBookingDetails?.contactName !== undefined
           ? {

--- a/server/validators/isValidUkPhoneNumber.test.ts
+++ b/server/validators/isValidUkPhoneNumber.test.ts
@@ -1,0 +1,34 @@
+import { Expose, plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import IsValidUkPhoneNumber from './isValidUkPhoneNumber'
+import { associateErrorsWithProperty } from '../utils/utils'
+
+describe('isValidPhoneNumber', () => {
+  class DummyForm {
+    @Expose()
+    @IsValidUkPhoneNumber({ message: 'Enter a valid phone number' })
+    phoneNumber: string
+  }
+
+  it('should fail validation for a bad phone number', async () => {
+    const body = {
+      phoneNumber: 'O1733 333867',
+    }
+
+    const requestObject = plainToInstance(DummyForm, body)
+    const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+    expect(errors).toEqual([{ property: 'phoneNumber', error: 'Enter a valid phone number' }])
+  })
+
+  it('should pass validation for a good phone number', async () => {
+    const body = {
+      phoneNumber: '01733 333867',
+    }
+
+    const requestObject = plainToInstance(DummyForm, body)
+    const errors = await validate(requestObject).then(errs => errs.flatMap(associateErrorsWithProperty))
+
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/server/validators/isValidUkPhoneNumber.ts
+++ b/server/validators/isValidUkPhoneNumber.ts
@@ -1,0 +1,16 @@
+import { registerDecorator, ValidationOptions } from 'class-validator'
+import { isValidPhoneNumber } from 'libphonenumber-js'
+
+export default function IsValidUkPhoneNumber(validationOptions: ValidationOptions) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: 'IsValidUkPhoneNumber',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate: dataToValidate => isValidPhoneNumber(dataToValidate, 'GB'),
+      },
+    })
+  }
+}

--- a/server/views/pages/appointments/video-link-booking/probation/check-booking.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/check-booking.njk
@@ -129,7 +129,7 @@
                                 text: "UK phone number"
                             },
                             value: {
-                                text: session.bookAProbationMeetingJourney.officer.telephone or ("Not yet known" if session.bookAProbationMeetingJourney.officerDetailsNotKnown else "None entered")
+                                text: session.bookAProbationMeetingJourney.officer.telephone or "Not yet known"
                             },
                             actions: {
                                 items: [

--- a/server/views/pages/appointments/video-link-booking/probation/probation-meeting-details.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/probation-meeting-details.njk
@@ -135,75 +135,73 @@
                 {% endif %}
 
               <div class="govuk-form-group">
-                <fieldset class="govuk-fieldset">
-                  {% set probationOfficerDetailsHtml %}
-                    {{ govukInput({
-                      id: "officerFullName",
-                      name: "officerFullName",
-                      label: {
-                        text: "Full name"
-                      },
-                      errorMessage: validationErrors | findError('officerFullName'),
-                      formGroup: {
-                        classes: 'govuk-!-margin-bottom-3'
-                      },
-                      classes: "govuk-!-width-one-half",
-                      value: formResponses.officerFullName or session.bookAProbationMeetingJourney.officer.fullName
-                    }) }}
-
-                    {{ govukInput({
-                      id: "officerEmail",
-                      name: "officerEmail",
-                      label: {
-                        text: "Email address"
-                      },
-                      errorMessage: validationErrors | findError('officerEmail'),
-                      formGroup: {
-                        classes: 'govuk-!-margin-bottom-3'
-                      },
-                      classes: "govuk-!-width-one-half",
-                      value: formResponses.officerEmail or session.bookAProbationMeetingJourney.officer.email
-                    }) }}
-
-                    {{ govukInput({
-                      id: "officerTelephone",
-                      name: "officerTelephone",
-                      label: {
-                        text: "UK phone number (optional)"
-                      },
-                      errorMessage: validationErrors | findError('officerTelephone'),
-                      classes: "govuk-!-width-one-half",
-                      value: formResponses.officerTelephone or session.bookAProbationMeetingJourney.officer.telephone
-                    }) }}
-                  {% endset %}
-
-                  {{ govukRadios({
-                    idPrefix: "probationOfficerDetailsKnown",
-                    name: "probationOfficerDetailsKnown",
-                    errorMessage: validationErrors | findError('probationOfficerDetailsKnown'),
-                    fieldset: {
-                      legend: {
-                        text: "Do you know the details of the probation officer?",
-                        classes: "govuk-fieldset__legend--s"
-                      }
+                {% set probationOfficerDetailsHtml %}
+                  {{ govukInput({
+                    id: "officerFullName",
+                    name: "officerFullName",
+                    label: {
+                      text: "Full name"
                     },
-                    items: [
-                      {
-                        value: 'YES',
-                        text: "Yes",
-                        checked: formResponses.probationOfficerDetailsKnown == 'YES' or session.bookAProbationMeetingJourney.probationOfficerDetailsKnown === true,
-                        conditional: {
-                        html: probationOfficerDetailsHtml
-                      }
-                      },
-                      {
-                        value: 'NO',
-                        text: "No",
-                        checked: formResponses.probationOfficerDetailsKnown == 'NO' or (session.bookAProbationMeetingJourney.probationOfficerDetailsKnown === false and not formResponses)
-                      }
-                    ]
+                    errorMessage: validationErrors | findError('officerFullName'),
+                    formGroup: {
+                      classes: 'govuk-!-margin-bottom-3'
+                    },
+                    classes: "govuk-!-width-one-half",
+                    value: formResponses.officerFullName or session.bookAProbationMeetingJourney.officer.fullName
                   }) }}
-                </fieldset>
+
+                  {{ govukInput({
+                    id: "officerEmail",
+                    name: "officerEmail",
+                    label: {
+                      text: "Email address"
+                    },
+                    errorMessage: validationErrors | findError('officerEmail'),
+                    formGroup: {
+                      classes: 'govuk-!-margin-bottom-3'
+                    },
+                    classes: "govuk-!-width-one-half",
+                    value: formResponses.officerEmail or session.bookAProbationMeetingJourney.officer.email
+                  }) }}
+
+                  {{ govukInput({
+                    id: "officerTelephone",
+                    name: "officerTelephone",
+                    label: {
+                      text: "UK phone number (optional)"
+                    },
+                    errorMessage: validationErrors | findError('officerTelephone'),
+                    classes: "govuk-!-width-one-half",
+                    value: formResponses.officerTelephone or session.bookAProbationMeetingJourney.officer.telephone
+                  }) }}
+                {% endset %}
+
+                {{ govukRadios({
+                  idPrefix: "probationOfficerDetailsKnown",
+                  name: "probationOfficerDetailsKnown",
+                  errorMessage: validationErrors | findError('probationOfficerDetailsKnown'),
+                  fieldset: {
+                    legend: {
+                      text: "Do you know the details of the probation officer?",
+                      classes: "govuk-fieldset__legend--s"
+                    }
+                  },
+                  items: [
+                    {
+                      value: 'YES',
+                      text: "Yes",
+                      checked: formResponses.probationOfficerDetailsKnown == 'YES' or session.bookAProbationMeetingJourney.probationOfficerDetailsKnown === true,
+                      conditional: {
+                      html: probationOfficerDetailsHtml
+                    }
+                    },
+                    {
+                      value: 'NO',
+                      text: "No",
+                      checked: formResponses.probationOfficerDetailsKnown == 'NO' or (session.bookAProbationMeetingJourney.probationOfficerDetailsKnown === false and not formResponses)
+                    }
+                  ]
+                }) }}
               </div>
 
               {{ govukButton({

--- a/server/views/pages/appointments/video-link-booking/probation/probation-meeting-details.njk
+++ b/server/views/pages/appointments/video-link-booking/probation/probation-meeting-details.njk
@@ -134,75 +134,81 @@
                   }) }}
                 {% endif %}
 
-                <div class="govuk-form-group {{ 'govuk-form-group--error' if validationErrors | findError("officerDetailsOrUnknown") }}">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Enter the probation officer's details</legend>
-                        <p id="officerDetailsOrUnknown" class="govuk-error-message"><span class="govuk-visually-hidden">Error:</span>{{ (validationErrors | findError("officerDetailsOrUnknown")).text }}</p>
-                        <p class="govuk-body">You can enter the details later if not yet known</p>
-                        {{ govukCheckboxes({
-                            idPrefix: "officerDetailsNotKnown",
-                            name: "officerDetailsNotKnown",
-                            items: [
-                                {
-                                  value: "true",
-                                  text: "Not yet known",
-                                  checked: formResponses.officerDetailsNotKnown or session.bookAProbationMeetingJourney.officerDetailsNotKnown
-                                },
-                                {
-                                  divider: "or"
-                                }
-                            ],
-                            errorMessage: validationErrors | findError("officerDetailsNotKnown"),
-                            formGroup: {
-                                classes: 'govuk-!-margin-bottom-3'
-                            },
-                            classes: "govuk-!-width-one-third"
-                        }) }}
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                  {% set probationOfficerDetailsHtml %}
+                    {{ govukInput({
+                      id: "officerFullName",
+                      name: "officerFullName",
+                      label: {
+                        text: "Full name"
+                      },
+                      errorMessage: validationErrors | findError('officerFullName'),
+                      formGroup: {
+                        classes: 'govuk-!-margin-bottom-3'
+                      },
+                      classes: "govuk-!-width-one-half",
+                      value: formResponses.officerFullName or session.bookAProbationMeetingJourney.officer.fullName
+                    }) }}
 
-                        {{ govukInput({
-                            id: "officerFullName",
-                            name: "officerFullName",
-                            label: {
-                              text: "Full name"
-                            },
-                            errorMessage: validationErrors | findError('officerFullName'),
-                            formGroup: {
-                              classes: 'govuk-!-margin-bottom-3'
-                            },
-                            classes: "govuk-!-width-one-half",
-                            value: formResponses.officerFullName or session.bookAProbationMeetingJourney.officer.fullName
-                        }) }}
+                    {{ govukInput({
+                      id: "officerEmail",
+                      name: "officerEmail",
+                      label: {
+                        text: "Email address"
+                      },
+                      errorMessage: validationErrors | findError('officerEmail'),
+                      formGroup: {
+                        classes: 'govuk-!-margin-bottom-3'
+                      },
+                      classes: "govuk-!-width-one-half",
+                      value: formResponses.officerEmail or session.bookAProbationMeetingJourney.officer.email
+                    }) }}
 
-                        {{ govukInput({
-                            id: "officerEmail",
-                            name: "officerEmail",
-                            label: {
-                              text: "Email address"
-                            },
-                            errorMessage: validationErrors | findError('officerEmail'),
-                            formGroup: {
-                              classes: 'govuk-!-margin-bottom-3'
-                            },
-                            classes: "govuk-!-width-one-half",
-                            value: formResponses.officerEmail or session.bookAProbationMeetingJourney.officer.email
-                        }) }}
+                    {{ govukInput({
+                      id: "officerTelephone",
+                      name: "officerTelephone",
+                      label: {
+                        text: "UK phone number (optional)"
+                      },
+                      errorMessage: validationErrors | findError('officerTelephone'),
+                      classes: "govuk-!-width-one-half",
+                      value: formResponses.officerTelephone or session.bookAProbationMeetingJourney.officer.telephone
+                    }) }}
+                  {% endset %}
 
-                        {{ govukInput({
-                            id: "officerTelephone",
-                            name: "officerTelephone",
-                            label: {
-                              text: "UK phone number (optional)"
-                            },
-                            errorMessage: validationErrors | findError('officerTelephone'),
-                            classes: "govuk-input--width-10",
-                            value: formResponses.officerTelephone or session.bookAProbationMeetingJourney.officer.telephone
-                        }) }}
-                  </fieldset>
-                </div>
+                  {{ govukRadios({
+                    idPrefix: "probationOfficerDetailsKnown",
+                    name: "probationOfficerDetailsKnown",
+                    errorMessage: validationErrors | findError('probationOfficerDetailsKnown'),
+                    fieldset: {
+                      legend: {
+                        text: "Do you know the details of the probation officer?",
+                        classes: "govuk-fieldset__legend--s"
+                      }
+                    },
+                    items: [
+                      {
+                        value: 'YES',
+                        text: "Yes",
+                        checked: formResponses.probationOfficerDetailsKnown == 'YES' or session.bookAProbationMeetingJourney.probationOfficerDetailsKnown === true,
+                        conditional: {
+                        html: probationOfficerDetailsHtml
+                      }
+                      },
+                      {
+                        value: 'NO',
+                        text: "No",
+                        checked: formResponses.probationOfficerDetailsKnown == 'NO' or (session.bookAProbationMeetingJourney.probationOfficerDetailsKnown === false and not formResponses)
+                      }
+                    ]
+                  }) }}
+                </fieldset>
+              </div>
 
-                {{ govukButton({
-                      text: "Continue"
-                }) }}
+              {{ govukButton({
+                text: "Continue"
+              }) }}
             </form>
         </div>
     </div>


### PR DESCRIPTION
Content change for video probation meetings. Now using conditional radio reveal instead of checkbox to determine if user knows what to enter for the probation officer details when booking the appointment.

**BEFORE**
<img width="1446" height="1788" alt="before-1" src="https://github.com/user-attachments/assets/ceb94c6b-4eec-42ce-b487-592feeabcb6b" />

<img width="1596" height="2154" alt="before-2" src="https://github.com/user-attachments/assets/5acc08d2-e5ee-4140-9cb6-78ffae6156b8" />

**AFTER:**
<img width="2400" height="1512" alt="after-1" src="https://github.com/user-attachments/assets/19efe821-373a-4003-a56e-d080b11093c2" />
<img width="1704" height="2312" alt="after-2" src="https://github.com/user-attachments/assets/280dcb76-e4ad-488a-a010-481e27bfbf80" />
