### PR TITLE
SAA-4101: Disable anchor behavior for started activity tag

### DIFF
--- a/frontend/utilities/_misc.scss
+++ b/frontend/utilities/_misc.scss
@@ -147,6 +147,22 @@ body {
   font-weight: normal;
 }
 
+.govuk-tag-no-anchor {
+  pointer-events: none;
+  cursor: default;
+  text-decoration: none;
+
+  &:link,
+  &:visited,
+  &:hover,
+  &:focus,
+  &:active {
+    color: inherit;
+    text-decoration: none;
+    box-shadow: none;
+  }
+}
+
 .govuk-hint {
   a {
     color: govuk-functional-colour(link);

--- a/server/views/pages/activities/manage-activities/view-activity.njk
+++ b/server/views/pages/activities/manage-activities/view-activity.njk
@@ -323,7 +323,7 @@
                         {
                             href: "#",
                             html: govukTag({ text: 'Started', classes: 'govuk-tag--small govuk-tag--green' }),
-                            classes: "govuk-tag--small govuk-tag--green govuk-tag-no-anchor",
+                            classes: "govuk-tag-no-anchor",
                             attributes: {
                                 tabindex: "-1",
                                 onclick: "return false"

--- a/server/views/pages/activities/manage-activities/view-activity.njk
+++ b/server/views/pages/activities/manage-activities/view-activity.njk
@@ -309,6 +309,8 @@
                 }) }}
             {% endif %}
 
+            {% set activityHasStarted = schedule.startDate <= now | toDateString %}
+
             {% set dateAndScheduleRows = [{
                 key: {
                     text: "Start date"
@@ -319,8 +321,14 @@
                 actions: {
                     items: [
                         {
-                            html: govukTag({ text: 'Started', classes: 'govuk-tag--small govuk-tag--green' })
-                        } if schedule.startDate <= now | toDateString else
+                            href: "#",
+                            html: govukTag({ text: 'Started', classes: 'govuk-tag--small govuk-tag--green' }),
+                            classes: "govuk-tag--small govuk-tag--green govuk-tag-no-anchor",
+                            attributes: {
+                                tabindex: "-1",
+                                onclick: "return false"
+                            }
+                        } if activityHasStarted else
                         {
                             href: "/activities/edit/" + activity.id + "/start-date?preserveHistory=true",
                             text: "Change",


### PR DESCRIPTION
Previously, the status tag on edit activities (RISLEY - https://activities-dev.prison.service.justice.gov.uk/activities/view/539) was a clickable anchor tag 

There are no macro options for disabling links at the end of the summary table so this is a bit of a hack-around. 