### PR TITLE
SAA-4107: Tweak 2 week activity schedules to use govukTag instead of govukInsetText for displaying current week.

### DIFF
--- a/server/views/pages/activities/manage-activities/view-activity.njk
+++ b/server/views/pages/activities/manage-activities/view-activity.njk
@@ -363,10 +363,7 @@
 
             {% for week, slots in slots %}
 
-                {% set showCurrentWeekTag =
-                  (schedule.scheduleWeeks == 2 and week == currentWeek)
-                  or (schedule.scheduleWeeks > 2 and currentWeek)
-                %}
+                {% set showCurrentWeekTag = schedule.scheduleWeeks == 2 and week == currentWeek %}
 
                 {% set dateAndScheduleRows = (dateAndScheduleRows.push(
                     {

--- a/server/views/pages/activities/manage-activities/view-activity.njk
+++ b/server/views/pages/activities/manage-activities/view-activity.njk
@@ -309,10 +309,6 @@
                 }) }}
             {% endif %}
 
-            {{ govukInsetText({
-                text: 'The current week is: Week ' + currentWeek,
-                classes: 'govuk-!-margin-top-0 govuk-!-margin-bottom-0'
-            }) if schedule.scheduleWeeks > 1 and currentWeek }}
             {% set dateAndScheduleRows = [{
                 key: {
                     text: "Start date"
@@ -366,10 +362,16 @@
             }), dateAndScheduleRows) %}
 
             {% for week, slots in slots %}
+
+                {% set showCurrentWeekTag =
+                  (schedule.scheduleWeeks == 2 and week == currentWeek)
+                  or (schedule.scheduleWeeks > 2 and currentWeek)
+                %}
+
                 {% set dateAndScheduleRows = (dateAndScheduleRows.push(
                     {
                         key: {
-                        text: "Week " + week
+                          html: '<span class="govuk-!-margin-right-2">Week ' + week + '</span>' + (govukTag({ text: "Current week", classes: "govuk-tag--small govuk-tag--green" }) if showCurrentWeekTag),                        classes: 'govuk-!-padding-top-4'
                     },
                         value: { html: daysAndCustomTimes(slots) },
                         actions: {
@@ -381,7 +383,8 @@
                                     classes: "govuk-link--no-visited-state",
                                     attributes: { "data-qa": "change-schedule-link" }
                                 }
-                            ]
+                            ],
+                            classes: "govuk-!-padding-top-4"
                             } if not activityEnded
                     }
                 ), dateAndScheduleRows) %}

--- a/server/views/pages/activities/manage-activities/view-activity.njk.test.ts
+++ b/server/views/pages/activities/manage-activities/view-activity.njk.test.ts
@@ -1,0 +1,124 @@
+import * as cheerio from 'cheerio'
+import { CheerioAPI } from 'cheerio'
+import { compile, Template } from 'nunjucks'
+import fs from 'fs'
+import { registerNunjucks } from '../../../../nunjucks/nunjucksSetup'
+
+const view = fs.readFileSync('server/views/pages/activities/manage-activities/view-activity.njk')
+
+describe('Views - Manage activities - View activity', () => {
+  let compiledTemplate: Template
+
+  const njkEnv = registerNunjucks()
+
+  const currentWeekTags = ($: CheerioAPI) =>
+    $('[data-qa="schedule-summary-list"] .govuk-tag').filter(
+      (_, element) => $(element).text().trim() === 'Current week',
+    )
+
+  const weekRow = ($: CheerioAPI, weekNumber: number) =>
+    $('[data-qa="schedule-summary-list"] .govuk-summary-list__row').filter((_, element) =>
+      $(element).find('.govuk-summary-list__key').text().includes(`Week ${weekNumber}`),
+    )
+
+  const renderView = (scheduleWeeks: number, currentWeek = 1): CheerioAPI => {
+    const viewContext = {
+      user: {
+        username: 'joebloggs',
+        externalActivitiesRolledOut: false,
+      },
+      feComponents: {
+        cssIncludes: [],
+        jsIncludes: [],
+        header: '',
+        footer: '',
+      },
+      cspNonce: 'test-nonce',
+      applicationInsightsConnectionString: '',
+      applicationInsightsRoleName: '',
+      liveIssueOutageBannerEnabled: false,
+      plannedDowntimeOutageBannerEnabled: false,
+      now: '2026-06-22',
+      activity: {
+        id: 1,
+        category: { code: 'EDUCATION', name: 'Education' },
+        summary: 'Maths Level 1',
+        attendanceRequired: false,
+        outsideWork: false,
+        paid: false,
+        riskLevel: 'low',
+        minimumEducationLevel: [],
+        tier: { code: 'STANDARD' },
+      },
+      schedule: {
+        startDate: '2026-06-01',
+        endDate: null,
+        scheduleWeeks,
+        capacity: 10,
+        runsOnBankHoliday: false,
+        internalLocation: { description: 'Education - R1' },
+        activity: {
+          paid: false,
+          outsideWork: false,
+          inCell: false,
+        },
+      },
+      slots:
+        scheduleWeeks === 2
+          ? {
+              1: [
+                {
+                  day: 'Monday',
+                  slots: [{ timeSlot: 'AM', startTime: '09:00', endTime: '10:00' }],
+                },
+              ],
+              2: [
+                {
+                  day: 'Tuesday',
+                  slots: [{ timeSlot: 'PM', startTime: '13:00', endTime: '14:00' }],
+                },
+              ],
+            }
+          : {
+              1: [
+                {
+                  day: 'Monday',
+                  slots: [{ timeSlot: 'AM', startTime: '09:00', endTime: '10:00' }],
+                },
+              ],
+            },
+      currentWeek,
+      hasAtLeastOneValidDay: true,
+      displayPays: [],
+      payEditable: true,
+      tier: 'Standard',
+      organiser: 'Education department',
+    }
+
+    return cheerio.load(compiledTemplate.render(viewContext))
+  }
+
+  beforeEach(() => {
+    compiledTemplate = compile(view.toString(), njkEnv)
+  })
+
+  it('does not show the current week tag for one-week schedules', () => {
+    const $ = renderView(1)
+
+    expect(currentWeekTags($).length).toBe(0)
+  })
+
+  it('shows the current week tag on Week 1 when currentWeek is 1 for two-week schedules', () => {
+    const $ = renderView(2, 1)
+
+    expect(weekRow($, 1).find('.govuk-tag').text().trim()).toBe('Current week')
+    expect(weekRow($, 2).find('.govuk-tag').length).toBe(0)
+  })
+
+  it('shows the current week tag on Week 2 when currentWeek is 2 for two-week schedules', () => {
+    const $ = renderView(2, 2)
+
+    expect(weekRow($, 1).find('.govuk-tag').length).toBe(0)
+    expect(weekRow($, 2).find('.govuk-tag').text().trim()).toBe('Current week')
+  })
+})


### PR DESCRIPTION
- This PR also levels out the text in the top row, as per the figma designs in [the ticket](https://dsdmoj.atlassian.net/browse/SAA-4107?atlOrigin=eyJpIjoiMGU3NmE2YmQ2YzMzNGRlMmI2YTA2MDAxM2YzYWEzNjciLCJwIjoiaiJ9). Before/After screenshots below.

- njk.test file also added to capture changes.

<img width="1687" height="884" alt="Screenshot 2026-06-22 at 16 54 10" src="https://github.com/user-attachments/assets/2f5101e0-2030-4b44-b322-43b81940c6f7" />
