### PR TITLE
If needed, this will revert "Redirect all UI egress via the envoy proxy in PROD (#2275)

### DIFF
--- a/helm_deploy/hmpps-activities-management/values.yaml
+++ b/helm_deploy/hmpps-activities-management/values.yaml
@@ -33,8 +33,6 @@ generic-service:
     FEEDBACK_URL: "https://www.smartsurvey.co.uk/s/ActivitiesAndAppointments/"
     BANK_HOLIDAYS_API_URL: "https://www.gov.uk/bank-holidays.json"
     PRISONER_EXTRA_INFORMATION_ENABLED: "false"
-    NODE_USE_ENV_PROXY: "1"
-    APPLICATION_INSIGHTS_NO_STATSBEAT: "true"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -56,13 +54,6 @@ generic-service:
     elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
-    hmpps-envoy-https-proxy-env:
-      HTTP_PROXY: "HTTP_PROXY"
-      HTTPS_PROXY: "HTTPS_PROXY"
-      NO_PROXY: "NO_PROXY"
-      http_proxy: "HTTP_PROXY"
-      https_proxy: "HTTPS_PROXY"
-      no_proxy: "NO_PROXY"
 
   allowlist:
     ark-nps-hmcts-ttp2: 194.33.192.0/25

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -41,6 +41,18 @@ generic-service:
     PLANNED_DOWNTIME_END_TIME: "11am"
     JOURNEY_DATA_TOKEN_DURATION_HOURS: 8
 
+    NODE_USE_ENV_PROXY: "1"
+    APPLICATION_INSIGHTS_NO_STATSBEAT: "true"
+
+  namespace_secrets:
+    hmpps-envoy-https-proxy-env:
+      HTTP_PROXY: "HTTP_PROXY"
+      HTTPS_PROXY: "HTTPS_PROXY"
+      NO_PROXY: "NO_PROXY"
+      http_proxy: "HTTP_PROXY"
+      https_proxy: "HTTPS_PROXY"
+      no_proxy: "NO_PROXY"
+
   allowlist: null
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -39,6 +39,17 @@ generic-service:
     PLANNED_DOWNTIME_END_TIME: "11am"
     JOURNEY_DATA_TOKEN_DURATION_HOURS: 8
     PRISONER_EXTRA_INFORMATION_ENABLED: "true"
+    NODE_USE_ENV_PROXY: "1"
+    APPLICATION_INSIGHTS_NO_STATSBEAT: "true"
+
+  namespace_secrets:
+    hmpps-envoy-https-proxy-env:
+      HTTP_PROXY: "HTTP_PROXY"
+      HTTPS_PROXY: "HTTPS_PROXY"
+      NO_PROXY: "NO_PROXY"
+      http_proxy: "HTTP_PROXY"
+      https_proxy: "HTTPS_PROXY"
+      no_proxy: "NO_PROXY"
 
   allowlist:
     moj-official-tgw-prod: 51.149.250.0/24


### PR DESCRIPTION
This reverts commit af48e9bb7b21cbe2c4c082ed4ef2639d21dc8685.

The effect is to undo the changes to production that routed all https egress via the Envoy proxy from the UI. 