### PR TITLE
SAA-4315: Fix disappearing filter on uncancel activity sessions page

### DIFF
--- a/integration_tests/e2e/activities/attendance/uncancelMultipleSessions.cy.ts
+++ b/integration_tests/e2e/activities/attendance/uncancelMultipleSessions.cy.ts
@@ -32,6 +32,10 @@ context('Cancel Multiple Sessions', () => {
     getScheduledInstanceEnglishLevel2.date = todayStr
     getScheduledInstanceEnglishLevel2.cancelled = true
 
+    getAttendanceSummaryCancelled[0].sessionDate = todayStr
+    getAttendanceSummaryCancelled[1].sessionDate = todayStr
+    getAttendanceSummaryCancelled[2].sessionDate = todayStr
+
     cy.stubEndpoint(
       'GET',
       `/scheduled-instances/attendance-summary\\?prisonCode=MDI&date=${todayStr}`,
@@ -132,5 +136,46 @@ context('Cancel Multiple Sessions', () => {
     uncancelConfirmSinglePage.confirm()
 
     Page.verifyOnPage(UncancelActivitiesListPage)
+  })
+
+  it('Should filter results correctly and display the correct text if none exist', () => {
+    getScheduledInstanceEnglishLevel1.date = tomorrowStr
+    getScheduledInstanceEnglishLevel2.date = tomorrowStr
+
+    cy.stubEndpoint(
+      'GET',
+      `/scheduled-instances/attendance-summary\\?prisonCode=MDI&date=${tomorrowStr}`,
+      getAttendanceSummaryCancelled,
+    )
+
+    const indexPage = Page.verifyOnPage(IndexPage)
+    indexPage.activitiesCard().click()
+
+    const activitiesIndexPage = Page.verifyOnPage(ActivitiesIndexPage)
+    activitiesIndexPage.recordAttendanceCard().click()
+
+    const recordAttendancePage = Page.verifyOnPage(AttendanceDashboardPage)
+    recordAttendancePage.recordAttendanceCard().click()
+
+    const howToRecordAttendancePage = Page.verifyOnPage(HowToRecordAttendancePage)
+    howToRecordAttendancePage.radioActivityClick().click()
+    howToRecordAttendancePage.continue()
+
+    const selectPeriodPage = Page.verifyOnPage(SelectPeriodPage)
+    selectPeriodPage.enterDate(new Date(tomorrowStr))
+    selectPeriodPage.selectAM()
+    selectPeriodPage.selectPM()
+    selectPeriodPage.selectED()
+    selectPeriodPage.continue()
+
+    const activitiesPage = Page.verifyOnPage(ActivitiesPage)
+    activitiesPage.containsActivities('English level 1', 'English level 2', 'Gym sports and fitness')
+    activitiesPage.uncancelSessionsLink().click()
+
+    const uncancelActivityPage = Page.verifyOnPage(UncancelActivitiesListPage)
+    cy.contains('No sessions to display').should('not.exist')
+    uncancelActivityPage.locationTypeRadio('IN_CELL').click()
+    uncancelActivityPage.applyFilters()
+    cy.contains('No sessions to display').should('exist')
   })
 })

--- a/integration_tests/pages/recordAttendance/uncancelActivitiesList.ts
+++ b/integration_tests/pages/recordAttendance/uncancelActivitiesList.ts
@@ -57,6 +57,10 @@ export default class UncancelActivitiesListPage extends Page {
       })
   }
 
+  locationTypeRadio = (value: string) => cy.get(`input[name="locationType"][value="${value}"]`)
+
+  applyFilters = () => cy.get('button[type="submit"]').first().click()
+
   sessionPMCheckbox = () => cy.get(`[name=sessionFilters][value="PM"]`)
 
   uncancelSessions = () => cy.get('button').contains('Uncancel activity sessions').click()

--- a/server/routes/activities/record-attendance/handlers/uncancel-multiple-sessions/activitiesList.test.ts
+++ b/server/routes/activities/record-attendance/handlers/uncancel-multiple-sessions/activitiesList.test.ts
@@ -221,6 +221,7 @@ describe('Route Handlers - Uncancel Multiple Sessions', () => {
             },
           ],
           locations: [],
+          hasCancelledSessionsToday: false,
         },
       )
     })
@@ -265,6 +266,7 @@ describe('Route Handlers - Uncancel Multiple Sessions', () => {
             },
           ],
           locations: [],
+          hasCancelledSessionsToday: false,
         },
       )
     })

--- a/server/routes/activities/record-attendance/handlers/uncancel-multiple-sessions/activitiesList.ts
+++ b/server/routes/activities/record-attendance/handlers/uncancel-multiple-sessions/activitiesList.ts
@@ -3,7 +3,7 @@ import { addDays, startOfDay } from 'date-fns'
 import _ from 'lodash'
 import ActivitiesService from '../../../../../services/activitiesService'
 import { asString, convertToArray, formatDate, toDate } from '../../../../../utils/utils'
-import { activityRows, filterItems } from '../../utils/activitiesPageUtils'
+import { activityRows, filterItems, hasCancelledSessionsToday } from '../../utils/activitiesPageUtils'
 import LocationsService from '../../../../../services/locationsService'
 
 export default class UncancelMultipleSessionsRoutes {
@@ -52,6 +52,7 @@ export default class UncancelMultipleSessionsRoutes {
         true,
       ),
       locations: uniqueLocations.filter(l => l.locationType !== 'BOX'),
+      hasCancelledSessionsToday: hasCancelledSessionsToday(activityAttendanceSummary),
     })
   }
 

--- a/server/routes/activities/record-attendance/utils/activitiesPageUtils.test.ts
+++ b/server/routes/activities/record-attendance/utils/activitiesPageUtils.test.ts
@@ -1,5 +1,5 @@
 import { addDays, subDays } from 'date-fns'
-import { activityRows, filterItems } from './activitiesPageUtils'
+import { activityRows, filterItems, hasCancelledSessionsToday } from './activitiesPageUtils'
 import TimeSlot from '../../../../enum/timeSlot'
 
 const attendanceSummaryResponse = [
@@ -491,5 +491,20 @@ describe('activityRows', () => {
         allowSelection: true,
       },
     ])
+  })
+
+  it('should return hasCancelledSessionsToday as TRUE if sessions are cancelled `today`', async () => {
+    // Mock system date to when there are cancelled sessions (Math 3)
+    jest.useFakeTimers().setSystemTime(new Date('2023-08-22'))
+    const response = hasCancelledSessionsToday(attendanceSummaryResponse)
+
+    expect(response).toEqual(true)
+  })
+
+  it('should return hasCancelledSessionsToday as FALSE if no sessions are cancelled `today`', async () => {
+    // Mock system date to when there are no cancelled sessions
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-01'))
+    const response = hasCancelledSessionsToday(attendanceSummaryResponse)
+    expect(response).toEqual(false)
   })
 })

--- a/server/routes/activities/record-attendance/utils/activitiesPageUtils.ts
+++ b/server/routes/activities/record-attendance/utils/activitiesPageUtils.ts
@@ -100,3 +100,8 @@ export const activityRows = (
       return a.endTime.localeCompare(b.endTime)
     })
 }
+
+export const hasCancelledSessionsToday = (activityAttendanceSummary: ScheduledInstanceAttendanceSummary[]) => {
+  const today = formatIsoDate(new Date())
+  return activityAttendanceSummary.some(a => a.cancelled && a.sessionDate === today)
+}

--- a/server/views/pages/activities/record-attendance/uncancel-multiple-sessions/cancelled-activities.njk
+++ b/server/views/pages/activities/record-attendance/uncancel-multiple-sessions/cancelled-activities.njk
@@ -65,7 +65,7 @@
     </div>
 
     <div class="attendance-activities">
-      {% if activityRows.length == 0 %}
+      {% if not hasCancelledSessionsToday %}
         <P>
           There are no cancelled sessions for {{ activityDate | formatDate }}
           {% set comma = joiner(', ') %}


### PR DESCRIPTION
Previously, the filter on `cancelled-activities.njk` disappeared when searching with a filter for cancelled sessions on a specific location.

This search caused a re-render but if there were no sessions matching that criteria, the filter would disappear and the text 'there are no cancelled sessions for today' would display instead. 

That is incorrect. The filter should remain and display the text 'There are no matching activities'. 

So rather than checking activityRows - we can check if there are any cancelled sessions for today. 
