### PR TITLE
SAA-4529: Only render clashing appointments for marking attendance (multipleNotAttended route)

### DIFF
--- a/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.test.ts
+++ b/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.test.ts
@@ -124,6 +124,25 @@ const clashingAppointment: ScheduledEvent = {
   date: today,
 } as ScheduledEvent
 
+const clashingActivity: ScheduledEvent = {
+  autoSuspended: false,
+  cancelled: false,
+  inCell: false,
+  offWing: false,
+  onWing: false,
+  outsidePrison: false,
+  priority: 0,
+  suspended: false,
+  scheduledInstanceId: 888888,
+  eventType: 'ACTIVITY',
+  eventSource: 'SAA',
+  summary: 'Activity - Kitchen',
+  startTime: '09:00',
+  endTime: '10:00',
+  prisonerNumber: 'ABC123',
+  date: today,
+} as ScheduledEvent
+
 const emptyScheduledEvents: PrisonerScheduledEvents = {
   activities: [],
   appointments: [],
@@ -132,9 +151,17 @@ const emptyScheduledEvents: PrisonerScheduledEvents = {
   adjudications: [],
 }
 
-const scheduledEventsWithClash: PrisonerScheduledEvents = {
+const scheduledEventsWithAppointmentClash: PrisonerScheduledEvents = {
   activities: [],
   appointments: [clashingAppointment],
+  courtHearings: [],
+  visits: [],
+  adjudications: [],
+}
+
+const scheduledEventsWithActivityClash: PrisonerScheduledEvents = {
+  activities: [clashingActivity],
+  appointments: [],
   courtHearings: [],
   visits: [],
   adjudications: [],
@@ -246,7 +273,7 @@ describe('Route Handlers - Multiple people not attended reasons', () => {
     it('should include clashingAppointment in other events when prisoner has appointment clash', async () => {
       when(activitiesService.getScheduledEventsForPrisoners)
         .calledWith(expect.any(Date), ['ABC123', 'ABC321'], res.locals.user)
-        .mockResolvedValue(scheduledEventsWithClash)
+        .mockResolvedValue(scheduledEventsWithAppointmentClash)
 
       await handler.GET(req, res)
 
@@ -255,6 +282,19 @@ describe('Route Handlers - Multiple people not attended reasons', () => {
 
       expect(attendanceDetails[0].otherEvents).toContainEqual(expect.objectContaining(clashingAppointment))
       expect(attendanceDetails[1].otherEvents).toEqual([])
+    })
+
+    it('should NOT include clashingActivities in other events when prisoner has activity clash', async () => {
+      when(activitiesService.getScheduledEventsForPrisoners)
+        .calledWith(expect.any(Date), ['ABC123', 'ABC321'], res.locals.user)
+        .mockResolvedValue(scheduledEventsWithActivityClash)
+
+      await handler.GET(req, res)
+
+      const renderCall = (res.render as jest.Mock).mock.calls[0]
+      const { attendanceDetails } = renderCall[1]
+
+      expect(attendanceDetails[0].otherEvents).toEqual([])
     })
   })
 })

--- a/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.ts
+++ b/server/routes/activities/record-attendance/handlers/attend-all/multipleNotAttendedReason.ts
@@ -14,7 +14,6 @@ import {
 import ActivitiesService from '../../../../../services/activitiesService'
 import PrisonService from '../../../../../services/prisonService'
 import { EventType, YesNo } from '../../../../../@types/activities'
-import applyCancellationDisplayRule from '../../../../../utils/applyCancellationDisplayRule'
 import AttendanceReason from '../../../../../enum/attendanceReason'
 import AttendanceStatus from '../../../../../enum/attendanceStatus'
 import { eventClashes, toDate } from '../../../../../utils/utils'
@@ -144,7 +143,7 @@ export default class MultipleNotAttendedReasonRoutes {
         .filter(event => event.prisonerNumber === prisonerNumber)
         .filter(event => filteredInstances.every(instance => event.scheduledInstanceId !== instance.id))
         .filter(event => filteredInstances.some(instance => eventClashes(event, instance)))
-        .filter(event => event.eventType !== EventType.APPOINTMENT || applyCancellationDisplayRule(event))
+        .filter(event => event.eventType === EventType.APPOINTMENT)
 
       return {
         prisonerNumber,


### PR DESCRIPTION
The original fix for this was displaying the clash attendance option when otherEvents is true => we should only be passing that as true if the clashing event is an appointment. 

Note:  applyCancellationDisplayRule(event)) is not applied on the single marking non attendance so have removed that to replicate the same logic.

Have added test to check for clashing activity