### PR TITLE
SAA-4349: Bump GOV.UK and MOJ Frontend dependencies

### DIFF
--- a/frontend/components/card/_card.scss
+++ b/frontend/components/card/_card.scss
@@ -4,8 +4,8 @@
 
 $card-border-width: 1px;
 $card-border-bottom-width: govuk-spacing(1);
-$card-border-hover-color: $govuk-border-colour;
-$card-border-color: lighten($card-border-hover-color, 15%);
+$card-border-hover-color: govuk-colour("black", $variant: "tint-50");
+$card-border-color: govuk-colour("black", $variant: "tint-80");
 
 .card {
   margin-bottom: govuk-spacing(7);

--- a/frontend/components/card/_card.scss
+++ b/frontend/components/card/_card.scss
@@ -9,7 +9,7 @@ $card-border-color: govuk-colour("black", $variant: "tint-80");
 
 .card {
   margin-bottom: govuk-spacing(7);
-  background: $govuk-body-background-colour;
+  background: govuk-functional-colour(body-background);
   border: $card-border-width solid $card-border-color;
   position: relative;
   width: 100%;
@@ -35,7 +35,7 @@ $card-border-color: govuk-colour("black", $variant: "tint-80");
 
       .card__heading a,
       .card__link {
-        color: $govuk-link-hover-colour;
+        color: govuk-functional-colour(link-hover);
         text-decoration: none;
 
         &:focus {

--- a/frontend/components/filters/_filters.scss
+++ b/frontend/components/filters/_filters.scss
@@ -2,7 +2,7 @@
   padding: 20px 0;
   margin-bottom: 20px;
 
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
 
   &__items {
     display: flex;

--- a/frontend/components/information-card/_information-card.scss
+++ b/frontend/components/information-card/_information-card.scss
@@ -1,22 +1,22 @@
 .information-card {
   padding: 25px;
-  border: 2px solid govuk-colour("light-grey");
+  border: 2px solid govuk-colour("black", $variant: "tint-95");
 
   .govuk-table {
     margin: 0;
 
     &__caption {
-      background-color: govuk-colour("light-grey");
+      background-color: govuk-colour("black", $variant: "tint-95");
       padding: 5px 0;
     }
 
     &__header {
       vertical-align: top;
-      border-bottom-color: govuk-colour("light-grey");
+      border-bottom-color: govuk-colour("black", $variant: "tint-95");
     }
 
     &__cell {
-      border-bottom-color: govuk-colour("light-grey");
+      border-bottom-color: govuk-colour("black", $variant: "tint-95");
     }
   }
 }

--- a/frontend/components/mini-profile/_mini-profile.scss
+++ b/frontend/components/mini-profile/_mini-profile.scss
@@ -1,7 +1,7 @@
 .mini-profile {
   @include govuk-responsive-padding(3);
   @include govuk-font($size: 19);
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   display: flex;
   flex-direction: row;
   align-items: start;

--- a/frontend/components/movement-list/_movement-list.scss
+++ b/frontend/components/movement-list/_movement-list.scss
@@ -13,7 +13,7 @@
 
   &__location-events {
     &__secondary-information {
-      color: $govuk-secondary-text-colour;
+      color: govuk-functional-colour(secondary-text);
     }
   }
 }
@@ -77,11 +77,11 @@
     }
 
     .dashed-mid-grey-tint-20-hr {
-      border-top: 1px dashed govuk-tint(govuk-colour("mid-grey"), 6);
+      border-top: 1px dashed govuk-colour("black", $variant: "tint-80");
     }
 
     .alerts-list > li {
-      border: 2px solid govuk-colour("mid-grey") !important;
+      border: 2px solid govuk-colour("black", $variant: "tint-80") !important;
       font-size: 7pt;
       align-items: center;
       justify-content: center;

--- a/frontend/components/movement-slip/_movement-slip.scss
+++ b/frontend/components/movement-slip/_movement-slip.scss
@@ -1,11 +1,11 @@
 .separate-slip-print:not(:last-child){
   page-break-after: always;
-} 
+}
 
 .movement-slip {
   margin-bottom: govuk-spacing(6);
   padding: govuk-spacing(4);
-  border: 2px dashed $govuk-border-colour;
+  border: 2px dashed govuk-functional-colour(border);
   page-break-inside: avoid;
 
   .movement-slip-header {
@@ -18,7 +18,7 @@
 
   .movement-slip-footer {
     text-align: right;
-    color: $govuk-secondary-text-colour;
+    color: govuk-functional-colour(secondary-text);
     margin-bottom: govuk-spacing(0);
 
     @media print {
@@ -35,7 +35,7 @@
     &__row {
       @extend .govuk-body;
       display: table-row;
-      border-bottom: 1px solid $govuk-border-colour;
+      border-bottom: 1px solid govuk-functional-colour(border);
 
       &--no-border {
         border-bottom: 0;

--- a/frontend/components/prisoner-info-banner/prisoner-info-banner.scss
+++ b/frontend/components/prisoner-info-banner/prisoner-info-banner.scss
@@ -1,5 +1,5 @@
 .prisonerInfoBanner {
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     display: flex;
     flex-direction: row;
     align-items: start;

--- a/frontend/components/related-tasks/_related-tasks.scss
+++ b/frontend/components/related-tasks/_related-tasks.scss
@@ -1,6 +1,6 @@
 .related-tasks {
   padding: 10px 10px 20px 20px;
-  border: 2px solid govuk-colour("light-grey");
+  border: 2px solid govuk-colour("black", $variant: "tint-95");
 
   &::before {
     @include govuk-font($size: 19, $weight: bold);

--- a/frontend/components/sticky-header/_sticky-header.scss
+++ b/frontend/components/sticky-header/_sticky-header.scss
@@ -3,18 +3,18 @@
       @media print {
         position: revert;
       }
-  
+
       position: sticky;
       z-index: 999;
-      top: 0px;
+      top: 0;
     }
 
     .govuk-table__header {
       background: govuk-colour("white");
-      border-bottom: 2px govuk-colour("mid-grey") solid;
+      border-bottom: 2px govuk-colour("black", $variant: "tint-80") solid;
     }
-  
-  // This is required to override a style added by govuk-frontend 
+
+  // This is required to override a style added by govuk-frontend
   // which sets the S-P-T to 0 when sticky is used
   @supports (position: sticky) {
     .govuk-template {

--- a/frontend/components/sticky-select/_sticky-select.scss
+++ b/frontend/components/sticky-select/_sticky-select.scss
@@ -6,12 +6,12 @@
 
     position: sticky;
     z-index: 999;
-    top: 0px;
+    top: 0;
   }
 
   .govuk-table__header {
     background: govuk-colour("white");
-    border-bottom: 2px govuk-colour("mid-grey") solid;
+    border-bottom: 2px govuk-colour("black", $variant: "tint-80") solid;
   }
 
   .govuk-checkboxes__item, .govuk-radios__item {
@@ -30,7 +30,7 @@
   .govuk-table__row {
     &:nth-of-type(even) {
       @media not print {
-        background: govuk-colour(light-grey);
+        background: govuk-colour("black", $variant: "tint-95");
       }
     }
   }
@@ -39,7 +39,7 @@
     position: sticky;
     z-index: 1000;
     bottom: -1px;
-    background-color: $govuk-brand-colour;
+    background-color: govuk-functional-colour(brand);
     margin-top: 0;
     margin-bottom: 0;
     padding: 20px 20px;
@@ -108,7 +108,7 @@
   }
 }
 
-// This is required to override a style added by govuk-frontend 
+// This is required to override a style added by govuk-frontend
 // which sets the S-P-T to 0 when sticky is used
 @supports (position: sticky) {
   .govuk-template {

--- a/frontend/components/tabs/_tabs.scss
+++ b/frontend/components/tabs/_tabs.scss
@@ -18,10 +18,10 @@
 
     .govuk-tabs__tab {
       text-decoration: none;
-      color: $govuk-link-colour;
+      color: govuk-functional-colour(link);
 
       &:hover {
-        color: govuk-colour('dark-blue') !important;
+        color: govuk-colour("blue", $variant: "shade-50") !important;
       }
       &:focus {
         color: #000 !important;
@@ -35,7 +35,7 @@
 
       .govuk-tabs__tab {
         &, &:visited, &:hover {
-          color: $govuk-link-active-colour;
+          color: govuk-functional-colour(link-active);
         }
       }
     }

--- a/frontend/utilities/_button.scss
+++ b/frontend/utilities/_button.scss
@@ -1,8 +1,8 @@
 $button-shadow-size: 2px;
 $govuk-white-button-colour: govuk-colour("white");
-$govuk-white-button-hover-colour: lighten(govuk-colour('blue'), 50%);
-$govuk-white-button-shadow-colour: govuk-shade(govuk-colour('blue'), 50%);
-$govuk-white-button-text-colour: govuk-shade(govuk-colour('blue'), 50%);
+$govuk-white-button-hover-colour: govuk-colour('blue', $variant: 'shade-25');
+$govuk-white-button-shadow-colour: govuk-colour('blue', $variant: 'shade-50');
+$govuk-white-button-text-colour: govuk-colour('blue', $variant: 'shade-50');
 
 .govuk-button--white {
   background-color: $govuk-white-button-colour;
@@ -17,7 +17,7 @@ $govuk-white-button-text-colour: govuk-shade(govuk-colour('blue'), 50%);
   }
 
   &:hover {
-    background-color: $govuk-white-button-hover-colour;
+    background-color: govuk-functional-colour(hover);
 
     &[disabled] {
       background-color: $govuk-white-button-colour;
@@ -28,8 +28,8 @@ $govuk-white-button-text-colour: govuk-shade(govuk-colour('blue'), 50%);
 .govuk-button--blue {
   background-color: govuk-colour('blue');
 
-  $govuk-blue-button-shadow-colour: govuk-shade(govuk-colour('blue'), 40%);
-  $govuk-blue-button-hover-colour: govuk-shade(govuk-colour('blue'), 20%);
+  $govuk-blue-button-shadow-colour: govuk-colour('blue', $variant: 'shade-50');
+  $govuk-blue-button-hover-colour: govuk-colour('blue', $variant: 'shade-25');
   box-shadow: 0 $button-shadow-size 0 $govuk-blue-button-shadow-colour;
 
   &,

--- a/frontend/utilities/_misc.scss
+++ b/frontend/utilities/_misc.scss
@@ -63,7 +63,7 @@ body {
 
 .mid-grey-tint-20-hr {
   border: none;
-  border-top: 1px solid govuk-colour("mid-grey");
+  border-top: 1px solid govuk-colour("black", $variant: "tint-80");
 }
 
 .dash-border {
@@ -97,7 +97,7 @@ body {
 
 .dashed-mid-grey-tint-20-hr {
   border: none;
-  border-top: 1px dashed govuk-tint(govuk-colour("mid-grey"), 20);
+  border-top: 1px dashed govuk-colour("black", $variant: "tint-80");
 }
 
 .govuk-list {
@@ -149,7 +149,7 @@ body {
 
 .govuk-hint {
   a {
-    color: $govuk-link-colour;
+    color: govuk-functional-colour(link);
   }
 }
 

--- a/frontend/utilities/_misc.scss
+++ b/frontend/utilities/_misc.scss
@@ -56,7 +56,7 @@ body {
 .alternating-row-shading {
   tr:nth-child(even) {
     @media not print {
-      background-color: govuk-tint(govuk-colour("light-grey"), 30);
+      background-color: govuk-colour("black", $variant: "tint-25");
     }
   }
 }

--- a/frontend/utilities/_print.scss
+++ b/frontend/utilities/_print.scss
@@ -119,7 +119,7 @@
   }
 
   .printable-textarea {
-    color: govuk-colour('dark-grey');
+    color: govuk-colour("black", $variant: "tint-25");
     border: 1px solid govuk-colour('black');
     padding: govuk-spacing(2);
     width: 90%;
@@ -127,7 +127,7 @@
   }
 
   .govuk-tag {
-    background-color: govuk-colour("dark-grey");
+    background-color: govuk-colour("black", $variant: "tint-25");
     font-size: 6pt;
     padding: 4px 5px 2px 5px;
     margin-bottom: 1px;
@@ -150,9 +150,9 @@
     margin-right: 17px;
     width: $_checkbox-size;
     height: $_checkbox-size;
-    border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+    border: $govuk-border-width-form-element solid govuk-functional-colour(input-border);
     background: govuk-colour("white");
-    color: govuk-colour("mid-grey");
+    color: govuk-colour("black", $variant: "tint-80");
     line-height: $_checkbox-size;
     text-align: center;
   }

--- a/frontend/utilities/_print.scss
+++ b/frontend/utilities/_print.scss
@@ -107,7 +107,7 @@
 
     &:link,
     &:visited {
-      color: $govuk-text-colour;
+      color: govuk-functional-colour(text);
     }
 
     // Remove url from links in printed view within a table

--- a/frontend/utilities/_typography.scss
+++ b/frontend/utilities/_typography.scss
@@ -1,5 +1,5 @@
 .secondary-text-colour {
-    color: $govuk-secondary-text-colour;
+    color: govuk-functional-colour(secondary-text);
 }
 
 // There's not a good way(?) to rotate text 45 degrees and force the parent
@@ -47,5 +47,5 @@
 }
 
 .grey-text {
-   color: govuk-colour("dark-grey")
+   color: govuk-colour("black", $variant: "tint-25")
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/applicationinsights-web": "3.4.1",
-        "@ministryofjustice/frontend": "^8.0.1",
+        "@ministryofjustice/frontend": "^9.0.0",
         "@ministryofjustice/hmpps-auth-clients": "2.0.0",
         "@ministryofjustice/hmpps-connect-dps-components": "6.1.0",
         "@ministryofjustice/hmpps-rest-client": "2.1.0",
@@ -32,7 +32,7 @@
         "dotenv": "17.4.2",
         "express": "^5.2.1",
         "express-session": "1.19.0",
-        "govuk-frontend": "5.14.0",
+        "govuk-frontend": "6.2.0",
         "helmet": "^8.2.0",
         "http-errors": "^2.0.1",
         "isbinaryfile": "^6.0.0",
@@ -274,6 +274,7 @@
       "version": "7.27.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -752,8 +753,7 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
       "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cypress/request": {
       "version": "4.0.1",
@@ -2413,15 +2413,15 @@
       }
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-8.0.1.tgz",
-      "integrity": "sha512-IPgCcNe+XKV55I4J/SIoYAkfYp7mmUKjO1igXhzOtcF05+stWPbJuL9QzKORlRUxkwZtQ1jmiY7PZxMQzOXniw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-9.0.0.tgz",
+      "integrity": "sha512-R63EvHq//lONAhpUfZCMfxlUHoysDx5Hc6mi9EEV+sfVGm2spGV52PJAkYCYAc3bhTaTiJDtEM+PXgJm0iTWvQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.11.2",
+        "govuk-frontend": "^6.0.0",
         "moment": "2.30.1"
       }
     },
@@ -2728,6 +2728,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.7.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3741,6 +3742,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4346,6 +4348,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4831,6 +4834,7 @@
       "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5121,8 +5125,7 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.25.0",
@@ -5142,6 +5145,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -5492,6 +5496,7 @@
       "version": "3.6.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5764,8 +5769,7 @@
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -6048,6 +6052,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^4.0.0",
         "@cypress/xvfb": "^1.2.4",
@@ -6288,7 +6293,6 @@
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6642,6 +6646,7 @@
     "node_modules/diagnostic-channel": {
       "version": "1.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -7118,6 +7123,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7269,6 +7275,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7329,6 +7336,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7477,6 +7485,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7959,6 +7968,7 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "~0.7.2",
         "cookie-signature": "~1.0.7",
@@ -8381,7 +8391,6 @@
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -8536,6 +8545,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8883,10 +8893,11 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.14.0.tgz",
-      "integrity": "sha512-MgfaXswIM6KpXS2T5gltEnzgVLgfM3UoE9+rYkhBiR0suaJ8Let31VZXQZqz9QhiPDbv28fW1nRjIyLujfZIBA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.2.0.tgz",
+      "integrity": "sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -9028,7 +9039,6 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "he": "bin/he"
       }
@@ -9716,7 +9726,6 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10046,6 +10055,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -12444,7 +12454,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -12461,7 +12470,6 @@
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -12482,8 +12490,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/mocha/node_modules/path-scurry": {
       "version": "1.11.1",
@@ -12491,7 +12498,6 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -12509,7 +12515,6 @@
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -12572,6 +12577,7 @@
     "node_modules/moment": {
       "version": "2.30.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -13470,6 +13476,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13600,6 +13607,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13681,6 +13689,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14008,6 +14017,7 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-6.0.0.tgz",
       "integrity": "sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redis/bloom": "6.0.0",
         "@redis/client": "6.0.0",
@@ -14036,6 +14046,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.0.tgz",
       "integrity": "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -14477,7 +14488,6 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14635,7 +14645,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "sass": "1.98.0"
       }
@@ -14653,7 +14662,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14671,7 +14679,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14689,7 +14696,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14707,7 +14713,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14725,7 +14730,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14743,7 +14747,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14761,7 +14764,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14779,7 +14781,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14797,7 +14798,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14815,7 +14815,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14833,7 +14832,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14851,7 +14849,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14869,7 +14866,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14887,7 +14883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14905,7 +14900,6 @@
         "!linux",
         "!win32"
       ],
-      "peer": true,
       "dependencies": {
         "sass": "1.98.0"
       }
@@ -14923,7 +14917,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14941,7 +14934,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15058,7 +15050,6 @@
       "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -15851,7 +15842,6 @@
       "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "sync-message-port": "^1.0.0"
       },
@@ -15865,7 +15855,6 @@
       "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -16275,7 +16264,8 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -16932,6 +16922,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17051,6 +17042,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.2.2"
       },
@@ -17192,8 +17184,7 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -17376,8 +17367,7 @@
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.3.tgz",
       "integrity": "sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -17541,7 +17531,6 @@
       "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
@@ -17558,7 +17547,6 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -274,7 +274,6 @@
       "version": "7.27.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -753,7 +752,8 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
       "dev": true,
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@cypress/request": {
       "version": "4.0.1",
@@ -2728,7 +2728,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.7.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3742,7 +3741,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -4348,7 +4346,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4834,7 +4831,6 @@
       "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5125,7 +5121,8 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/browserslist": {
       "version": "4.25.0",
@@ -5145,7 +5142,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -5496,7 +5492,6 @@
       "version": "3.6.0",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5769,7 +5764,8 @@
       "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.5.2.tgz",
       "integrity": "sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -6052,7 +6048,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cypress/request": "^4.0.0",
         "@cypress/xvfb": "^1.2.4",
@@ -6293,6 +6288,7 @@
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6646,7 +6642,6 @@
     "node_modules/diagnostic-channel": {
       "version": "1.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.3"
       }
@@ -7123,7 +7118,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7275,7 +7269,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7336,7 +7329,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7485,7 +7477,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7968,7 +7959,6 @@
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
       "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cookie": "~0.7.2",
         "cookie-signature": "~1.0.7",
@@ -8391,6 +8381,7 @@
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -8545,7 +8536,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8897,7 +8887,6 @@
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.2.0.tgz",
       "integrity": "sha512-PCRyQT+7kiV2dUz0Ku6Co+Nx4anOwJ7mAduXYbTQHK2krppBSynv9dBXtOYha/8j+LIzK7FqesTbJl9HD6ekHg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -9039,6 +9028,7 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "he": "bin/he"
       }
@@ -9726,6 +9716,7 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -10055,7 +10046,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -12454,6 +12444,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -12470,6 +12461,7 @@
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -12490,7 +12482,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/mocha/node_modules/path-scurry": {
       "version": "1.11.1",
@@ -12498,6 +12491,7 @@
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -12515,6 +12509,7 @@
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.18.0"
       },
@@ -12577,7 +12572,6 @@
     "node_modules/moment": {
       "version": "2.30.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -13476,7 +13470,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13607,7 +13600,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13689,7 +13681,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14017,7 +14008,6 @@
       "resolved": "https://registry.npmjs.org/redis/-/redis-6.0.0.tgz",
       "integrity": "sha512-n9Thfc39OXleEoPT2k5gwKsqY+HfCww3YS71ofcr9KKbkn89bpjU9dToIlD+JRdM3/GYQkwMtVgTxLyed+LptQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redis/bloom": "6.0.0",
         "@redis/client": "6.0.0",
@@ -14046,7 +14036,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.0.tgz",
       "integrity": "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -14488,6 +14477,7 @@
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14645,6 +14635,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "sass": "1.98.0"
       }
@@ -14662,6 +14653,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14679,6 +14671,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14696,6 +14689,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14713,6 +14707,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14730,6 +14725,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14747,6 +14743,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14764,6 +14761,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14781,6 +14779,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14798,6 +14797,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14815,6 +14815,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14832,6 +14833,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14849,6 +14851,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14866,6 +14869,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14883,6 +14887,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14900,6 +14905,7 @@
         "!linux",
         "!win32"
       ],
+      "peer": true,
       "dependencies": {
         "sass": "1.98.0"
       }
@@ -14917,6 +14923,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14934,6 +14941,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15050,6 +15058,7 @@
       "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -15842,6 +15851,7 @@
       "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "sync-message-port": "^1.0.0"
       },
@@ -15855,6 +15865,7 @@
       "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -16264,8 +16275,7 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -16922,7 +16932,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17042,7 +17051,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.2.2"
       },
@@ -17184,7 +17192,8 @@
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
       "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -17367,7 +17376,8 @@
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.3.tgz",
       "integrity": "sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -17531,6 +17541,7 @@
       "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
@@ -17547,6 +17558,7 @@
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@microsoft/applicationinsights-web": "3.4.1",
-    "@ministryofjustice/frontend": "^8.0.1",
+    "@ministryofjustice/frontend": "^9.0.0",
     "@ministryofjustice/hmpps-auth-clients": "2.0.0",
     "@ministryofjustice/hmpps-connect-dps-components": "6.1.0",
     "@ministryofjustice/hmpps-rest-client": "2.1.0",
@@ -61,7 +61,7 @@
     "dotenv": "17.4.2",
     "express": "^5.2.1",
     "express-session": "1.19.0",
-    "govuk-frontend": "5.14.0",
+    "govuk-frontend": "6.2.0",
     "helmet": "^8.2.0",
     "http-errors": "^2.0.1",
     "isbinaryfile": "^6.0.0",

--- a/server/views/homepageLayout.njk
+++ b/server/views/homepageLayout.njk
@@ -1,6 +1,6 @@
 {% extends "layout.njk" %}
 
-{% block main %}
+{% block container %}
   {% if liveIssueOutageBannerEnabled or plannedDowntimeOutageBannerEnabled %}
     {% include 'partials/serviceOutageBanner.njk' %}
   {% endif %}

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -29,18 +29,17 @@
 
 {% block pageTitle %}{{pageTitle | default(applicationName)}}{% endblock %}
 
-{% block header %}
+{% block govukHeader %}
   {{ feComponents.header | safe }}
   {% block meta %}{% endblock %}
 {% endblock %}
 
-
-{% block main %}
+{% block container %}
   {% if liveIssueOutageBannerEnabled or plannedDowntimeOutageBannerEnabled %}
     {% include 'partials/serviceOutageBanner.njk' %}
   {% endif %}
   <div class="govuk-width-container {%- if containerClasses %} {{ containerClasses }}{% endif %}">
-  {% block beforeContent %}
+  {% block containerStart %}
     {% include 'partials/beforeContent.njk' %}
   {% endblock %}
     <main class="govuk-main-wrapper {%- if mainClasses %} {{ mainClasses }}{% endif %}" id="main-content" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
@@ -50,8 +49,7 @@
 {% endblock %}
 
 
-
-{% block footer %}
+{% block govukFooter %}
   {{ feComponents.footer | safe }}
 {% endblock %}
 

--- a/server/views/pages/appointments/appointment-set/movement-slip.njk
+++ b/server/views/pages/appointments/appointment-set/movement-slip.njk
@@ -9,7 +9,7 @@
 {% block header %}
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
     <span class="govuk-visually-hidden" id="{{ pageId }}"></span>
 {% endblock %}
 
@@ -32,5 +32,5 @@
     {% endfor %}
 {% endblock %}
 
-{% block footer %}
+{% block govukFooter %}
 {% endblock %}

--- a/server/views/pages/appointments/appointment/movement-slip.njk
+++ b/server/views/pages/appointments/appointment/movement-slip.njk
@@ -9,7 +9,7 @@
 {% block header %}
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
     <span class="govuk-visually-hidden" id="{{ pageId }}"></span>
 {% endblock %}
 
@@ -37,5 +37,5 @@
     {{ appointmentMovementSlip(appointment, user.activeCaseLoad.description, now) }}
 {% endblock %}
 
-{% block footer %}
+{% block govukFooter %}
 {% endblock %}

--- a/server/views/partials/beforeContent.njk
+++ b/server/views/partials/beforeContent.njk
@@ -1,16 +1,16 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{{ govukPhaseBanner({
-  attributes: {
-    role: "complementary"
-  },
-  tag: {
-    text: "Beta"
-  },
-  classes: 'govuk-!-display-none-print',
-  html: 'This is a new service. <a href="' + feedbackUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Give feedback</a> to help us improve it.'
-}) }}
+{#{{ govukPhaseBanner({#}
+{#  attributes: {#}
+{#    role: "complementary"#}
+{#  },#}
+{#  tag: {#}
+{#    text: "Beta"#}
+{#  },#}
+{#  classes: 'govuk-!-display-none-print',#}
+{#  html: 'This is a new service. <a href="' + feedbackUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Give feedback</a> to help us improve it.'#}
+{#}) }}#}
 
 {% if jsBackLink or (hardBackLinkHref and hardBackLinkText) or (serviceReturnLinkHref and serviceReturnLinkText) %}
   <nav class="govuk-!-display-none-print">

--- a/server/views/partials/beforeContent.njk
+++ b/server/views/partials/beforeContent.njk
@@ -1,16 +1,18 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{#{{ govukPhaseBanner({#}
-{#  attributes: {#}
-{#    role: "complementary"#}
-{#  },#}
-{#  tag: {#}
-{#    text: "Beta"#}
-{#  },#}
-{#  classes: 'govuk-!-display-none-print',#}
-{#  html: 'This is a new service. <a href="' + feedbackUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Give feedback</a> to help us improve it.'#}
-{#}) }}#}
+{% block headerEnd %}
+{{ govukPhaseBanner({
+  attributes: {
+    role: "complementary"
+  },
+  tag: {
+    text: "Beta"
+  },
+  classes: 'govuk-!-display-none-print',
+  html: 'This is a new service. <a href="' + feedbackUrl + '" class="govuk-link govuk-link--no-visited-state" rel="noopener noreferrer" target="_blank">Give feedback</a> to help us improve it.'
+}) }}
+{% endblock %}
 
 {% if jsBackLink or (hardBackLinkHref and hardBackLinkText) or (serviceReturnLinkHref and serviceReturnLinkText) %}
   <nav class="govuk-!-display-none-print">


### PR DESCRIPTION
**This PR bumps the following:**

`@ministryofjustice/frontend`:  8.0.1 ------> 9.0.0
`govuk-frontend`:  5.14.0 -----> 6.2.0

Mostly, its just overriding mixins. See: [https://github.com/alphagov/govuk-frontend/releases/v6.0.0](https://github.com/alphagov/govuk-frontend/releases/v6.0.0) 

- **Also:** noteworthy changes are the gov-tag colours are slightly tweaked & the favicon colour has updated to blue

- **Second Also:** as a result of this update, alongside the existing Dart Sass warnings, we also get the following warning: 

> [WARNING] sass warning: The `govuk-text-colour` mixin is deprecated. Use `color: govuk-functional-colour(text)` instead. To silence this warning, update $govuk-suppressed-warnings with key: "govuk-text-colour" [plugin sass-plugin]

This warning seems to be from the node modules, which I assume will be updated soon.