### PR TITLE
SAA-4529: Add clash option for marking non-attendance via unlock list route

### DIFF
--- a/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.test.ts
+++ b/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.test.ts
@@ -243,7 +243,7 @@ describe('Route Handlers - Multiple people not attended reasons', () => {
       )
     })
 
-    it('should include clashingActivityEvent in other events when prisoner has appointment clash', async () => {
+    it('should include clashingAppointmentEvent in other events when prisoner has appointment clash', async () => {
       when(activitiesService.getScheduledEventsForPrisoners)
         .calledWith(expect.any(Date), ['ABC123', 'ABC321'], res.locals.user)
         .mockResolvedValue(scheduledEventsWithClash)

--- a/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.test.ts
+++ b/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.test.ts
@@ -3,7 +3,12 @@ import { when } from 'jest-when'
 import { format } from 'date-fns'
 import ActivitiesService from '../../../../../services/activitiesService'
 import PrisonService from '../../../../../services/prisonService'
-import { AttendanceReason, ScheduledActivity } from '../../../../../@types/activitiesAPI/types'
+import {
+  AttendanceReason,
+  PrisonerScheduledEvents,
+  ScheduledActivity,
+  ScheduledEvent,
+} from '../../../../../@types/activitiesAPI/types'
 import { Prisoner } from '../../../../../@types/prisonerOffenderSearchImport/types'
 import MultipleNotAttendedReasonRoutes from './multipleNotAttendedReason'
 
@@ -100,6 +105,41 @@ const prisoners = [
   },
 ] as unknown as Prisoner[]
 
+const clashingAppointment: ScheduledEvent = {
+  autoSuspended: false,
+  cancelled: false,
+  inCell: false,
+  offWing: false,
+  onWing: false,
+  outsidePrison: false,
+  priority: 0,
+  suspended: false,
+  scheduledInstanceId: 999999,
+  eventType: 'APPOINTMENT',
+  eventSource: 'SAA',
+  summary: 'Gym',
+  startTime: '09:00',
+  endTime: '10:00',
+  prisonerNumber: 'ABC123',
+  date: today,
+} as ScheduledEvent
+
+const emptyScheduledEvents: PrisonerScheduledEvents = {
+  activities: [],
+  appointments: [],
+  courtHearings: [],
+  visits: [],
+  adjudications: [],
+}
+
+const scheduledEventsWithClash: PrisonerScheduledEvents = {
+  activities: [],
+  appointments: [clashingAppointment],
+  courtHearings: [],
+  visits: [],
+  adjudications: [],
+}
+
 const notAttendedReasons = [
   {
     id: 1,
@@ -112,6 +152,19 @@ const notAttendedReasons = [
     captureIncentiveLevelWarning: false,
     captureOtherText: false,
     displaySequence: 1,
+    displayInAbsence: true,
+  },
+  {
+    id: 2,
+    code: 'CLASH',
+    description: 'Appointment clash',
+    attended: false,
+    capturePay: false,
+    captureMoreDetail: false,
+    captureCaseNote: false,
+    captureIncentiveLevelWarning: false,
+    captureOtherText: false,
+    displaySequence: 5,
     displayInAbsence: true,
   },
 ] as AttendanceReason[]
@@ -153,11 +206,15 @@ describe('Route Handlers - Multiple people not attended reasons', () => {
 
     when(prisonService.searchInmatesByPrisonerNumbers).mockResolvedValue(prisoners)
 
+    when(activitiesService.getScheduledEventsForPrisoners)
+      .calledWith(expect.any(Date), ['ABC123', 'ABC321'], res.locals.user)
+      .mockResolvedValue(emptyScheduledEvents)
+
     when(activitiesService.getAttendanceReasons).calledWith(res.locals.user).mockResolvedValue(notAttendedReasons)
   })
 
   describe('GET', () => {
-    it('should render the expected view with only not attended instances', async () => {
+    it('should render the expected view with only not attended instances and empty other events', async () => {
       await handler.GET(req, res)
       expect(res.render).toHaveBeenCalledWith(
         'pages/activities/record-attendance/attend-all/multiple-not-attended-reason',
@@ -169,6 +226,7 @@ describe('Route Handlers - Multiple people not attended reasons', () => {
               lastName: 'Onester',
               instances: [scheduledActivity1],
               isPayable: false,
+              otherEvents: [],
             },
             {
               prisonerNumber: 'ABC321',
@@ -176,12 +234,27 @@ describe('Route Handlers - Multiple people not attended reasons', () => {
               lastName: 'Twoster',
               instances: [],
               isPayable: false,
+              otherEvents: [],
             },
           ],
           notAttendedReasons,
           backLink: req.journeyData.recordAttendanceJourney.returnUrl || 'choose-details-by-residential-location',
         },
       )
+    })
+
+    it('should include clashingActivityEvent in other events when prisoner has appointment clash', async () => {
+      when(activitiesService.getScheduledEventsForPrisoners)
+        .calledWith(expect.any(Date), ['ABC123', 'ABC321'], res.locals.user)
+        .mockResolvedValue(scheduledEventsWithClash)
+
+      await handler.GET(req, res)
+
+      const renderCall = (res.render as jest.Mock).mock.calls[0]
+      const { attendanceDetails } = renderCall[1]
+
+      expect(attendanceDetails[0].otherEvents).toContainEqual(expect.objectContaining(clashingAppointment))
+      expect(attendanceDetails[1].otherEvents).toEqual([])
     })
   })
 })

--- a/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.test.ts
+++ b/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.test.ts
@@ -243,7 +243,7 @@ describe('Route Handlers - Multiple people not attended reasons', () => {
       )
     })
 
-    it('should include clashingAppointmentEvent in other events when prisoner has appointment clash', async () => {
+    it('should include clashingAppointment in other events when prisoner has appointment clash', async () => {
       when(activitiesService.getScheduledEventsForPrisoners)
         .calledWith(expect.any(Date), ['ABC123', 'ABC321'], res.locals.user)
         .mockResolvedValue(scheduledEventsWithClash)

--- a/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.ts
+++ b/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.ts
@@ -13,9 +13,12 @@ import {
 } from 'class-validator'
 import ActivitiesService from '../../../../../services/activitiesService'
 import PrisonService from '../../../../../services/prisonService'
+import { EventType, YesNo } from '../../../../../@types/activities'
+import applyCancellationDisplayRule from '../../../../../utils/applyCancellationDisplayRule'
 import AttendanceReason from '../../../../../enum/attendanceReason'
-import { YesNo } from '../../../../../@types/activities'
 import AttendanceStatus from '../../../../../enum/attendanceStatus'
+import { eventClashes, toDate } from '../../../../../utils/utils'
+import { flattenPrisonerScheduledEvents } from '../../utils/recordAttendanceUtils'
 import {
   parseSelectedAttendances,
   getPrisonerNumberFromAttendance,
@@ -112,8 +115,16 @@ export default class MultipleNotAttendedReasonRoutes {
     const { instanceIds, prisonerNumbers } = parseSelectedAttendances(selectedAttendances)
 
     const allInstances = await this.activitiesService.getScheduledActivities(instanceIds, user)
-    const prisoners = await this.prisonService.searchInmatesByPrisonerNumbers(prisonerNumbers, user)
-    const notAttendedReasons = (await this.activitiesService.getAttendanceReasons(user))
+
+    const [prisoners, scheduledEvents, attendanceReasons] = await Promise.all([
+      this.prisonService.searchInmatesByPrisonerNumbers(prisonerNumbers, user),
+      this.activitiesService.getScheduledEventsForPrisoners(toDate(allInstances[0].date), prisonerNumbers, user),
+      this.activitiesService.getAttendanceReasons(user),
+    ])
+
+    const allEvents = flattenPrisonerScheduledEvents(scheduledEvents)
+
+    const notAttendedReasons = attendanceReasons
       .filter(r => r.displayInAbsence)
       .sort((r1, r2) => r1.displaySequence - r2.displaySequence)
 
@@ -129,12 +140,19 @@ export default class MultipleNotAttendedReasonRoutes {
         return !instance.cancelled && attendance && attendance.status === AttendanceStatus.WAITING
       })
 
+      const otherEvents = allEvents
+        .filter(event => event.prisonerNumber === prisonerNumber)
+        .filter(event => filteredInstances.every(instance => event.scheduledInstanceId !== instance.id))
+        .filter(event => filteredInstances.some(instance => eventClashes(event, instance)))
+        .filter(event => event.eventType !== EventType.APPOINTMENT || applyCancellationDisplayRule(event))
+
       return {
         prisonerNumber,
         firstName: prisoner.firstName,
         lastName: prisoner.lastName,
         instances: filteredInstances,
         isPayable: instances.some(i => i.activitySchedule.activity.paid),
+        otherEvents,
       }
     })
 


### PR DESCRIPTION
**Overview:**

Fixes bug where clashing appointments were being rendered on the attendance overview page but then not when going to mark attendance options. This ensures **Person’s schedule shows another appointment** is shown as one of these options.

----------

**Cause:** 
 
otherEvents wasnt being passed to the template in multipleNotAttendedReason.ts‎. The fix uses the same logic as seen in attendanceList.ts: 

<img width="1180" height="614" alt="Screenshot 2026-07-23 at 17 22 33" src="https://github.com/user-attachments/assets/4bc9fff4-2860-4c00-8b29-1b85c08897ca" />
